### PR TITLE
Add support to create private issues.

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -132,6 +132,10 @@ class Issue:
         raise NotImplementedError()
 
     @property
+    def private(self) -> bool:
+        raise NotImplementedError()
+
+    @property
     def id(self) -> int:
         raise NotImplementedError()
 
@@ -175,7 +179,9 @@ class Issue:
         )
 
     @staticmethod
-    def create(project: Any, title: str, body: str) -> "Issue":
+    def create(
+        project: Any, title: str, body: str, private: Optional[bool] = None
+    ) -> "Issue":
         """
         Open new Issue.
 
@@ -981,12 +987,17 @@ class GitProject:
         """
         raise NotImplementedError()
 
-    def create_issue(self, title: str, body: str) -> Issue:
+    def create_issue(
+        self, title: str, body: str, private: Optional[bool] = None,
+    ) -> Issue:
         """
         Open new Issue.
+        Private issues are only supported by Gitlab and Pagure.
 
         :param title: str
         :param body: str
+        :param private: bool
+        :param labels: [str]
         :return: Issue
         """
         raise NotImplementedError()

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -988,7 +988,11 @@ class GitProject:
         raise NotImplementedError()
 
     def create_issue(
-        self, title: str, body: str, private: Optional[bool] = None,
+        self,
+        title: str,
+        body: str,
+        private: Optional[bool] = None,
+        labels: Optional[List[str]] = None,
     ) -> Issue:
         """
         Open new Issue.

--- a/ogr/services/github/issue.py
+++ b/ogr/services/github/issue.py
@@ -90,7 +90,12 @@ class GithubIssue(BaseIssue):
         return "Github" + super().__str__()
 
     @staticmethod
-    def create(project: "ogr_github.GithubProject", title: str, body: str) -> "Issue":
+    def create(
+        project: "ogr_github.GithubProject",
+        title: str,
+        body: str,
+        private: Optional[bool] = None,
+    ) -> "Issue":
         github_issue = project.github_repo.create_issue(title=title, body=body)
         return GithubIssue(github_issue, project)
 

--- a/ogr/services/github/issue.py
+++ b/ogr/services/github/issue.py
@@ -95,8 +95,11 @@ class GithubIssue(BaseIssue):
         title: str,
         body: str,
         private: Optional[bool] = None,
+        labels: Optional[List[str]] = None,
     ) -> "Issue":
-        github_issue = project.github_repo.create_issue(title=title, body=body)
+        github_issue = project.github_repo.create_issue(
+            title=title, body=body, labels=labels
+        )
         return GithubIssue(github_issue, project)
 
     @staticmethod

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -301,7 +301,11 @@ class GithubProject(BaseGitProject):
     def get_issue(self, issue_id: int) -> Issue:
         return GithubIssue.get(project=self, id=issue_id)
 
-    def create_issue(self, title: str, body: str) -> Issue:
+    def create_issue(
+        self, title: str, body: str, private: Optional[bool] = None,
+    ) -> Issue:
+        if private:
+            raise NotImplementedError("Private issues are not supported by Github")
         return GithubIssue.create(project=self, title=title, body=body)
 
     def get_pr_list(self, status: PRStatus = PRStatus.open) -> List[PullRequest]:

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -302,11 +302,15 @@ class GithubProject(BaseGitProject):
         return GithubIssue.get(project=self, id=issue_id)
 
     def create_issue(
-        self, title: str, body: str, private: Optional[bool] = None,
+        self,
+        title: str,
+        body: str,
+        private: Optional[bool] = None,
+        labels: Optional[List[str]] = None,
     ) -> Issue:
         if private:
             raise NotImplementedError("Private issues are not supported by Github")
-        return GithubIssue.create(project=self, title=title, body=body)
+        return GithubIssue.create(project=self, title=title, body=body, labels=labels)
 
     def get_pr_list(self, status: PRStatus = PRStatus.open) -> List[PullRequest]:
         return GithubPullRequest.get_list(project=self, status=status)

--- a/ogr/services/gitlab/issue.py
+++ b/ogr/services/gitlab/issue.py
@@ -95,8 +95,11 @@ class GitlabIssue(BaseIssue):
         title: str,
         body: str,
         private: Optional[bool] = None,
+        labels: Optional[List[str]] = None,
     ) -> "Issue":
         data = {"title": title, "description": body}
+        if labels:
+            data["labels"] = ",".join(labels)
         issue = project.gitlab_repo.issues.create(data, confidential=private)
         return GitlabIssue(issue, project)
 

--- a/ogr/services/gitlab/issue.py
+++ b/ogr/services/gitlab/issue.py
@@ -50,6 +50,10 @@ class GitlabIssue(BaseIssue):
         return self._raw_issue.iid
 
     @property
+    def private(self) -> bool:
+        return self._raw_issue.confidential
+
+    @property
     def status(self) -> IssueStatus:
         return (
             IssueStatus.open
@@ -86,8 +90,14 @@ class GitlabIssue(BaseIssue):
         return "Gitlab" + super().__str__()
 
     @staticmethod
-    def create(project: "ogr_gitlab.GitlabProject", title: str, body: str) -> "Issue":
-        issue = project.gitlab_repo.issues.create({"title": title, "description": body})
+    def create(
+        project: "ogr_gitlab.GitlabProject",
+        title: str,
+        body: str,
+        private: Optional[bool] = None,
+    ) -> "Issue":
+        data = {"title": title, "description": body}
+        issue = project.gitlab_repo.issues.create(data, confidential=private)
         return GitlabIssue(issue, project)
 
     @staticmethod

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -410,8 +410,10 @@ class GitlabProject(BaseGitProject):
     def get_issue(self, issue_id: int) -> Issue:
         return GitlabIssue.get(project=self, id=issue_id)
 
-    def create_issue(self, title: str, description: str) -> Issue:
-        return GitlabIssue.create(project=self, title=title, body=description)
+    def create_issue(
+        self, title: str, body: str, private: Optional[bool] = None,
+    ) -> Issue:
+        return GitlabIssue.create(project=self, title=title, body=body, private=private)
 
     def get_pr(self, pr_id: int) -> PullRequest:
         return GitlabPullRequest.get(project=self, id=pr_id)

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -411,9 +411,15 @@ class GitlabProject(BaseGitProject):
         return GitlabIssue.get(project=self, id=issue_id)
 
     def create_issue(
-        self, title: str, body: str, private: Optional[bool] = None,
+        self,
+        title: str,
+        body: str,
+        private: Optional[bool] = None,
+        labels: Optional[List[str]] = None,
     ) -> Issue:
-        return GitlabIssue.create(project=self, title=title, body=body, private=private)
+        return GitlabIssue.create(
+            project=self, title=title, body=body, private=private, labels=labels
+        )
 
     def get_pr(self, pr_id: int) -> PullRequest:
         return GitlabPullRequest.get(project=self, id=pr_id)

--- a/ogr/services/pagure/issue.py
+++ b/ogr/services/pagure/issue.py
@@ -52,6 +52,11 @@ class PagureIssue(BaseIssue):
         self.__update_info(title=new_title)
 
     @property
+    def private(self) -> bool:
+        self.__update()
+        return self._raw_issue["private"]
+
+    @property
     def id(self) -> int:
         return self._raw_issue["id"]
 
@@ -113,11 +118,11 @@ class PagureIssue(BaseIssue):
         project: "ogr_pagure.PagureProject",
         title: str,
         body: str,
-        labels: Optional[List[str]] = None,
+        private: Optional[bool] = None,
     ) -> "Issue":
         payload = {"title": title, "issue_content": body}
-        if labels is not None:
-            payload["tag"] = ",".join(labels)
+        if private:
+            payload["private"] = "true"
         new_issue = project._call_project_api("new_issue", data=payload, method="POST")[
             "issue"
         ]

--- a/ogr/services/pagure/issue.py
+++ b/ogr/services/pagure/issue.py
@@ -119,8 +119,11 @@ class PagureIssue(BaseIssue):
         title: str,
         body: str,
         private: Optional[bool] = None,
+        labels: Optional[List[str]] = None,
     ) -> "Issue":
         payload = {"title": title, "issue_content": body}
+        if labels is not None:
+            payload["tag"] = ",".join(labels)
         if private:
             payload["private"] = "true"
         new_issue = project._call_project_api("new_issue", data=payload, method="POST")[

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -223,9 +223,9 @@ class PagureProject(BaseGitProject):
         return PagureIssue.get(project=self, id=issue_id)
 
     def create_issue(
-        self, title: str, body: str, labels: Optional[List[str]] = None
+        self, title: str, body: str, private: Optional[bool] = None,
     ) -> Issue:
-        return PagureIssue.create(project=self, title=title, body=body, labels=labels)
+        return PagureIssue.create(project=self, title=title, body=body)
 
     def get_pr_list(
         self, status: PRStatus = PRStatus.open, assignee=None, author=None

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -223,9 +223,15 @@ class PagureProject(BaseGitProject):
         return PagureIssue.get(project=self, id=issue_id)
 
     def create_issue(
-        self, title: str, body: str, private: Optional[bool] = None,
+        self,
+        title: str,
+        body: str,
+        private: Optional[bool] = None,
+        labels: Optional[List[str]] = None,
     ) -> Issue:
-        return PagureIssue.create(project=self, title=title, body=body)
+        return PagureIssue.create(
+            project=self, title=title, body=body, labels=labels, private=private
+        )
 
     def get_pr_list(
         self, status: PRStatus = PRStatus.open, assignee=None, author=None

--- a/tests/integration/test_data/test_github/tests.integration.test_github.Issues.test_create_issue.yaml
+++ b/tests/integration/test_data/test_github/tests.integration.test_github.Issues.test_create_issue.yaml
@@ -1,0 +1,369 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_github:
+    ogr.services.github.issue:
+      github.PaginatedList:
+        github.Requester:
+          requests.sessions:
+            requre.objects:
+              requre.cassette:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 0.39757704734802246
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_github
+                      - ogr.services.github.issue
+                      - github.PaginatedList
+                      - github.Requester
+                      - requests.sessions
+                      - requre.objects
+                      - requre.cassette
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                      - color: ededed
+                        default: false
+                        description: null
+                        id: 2242697673
+                        name: label1
+                        node_id: MDU6TGFiZWwyMjQyNjk3Njcz
+                        url: https://api.github.com/repos/shreyaspapi/test/labels/label1
+                      - color: ededed
+                        default: false
+                        description: null
+                        id: 2242697675
+                        name: label2
+                        node_id: MDU6TGFiZWwyMjQyNjk3Njc1
+                        url: https://api.github.com/repos/shreyaspapi/test/labels/label2
+                      _next: null
+                      elapsed: 0.2
+                      encoding: utf-8
+                      headers:
+                        Access-Control-Allow-Origin: '*'
+                        Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                          X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                          X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                          X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                        Cache-Control: private, max-age=60, s-maxage=60
+                        Content-Encoding: gzip
+                        Content-Security-Policy: default-src 'none'
+                        Content-Type: application/json; charset=utf-8
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                        Last-Modified: Thu, 30 Jul 2020 21:20:58 GMT
+                        Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                        Server: GitHub.com
+                        Status: 200 OK
+                        Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                          preload
+                        Transfer-Encoding: chunked
+                        Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                          Accept, X-Requested-With, Accept-Encoding
+                        X-Accepted-OAuth-Scopes: repo
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: deny
+                        X-GitHub-Media-Type: github.v3; format=json
+                        X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                        X-OAuth-Scopes: admin:org, delete:packages, read:packages,
+                          repo, user, write:packages
+                        X-RateLimit-Limit: '5000'
+                        X-RateLimit-Remaining: '4972'
+                        X-RateLimit-Reset: '1572953901'
+                        X-XSS-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200
+    ogr.services.github.project:
+      ogr.services.github.issue:
+        github.Repository:
+          github.Requester:
+            requests.sessions:
+              requre.objects:
+                requre.cassette:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.8941841125488281
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_github
+                        - ogr.services.github.project
+                        - ogr.services.github.issue
+                        - github.Repository
+                        - github.Requester
+                        - requests.sessions
+                        - requre.objects
+                        - requre.cassette
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          active_lock_reason: null
+                          assignee: null
+                          assignees: []
+                          author_association: OWNER
+                          body: Example of Issue description
+                          closed_at: null
+                          closed_by: null
+                          comments: 0
+                          comments_url: https://api.github.com/repos/shreyaspapi/test/issues/4/comments
+                          created_at: '2020-07-30T21:20:58Z'
+                          events_url: https://api.github.com/repos/shreyaspapi/test/issues/4/events
+                          html_url: https://github.com/shreyaspapi/test/issues/4
+                          id: 669206709
+                          labels:
+                          - color: ededed
+                            default: false
+                            description: null
+                            id: 2242697673
+                            name: label1
+                            node_id: MDU6TGFiZWwyMjQyNjk3Njcz
+                            url: https://api.github.com/repos/shreyaspapi/test/labels/label1
+                          - color: ededed
+                            default: false
+                            description: null
+                            id: 2242697675
+                            name: label2
+                            node_id: MDU6TGFiZWwyMjQyNjk3Njc1
+                            url: https://api.github.com/repos/shreyaspapi/test/labels/label2
+                          labels_url: https://api.github.com/repos/shreyaspapi/test/issues/4/labels{/name}
+                          locked: false
+                          milestone: null
+                          node_id: MDU6SXNzdWU2NjkyMDY3MDk=
+                          number: 4
+                          performed_via_github_app: null
+                          repository_url: https://api.github.com/repos/shreyaspapi/test
+                          state: open
+                          title: This is an issue
+                          updated_at: '2020-07-30T21:20:58Z'
+                          url: https://api.github.com/repos/shreyaspapi/test/issues/4
+                          user:
+                            avatar_url: https://avatars2.githubusercontent.com/u/22324802?v=4
+                            events_url: https://api.github.com/users/shreyaspapi/events{/privacy}
+                            followers_url: https://api.github.com/users/shreyaspapi/followers
+                            following_url: https://api.github.com/users/shreyaspapi/following{/other_user}
+                            gists_url: https://api.github.com/users/shreyaspapi/gists{/gist_id}
+                            gravatar_id: ''
+                            html_url: https://github.com/shreyaspapi
+                            id: 22324802
+                            login: shreyaspapi
+                            node_id: MDQ6VXNlcjIyMzI0ODAy
+                            organizations_url: https://api.github.com/users/shreyaspapi/orgs
+                            received_events_url: https://api.github.com/users/shreyaspapi/received_events
+                            repos_url: https://api.github.com/users/shreyaspapi/repos
+                            site_admin: false
+                            starred_url: https://api.github.com/users/shreyaspapi/starred{/owner}{/repo}
+                            subscriptions_url: https://api.github.com/users/shreyaspapi/subscriptions
+                            type: User
+                            url: https://api.github.com/users/shreyaspapi
+                        _next: null
+                        elapsed: 0.2
+                        encoding: utf-8
+                        headers:
+                          Access-Control-Allow-Origin: '*'
+                          Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                            X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                            X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                            X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                          Cache-Control: private, max-age=60, s-maxage=60
+                          Content-Length: '2186'
+                          Content-Security-Policy: default-src 'none'
+                          Content-Type: application/json; charset=utf-8
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                          Location: https://api.github.com/repos/shreyaspapi/test/issues/4
+                          Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                          Server: GitHub.com
+                          Status: 201 Created
+                          Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                            preload
+                          Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                            Accept, X-Requested-With, Accept-Encoding
+                          X-Accepted-OAuth-Scopes: ''
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: deny
+                          X-GitHub-Media-Type: github.v3; format=json
+                          X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                          X-OAuth-Scopes: admin:org, delete:packages, read:packages,
+                            repo, user, write:packages
+                          X-RateLimit-Limit: '5000'
+                          X-RateLimit-Remaining: '4972'
+                          X-RateLimit-Reset: '1572953901'
+                          X-XSS-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: Created
+                        status_code: 201
+        ogr.services.github.project:
+          github.MainClass:
+            github.Requester:
+              requests.sessions:
+                requre.objects:
+                  requre.cassette:
+                    requests.sessions:
+                      send:
+                      - metadata:
+                          latency: 0.38182926177978516
+                          module_call_list:
+                          - unittest.case
+                          - tests.integration.test_github
+                          - ogr.services.github.project
+                          - ogr.services.github.issue
+                          - ogr.services.github.project
+                          - github.MainClass
+                          - github.Requester
+                          - requests.sessions
+                          - requre.objects
+                          - requre.cassette
+                          - requests.sessions
+                          - send
+                        output:
+                          __store_indicator: 2
+                          _content:
+                            allow_merge_commit: true
+                            allow_rebase_merge: true
+                            allow_squash_merge: true
+                            archive_url: https://api.github.com/repos/shreyaspapi/test/{archive_format}{/ref}
+                            archived: false
+                            assignees_url: https://api.github.com/repos/shreyaspapi/test/assignees{/user}
+                            blobs_url: https://api.github.com/repos/shreyaspapi/test/git/blobs{/sha}
+                            branches_url: https://api.github.com/repos/shreyaspapi/test/branches{/branch}
+                            clone_url: https://github.com/shreyaspapi/test.git
+                            collaborators_url: https://api.github.com/repos/shreyaspapi/test/collaborators{/collaborator}
+                            comments_url: https://api.github.com/repos/shreyaspapi/test/comments{/number}
+                            commits_url: https://api.github.com/repos/shreyaspapi/test/commits{/sha}
+                            compare_url: https://api.github.com/repos/shreyaspapi/test/compare/{base}...{head}
+                            contents_url: https://api.github.com/repos/shreyaspapi/test/contents/{+path}
+                            contributors_url: https://api.github.com/repos/shreyaspapi/test/contributors
+                            created_at: '2020-06-28T20:42:21Z'
+                            default_branch: master
+                            delete_branch_on_merge: false
+                            deployments_url: https://api.github.com/repos/shreyaspapi/test/deployments
+                            description: null
+                            disabled: false
+                            downloads_url: https://api.github.com/repos/shreyaspapi/test/downloads
+                            events_url: https://api.github.com/repos/shreyaspapi/test/events
+                            fork: false
+                            forks: 1
+                            forks_count: 1
+                            forks_url: https://api.github.com/repos/shreyaspapi/test/forks
+                            full_name: shreyaspapi/test
+                            git_commits_url: https://api.github.com/repos/shreyaspapi/test/git/commits{/sha}
+                            git_refs_url: https://api.github.com/repos/shreyaspapi/test/git/refs{/sha}
+                            git_tags_url: https://api.github.com/repos/shreyaspapi/test/git/tags{/sha}
+                            git_url: git://github.com/shreyaspapi/test.git
+                            has_downloads: true
+                            has_issues: true
+                            has_pages: false
+                            has_projects: true
+                            has_wiki: true
+                            homepage: null
+                            hooks_url: https://api.github.com/repos/shreyaspapi/test/hooks
+                            html_url: https://github.com/shreyaspapi/test
+                            id: 275664870
+                            issue_comment_url: https://api.github.com/repos/shreyaspapi/test/issues/comments{/number}
+                            issue_events_url: https://api.github.com/repos/shreyaspapi/test/issues/events{/number}
+                            issues_url: https://api.github.com/repos/shreyaspapi/test/issues{/number}
+                            keys_url: https://api.github.com/repos/shreyaspapi/test/keys{/key_id}
+                            labels_url: https://api.github.com/repos/shreyaspapi/test/labels{/name}
+                            language: null
+                            languages_url: https://api.github.com/repos/shreyaspapi/test/languages
+                            license: null
+                            merges_url: https://api.github.com/repos/shreyaspapi/test/merges
+                            milestones_url: https://api.github.com/repos/shreyaspapi/test/milestones{/number}
+                            mirror_url: null
+                            name: test
+                            network_count: 1
+                            node_id: MDEwOlJlcG9zaXRvcnkyNzU2NjQ4NzA=
+                            notifications_url: https://api.github.com/repos/shreyaspapi/test/notifications{?since,all,participating}
+                            open_issues: 3
+                            open_issues_count: 3
+                            owner:
+                              avatar_url: https://avatars2.githubusercontent.com/u/22324802?v=4
+                              events_url: https://api.github.com/users/shreyaspapi/events{/privacy}
+                              followers_url: https://api.github.com/users/shreyaspapi/followers
+                              following_url: https://api.github.com/users/shreyaspapi/following{/other_user}
+                              gists_url: https://api.github.com/users/shreyaspapi/gists{/gist_id}
+                              gravatar_id: ''
+                              html_url: https://github.com/shreyaspapi
+                              id: 22324802
+                              login: shreyaspapi
+                              node_id: MDQ6VXNlcjIyMzI0ODAy
+                              organizations_url: https://api.github.com/users/shreyaspapi/orgs
+                              received_events_url: https://api.github.com/users/shreyaspapi/received_events
+                              repos_url: https://api.github.com/users/shreyaspapi/repos
+                              site_admin: false
+                              starred_url: https://api.github.com/users/shreyaspapi/starred{/owner}{/repo}
+                              subscriptions_url: https://api.github.com/users/shreyaspapi/subscriptions
+                              type: User
+                              url: https://api.github.com/users/shreyaspapi
+                            permissions:
+                              admin: true
+                              pull: true
+                              push: true
+                            private: false
+                            pulls_url: https://api.github.com/repos/shreyaspapi/test/pulls{/number}
+                            pushed_at: '2020-07-09T15:30:50Z'
+                            releases_url: https://api.github.com/repos/shreyaspapi/test/releases{/id}
+                            size: 2
+                            ssh_url: git@github.com:shreyaspapi/test.git
+                            stargazers_count: 0
+                            stargazers_url: https://api.github.com/repos/shreyaspapi/test/stargazers
+                            statuses_url: https://api.github.com/repos/shreyaspapi/test/statuses/{sha}
+                            subscribers_count: 1
+                            subscribers_url: https://api.github.com/repos/shreyaspapi/test/subscribers
+                            subscription_url: https://api.github.com/repos/shreyaspapi/test/subscription
+                            svn_url: https://github.com/shreyaspapi/test
+                            tags_url: https://api.github.com/repos/shreyaspapi/test/tags
+                            teams_url: https://api.github.com/repos/shreyaspapi/test/teams
+                            temp_clone_token: ''
+                            trees_url: https://api.github.com/repos/shreyaspapi/test/git/trees{/sha}
+                            updated_at: '2020-06-28T20:42:51Z'
+                            url: https://api.github.com/repos/shreyaspapi/test
+                            watchers: 0
+                            watchers_count: 0
+                          _next: null
+                          elapsed: 0.2
+                          encoding: utf-8
+                          headers:
+                            Access-Control-Allow-Origin: '*'
+                            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After,
+                              X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+                              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+                              X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+                            Cache-Control: private, max-age=60, s-maxage=60
+                            Content-Encoding: gzip
+                            Content-Security-Policy: default-src 'none'
+                            Content-Type: application/json; charset=utf-8
+                            Date: Fri, 01 Nov 2019 13-36-03 GMT
+                            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+                            Last-Modified: Sun, 28 Jun 2020 20:42:51 GMT
+                            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+                            Server: GitHub.com
+                            Status: 200 OK
+                            Strict-Transport-Security: max-age=31536000; includeSubdomains;
+                              preload
+                            Transfer-Encoding: chunked
+                            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                              Accept, X-Requested-With, Accept-Encoding
+                            X-Accepted-OAuth-Scopes: repo
+                            X-Content-Type-Options: nosniff
+                            X-Frame-Options: deny
+                            X-GitHub-Media-Type: github.v3; format=json
+                            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+                            X-OAuth-Scopes: admin:org, delete:packages, read:packages,
+                              repo, user, write:packages
+                            X-RateLimit-Limit: '5000'
+                            X-RateLimit-Remaining: '4972'
+                            X-RateLimit-Reset: '1572953901'
+                            X-XSS-Protection: 1; mode=block
+                          raw: !!binary ""
+                          reason: OK
+                          status_code: 200

--- a/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.Issues.test_create_private_issue.yaml
+++ b/tests/integration/test_data/test_gitlab/tests.integration.test_gitlab.Issues.test_create_private_issue.yaml
@@ -14,7 +14,7 @@ unittest.case:
                   requests.sessions:
                     send:
                     - metadata:
-                        latency: 1.4438090324401855
+                        latency: 1.133673906326294
                         module_call_list:
                         - unittest.case
                         - tests.integration.test_gitlab
@@ -31,10 +31,10 @@ unittest.case:
                         __store_indicator: 2
                         _content:
                           _links:
-                            award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/61/award_emoji
-                            notes: https://gitlab.com/api/v4/projects/14233409/issues/61/notes
+                            award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/60/award_emoji
+                            notes: https://gitlab.com/api/v4/projects/14233409/issues/60/notes
                             project: https://gitlab.com/api/v4/projects/14233409
-                            self: https://gitlab.com/api/v4/projects/14233409/issues/61
+                            self: https://gitlab.com/api/v4/projects/14233409/issues/60
                           assignee: null
                           assignees: []
                           author:
@@ -47,24 +47,24 @@ unittest.case:
                           blocking_issues_count: null
                           closed_at: null
                           closed_by: null
-                          confidential: false
-                          created_at: '2020-07-30T21:25:04.755Z'
+                          confidential: true
+                          created_at: '2020-07-30T12:08:46.018Z'
                           description: Description for issue abcde
                           discussion_locked: null
                           downvotes: 0
                           due_date: null
                           has_tasks: false
-                          id: 69247536
-                          iid: 61
+                          id: 69230881
+                          iid: 60
                           labels: []
                           merge_requests_count: 0
                           milestone: null
                           moved_to_id: null
                           project_id: 14233409
                           references:
-                            full: packit-service/ogr-tests#61
-                            relative: '#61'
-                            short: '#61'
+                            full: packit-service/ogr-tests#60
+                            relative: '#60'
+                            short: '#60'
                           state: opened
                           subscribed: true
                           task_completion_status:
@@ -75,41 +75,41 @@ unittest.case:
                             human_total_time_spent: null
                             time_estimate: 0
                             total_time_spent: 0
-                          title: New Issue abcde
-                          updated_at: '2020-07-30T21:25:04.755Z'
+                          title: New Confidential Issue abcde
+                          updated_at: '2020-07-30T12:08:46.018Z'
                           upvotes: 0
                           user_notes_count: 0
-                          web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/61
+                          web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/60
                           weight: null
                         _next: null
                         elapsed: 0.2
                         encoding: null
                         headers:
                           CF-Cache-Status: DYNAMIC
-                          CF-RAY: 5bb2266b0dbd8a77-BOM
+                          CF-RAY: 5baef7829b7f8a83-BOM
                           Cache-Control: max-age=0, private, must-revalidate
                           Connection: keep-alive
-                          Content-Length: '1371'
+                          Content-Length: '1383'
                           Content-Type: application/json
                           Date: Fri, 01 Nov 2019 13-36-03 GMT
-                          Etag: W/"4e977ca09b70d79f326740e17a157783"
+                          Etag: W/"cb173743428dca520d0091c11853e75e"
                           Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-                          GitLab-LB: fe-09-lb-gprd
+                          GitLab-LB: fe-01-lb-gprd
                           GitLab-SV: localhost
                           RateLimit-Limit: '600'
-                          RateLimit-Observed: '3'
-                          RateLimit-Remaining: '597'
-                          RateLimit-Reset: '1596144364'
-                          RateLimit-ResetTime: Thu, 30 Jul 2020 21:26:04 GMT
+                          RateLimit-Observed: '2'
+                          RateLimit-Remaining: '598'
+                          RateLimit-Reset: '1596110986'
+                          RateLimit-ResetTime: Thu, 30 Jul 2020 12:09:46 GMT
                           Referrer-Policy: strict-origin-when-cross-origin
                           Server: cloudflare
                           Strict-Transport-Security: max-age=31536000
                           Vary: Origin
                           X-Content-Type-Options: nosniff
                           X-Frame-Options: SAMEORIGIN
-                          X-Request-Id: 7NAxzNPcs05
-                          X-Runtime: '0.398148'
-                          cf-request-id: 04433656e000008a777a263200000001
+                          X-Request-Id: 88FrO3Ueaua
+                          X-Runtime: '0.234457'
+                          cf-request-id: 04413905a300008a833a18b200000001
                         raw: !!binary ""
                         reason: Created
                         status_code: 201
@@ -122,7 +122,7 @@ unittest.case:
                     requests.sessions:
                       send:
                       - metadata:
-                          latency: 0.9949979782104492
+                          latency: 0.9892380237579346
                           module_call_list:
                           - unittest.case
                           - tests.integration.test_gitlab
@@ -178,7 +178,7 @@ unittest.case:
                             issues_access_level: enabled
                             issues_enabled: true
                             jobs_enabled: true
-                            last_activity_at: '2020-07-30T12:08:46.083Z'
+                            last_activity_at: '2020-07-29T10:12:41.755Z'
                             lfs_enabled: true
                             marked_for_deletion_at: null
                             marked_for_deletion_on: null
@@ -233,21 +233,21 @@ unittest.case:
                           encoding: null
                           headers:
                             CF-Cache-Status: DYNAMIC
-                            CF-RAY: 5bb22664ac328a77-BOM
+                            CF-RAY: 5baef77c6b378a83-BOM
                             Cache-Control: max-age=0, private, must-revalidate
                             Connection: keep-alive
                             Content-Encoding: gzip
                             Content-Type: application/json
                             Date: Fri, 01 Nov 2019 13-36-03 GMT
-                            Etag: W/"e5d5a2e94f876fd4dc8e636b2b1dacdb"
+                            Etag: W/"2e3a1fa4c0ea40f53d7b3497974611b8"
                             Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-                            GitLab-LB: fe-05-lb-gprd
+                            GitLab-LB: fe-02-lb-gprd
                             GitLab-SV: localhost
                             RateLimit-Limit: '600'
-                            RateLimit-Observed: '2'
-                            RateLimit-Remaining: '598'
-                            RateLimit-Reset: '1596144363'
-                            RateLimit-ResetTime: Thu, 30 Jul 2020 21:26:03 GMT
+                            RateLimit-Observed: '1'
+                            RateLimit-Remaining: '599'
+                            RateLimit-Reset: '1596110985'
+                            RateLimit-ResetTime: Thu, 30 Jul 2020 12:09:45 GMT
                             Referrer-Policy: strict-origin-when-cross-origin
                             Server: cloudflare
                             Strict-Transport-Security: max-age=31536000
@@ -255,9 +255,9 @@ unittest.case:
                             Vary: Accept-Encoding, Origin
                             X-Content-Type-Options: nosniff
                             X-Frame-Options: SAMEORIGIN
-                            X-Request-Id: A3Xa4xdBFo9
-                            X-Runtime: '0.080131'
-                            cf-request-id: 04433652ed00008a777a24f200000001
+                            X-Request-Id: gVWaHgMamp1
+                            X-Runtime: '0.094650'
+                            cf-request-id: 04413901bd00008a833a182200000001
                           raw: !!binary ""
                           reason: OK
                           status_code: 200
@@ -271,7 +271,7 @@ unittest.case:
                         requests.sessions:
                           send:
                           - metadata:
-                              latency: 1.2211172580718994
+                              latency: 1.2381329536437988
                               module_call_list:
                               - unittest.case
                               - tests.integration.test_gitlab
@@ -332,7 +332,7 @@ unittest.case:
                               encoding: null
                               headers:
                                 CF-Cache-Status: DYNAMIC
-                                CF-RAY: 5bb2265d9b3f8a77-BOM
+                                CF-RAY: 5baef7753a738a83-BOM
                                 Cache-Control: max-age=0, private, must-revalidate
                                 Connection: keep-alive
                                 Content-Encoding: gzip
@@ -340,26 +340,26 @@ unittest.case:
                                 Date: Fri, 01 Nov 2019 13-36-03 GMT
                                 Etag: W/"a07f19254da3515f57d00da499843a13"
                                 Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-                                GitLab-LB: fe-01-lb-gprd
+                                GitLab-LB: fe-07-lb-gprd
                                 GitLab-SV: localhost
                                 RateLimit-Limit: '600'
                                 RateLimit-Observed: '1'
                                 RateLimit-Remaining: '599'
-                                RateLimit-Reset: '1596144362'
-                                RateLimit-ResetTime: Thu, 30 Jul 2020 21:26:02 GMT
+                                RateLimit-Reset: '1596110983'
+                                RateLimit-ResetTime: Thu, 30 Jul 2020 12:09:43 GMT
                                 Referrer-Policy: strict-origin-when-cross-origin
                                 Server: cloudflare
-                                Set-Cookie: __cfduid=d9147d7f42987545634684d6388e4e3fb1596144301;
-                                  expires=Sat, 29-Aug-20 21:25:01 GMT; path=/; domain=.gitlab.com;
+                                Set-Cookie: __cfduid=d3598401b59aa080408e2d16b7ca74d261596110923;
+                                  expires=Sat, 29-Aug-20 12:08:43 GMT; path=/; domain=.gitlab.com;
                                   HttpOnly; SameSite=Lax; Secure
                                 Strict-Transport-Security: max-age=31536000
                                 Transfer-Encoding: chunked
                                 Vary: Accept-Encoding, Origin
                                 X-Content-Type-Options: nosniff
                                 X-Frame-Options: SAMEORIGIN
-                                X-Request-Id: LO3RqRzyWIa
-                                X-Runtime: '0.030304'
-                                cf-request-id: 0443364e7d00008a777a241200000001
+                                X-Request-Id: 2WJhBC6YPr6
+                                X-Runtime: '0.033572'
+                                cf-request-id: 044138fd4500008a833a17d200000001
                               raw: !!binary ""
                               reason: OK
                               status_code: 200

--- a/tests/integration/test_data/test_pagure/tests.integration.test_pagure.Issues.test_create_issue.yaml
+++ b/tests/integration/test_data/test_pagure/tests.integration.test_pagure.Issues.test_create_issue.yaml
@@ -1,0 +1,136 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectFull
+  version_storage_file: 2
+unittest.case:
+  tests.integration.test_pagure:
+    ogr.services.pagure.project:
+      ogr.services.pagure.issue:
+        ogr.services.pagure.project:
+          ogr.services.pagure.service:
+            requests.sessions:
+              requre.objects:
+                requre.cassette:
+                  requests.sessions:
+                    send:
+                    - metadata:
+                        latency: 0.5660958290100098
+                        module_call_list:
+                        - unittest.case
+                        - tests.integration.test_pagure
+                        - ogr.services.pagure.project
+                        - ogr.services.pagure.issue
+                        - ogr.services.pagure.project
+                        - ogr.services.pagure.service
+                        - requests.sessions
+                        - requre.objects
+                        - requre.cassette
+                        - requests.sessions
+                        - send
+                      output:
+                        __store_indicator: 2
+                        _content:
+                          issue:
+                            assignee: null
+                            blocks: []
+                            close_status: null
+                            closed_at: null
+                            closed_by: null
+                            comments: []
+                            content: Example of Issue description
+                            custom_fields: []
+                            date_created: '1596113996'
+                            depends: []
+                            id: 8
+                            last_updated: '1596113996'
+                            milestone: null
+                            priority: null
+                            private: true
+                            related_prs: []
+                            status: Open
+                            tags: []
+                            title: This is an issue
+                            user:
+                              fullname: Shreyas Papinwar
+                              name: spapinwar
+                              url_path: user/spapinwar
+                          message: Issue created
+                        _next: null
+                        elapsed: 0.2
+                        encoding: null
+                        headers:
+                          Connection: Keep-Alive
+                          Content-Length: '634'
+                          Content-Security-Policy: default-src 'self';script-src 'self'
+                            'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                            style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                            'none';base-uri 'self';img-src 'self' https:;
+                          Content-Type: application/json
+                          Date: Fri, 01 Nov 2019 13-36-03 GMT
+                          Keep-Alive: timeout=5, max=99
+                          Referrer-Policy: same-origin
+                          Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                            mod_wsgi/3.4 Python/2.7.5
+                          Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWkRjM1pEWTFabUk0TUdWbFptTmhOMk5oTUdReVpqTmhaR05sWW1WaU5UazFOekJsWkRjNE13PT0ifX0.EgRVzA.Ysp-hnq3i_1WfLppTPMVbVdHsXc;
+                            Expires=Sun, 30-Aug-2020 12:59:56 GMT; Secure; HttpOnly;
+                            Path=/
+                          Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                            preload
+                          X-Content-Type-Options: nosniff
+                          X-Frame-Options: ALLOW-FROM https://pagure.io/
+                          X-Xss-Protection: 1; mode=block
+                        raw: !!binary ""
+                        reason: OK
+                        status_code: 200
+    ogr.services.pagure.service:
+      ogr.services.pagure.user:
+        ogr.services.pagure.service:
+          requests.sessions:
+            requre.objects:
+              requre.cassette:
+                requests.sessions:
+                  send:
+                  - metadata:
+                      latency: 1.532729148864746
+                      module_call_list:
+                      - unittest.case
+                      - tests.integration.test_pagure
+                      - ogr.services.pagure.service
+                      - ogr.services.pagure.user
+                      - ogr.services.pagure.service
+                      - requests.sessions
+                      - requre.objects
+                      - requre.cassette
+                      - requests.sessions
+                      - send
+                    output:
+                      __store_indicator: 2
+                      _content:
+                        username: spapinwar
+                      _next: null
+                      elapsed: 0.2
+                      encoding: null
+                      headers:
+                        Connection: Keep-Alive
+                        Content-Length: '29'
+                        Content-Security-Policy: default-src 'self';script-src 'self'
+                          'nonce-YqLDC0BS8d7iY8mKO7VtBbIne' https://apps.fedoraproject.org;
+                          style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'; object-src
+                          'none';base-uri 'self';img-src 'self' https:;
+                        Content-Type: application/json
+                        Date: Fri, 01 Nov 2019 13-36-03 GMT
+                        Keep-Alive: timeout=5, max=100
+                        Referrer-Policy: same-origin
+                        Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips
+                          mod_wsgi/3.4 Python/2.7.5
+                        Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWkRjM1pEWTFabUk0TUdWbFptTmhOMk5oTUdReVpqTmhaR05sWW1WaU5UazFOekJsWkRjNE13PT0ifX0.EgRVzA.Ysp-hnq3i_1WfLppTPMVbVdHsXc;
+                          Expires=Sun, 30-Aug-2020 12:59:56 GMT; Secure; HttpOnly;
+                          Path=/
+                        Strict-Transport-Security: max-age=31536000; includeSubDomains;
+                          preload
+                        X-Content-Type-Options: nosniff
+                        X-Frame-Options: ALLOW-FROM https://pagure.io/
+                        X-Xss-Protection: 1; mode=block
+                      raw: !!binary ""
+                      reason: OK
+                      status_code: 200

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -395,6 +395,17 @@ class Issues(GithubTests):
         assert issue_list
         assert len(issue_list) >= 3
 
+    def test_create_issue(self):
+        title = "This is an issue"
+        description = "Example of Issue description"
+        project = self.service.get_project(namespace="shreyaspapi", repo="test")
+        issue = project.create_issue(title=title, body=description)
+        assert issue.title == title
+        assert issue.description == description
+
+        with self.assertRaises(NotImplementedError):
+            project.create_issue(title=title, body=description, private=True)
+
     def test_issue_list_author(self):
         issue_list = self.ogr_project.get_issue_list(
             status=IssueStatus.all, author="mfocko"

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -398,10 +398,13 @@ class Issues(GithubTests):
     def test_create_issue(self):
         title = "This is an issue"
         description = "Example of Issue description"
+        labels = ["label1", "label2"]
         project = self.service.get_project(namespace="shreyaspapi", repo="test")
-        issue = project.create_issue(title=title, body=description)
+        issue = project.create_issue(title=title, body=description, labels=labels)
         assert issue.title == title
         assert issue.description == description
+        for issue_label, label in zip(issue.labels, labels):
+            assert issue_label.name == label
 
         with self.assertRaises(NotImplementedError):
             project.create_issue(title=title, body=description, private=True)

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -255,9 +255,23 @@ class Issues(GitlabTests):
         """
         issue_title = f"New Issue {self.random_str}"
         issue_desc = f"Description for issue {self.random_str}"
