### PR TITLE
Set GitLab object on project_create

### DIFF
--- a/ogr/services/gitlab.py
+++ b/ogr/services/gitlab.py
@@ -139,8 +139,10 @@ class GitlabService(GitService):
             except gitlab.GitlabGetError:
                 raise GitlabAPIException(f"Group {namespace} not found.")
             data["namespace_id"] = group.id
-        self.gitlab_instance.projects.create(data)
-        return GitlabProject(repo=repo, namespace=namespace, service=self)
+        new_project = self.gitlab_instance.projects.create(data)
+        return GitlabProject(
+            repo=repo, namespace=namespace, service=self, gitlab_repo=new_project
+        )
 
 
 class GitlabProject(BaseGitProject):

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -8,7 +8,6 @@ from ogr.exceptions import GitlabAPIException
 from ogr.persistent_storage import PersistentObjectStorage
 from ogr.services.gitlab import GitlabService, PRStatus, IssueStatus
 
-
 DATA_DIR = "test_data"
 PERSISTENT_DATA_PREFIX = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), DATA_DIR
@@ -233,7 +232,10 @@ class Service(GitlabTests):
         with pytest.raises(GitlabGetError):
             assert project.gitlab_repo
 
-        self.service.project_create(name_of_the_repo)
+        new_project = self.service.project_create(name_of_the_repo)
+        assert new_project.repo == name_of_the_repo
+        assert new_project.gitlab_repo
+
         project = self.service.get_project(
             repo=name_of_the_repo, namespace=self.service.user.get_username()
         )
@@ -248,9 +250,13 @@ class Service(GitlabTests):
         with pytest.raises(GitlabGetError):
             assert project.gitlab_repo
 
-        self.service.project_create(
+        new_project = self.service.project_create(
             repo=name_of_the_repo, namespace=namespace_of_the_repo
         )
+        assert new_project.repo == name_of_the_repo
+        assert new_project.namespace == namespace_of_the_repo
+        assert new_project.gitlab_repo
+
         project = self.service.get_project(
             repo=name_of_the_repo, namespace=namespace_of_the_repo
         )


### PR DESCRIPTION
- Use returned GitLab repo instance in GitlabService.project_create.