### PR TITLE
Fix lru_cache decorator

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -36,7 +36,7 @@ except ImportError:
     from functools import lru_cache
 
     def cached_property(func):  # type: ignore
-        return property(lru_cache(func))
+        return property(lru_cache()(func))
 
 
 AnyComment = TypeVar("AnyComment", bound="Comment")

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -48,7 +48,7 @@ except ImportError:
     from functools import lru_cache
 
     def cached_property(func):  # type: ignore
-        return property(lru_cache(func))
+        return property(lru_cache()(func))
 
 
 class BaseGitService(GitService):


### PR DESCRIPTION
- Use parenthesis for `lru_cache` decorator for backwards compatibility.
- Fixes problem found in packit PR: https://github.com/packit/packit-service/pull/820