-        issue = self.project.create_issue(title=issue_title, description=issue_desc)
+        issue = self.project.create_issue(title=issue_title, body=issue_desc)
+
         assert issue.title == issue_title
         assert issue.description == issue_desc
+
+    def test_create_private_issue(self):
+        """
+        see class comment in case of fail
+        """
+        issue_title = f"New Confidential Issue {self.random_str}"
+        issue_desc = f"Description for issue {self.random_str}"
+        issue = self.project.create_issue(
+            title=issue_title, body=issue_desc, private=True
+        )
+        assert issue.title == issue_title
+        assert issue.description == issue_desc
+        assert issue.private
 
     def test_close_issue(self):
         """
@@ -265,7 +279,7 @@ class Issues(GitlabTests):
         """
         issue = self.project.create_issue(
             title=f"Close issue {self.random_str}",
-            description=f"Description for issue for closing {self.random_str}",
+            body=f"Description for issue for closing {self.random_str}",
         )
         issue_for_closing = self.project.get_issue_info(issue_id=issue.id)
         assert issue_for_closing.status == IssueStatus.open

--- a/tests/integration/test_gitlab.py
+++ b/tests/integration/test_gitlab.py
@@ -253,12 +253,17 @@ class Issues(GitlabTests):
         """
         see class comment in case of fail
         """
+        labels = ["label1", "label2"]
         issue_title = f"New Issue {self.random_str}"
         issue_desc = f"Description for issue {self.random_str}"
-        issue = self.project.create_issue(title=issue_title, body=issue_desc)
+        issue = self.project.create_issue(
+            title=issue_title, body=issue_desc, labels=labels
+        )
 
         assert issue.title == issue_title
         assert issue.description == issue_desc
+        for issue_label, label in zip(issue.labels, labels):
+            assert issue_label.name == label
 
     def test_create_private_issue(self):
         """

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -287,6 +287,15 @@ class Issues(PagureTests):
         assert issue_list
         assert len(issue_list) == 1
 
+    def test_create_issue(self):
+        title = "This is an issue"
+        description = "Example of Issue description"
+        project = self.service.get_project(repo="hello-112111", namespace="testing")
+        issue = project.create_issue(title=title, body=description, private=True)
+        assert issue.title == title
+        assert issue.description == description
+        assert issue.private
+
 
 class PullRequests(PagureTests):
     def test_pr_create(self):

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -290,11 +290,16 @@ class Issues(PagureTests):
     def test_create_issue(self):
         title = "This is an issue"
         description = "Example of Issue description"
-        project = self.service.get_project(repo="hello-112111", namespace="testing")
-        issue = project.create_issue(title=title, body=description, private=True)
+        labels = ["label1", "label2"]
+        project = self.service.get_project(repo="hello-112111", namespace="testing",)
+        issue = project.create_issue(
+            title=title, body=description, private=True, labels=labels
+        )
         assert issue.title == title
         assert issue.description == description
         assert issue.private
+        for issue_label, label in zip(issue.labels, labels):
+            assert issue_label.name == label
 
 
 class PullRequests(PagureTests):


### PR DESCRIPTION
- [x] Gitlab - Private issues are known as confidential issues
- [x] Github - Does not support private/confidential issues. (raised an error here)
- [x] Pagure