### PR TITLE
Return `None` for user's email in Pagure

### DIFF
--- a/ogr/services/pagure/user.py
+++ b/ogr/services/pagure/user.py
@@ -22,6 +22,7 @@
 
 from typing import List
 
+from ogr.exceptions import OperationNotSupported
 from ogr.services import pagure as ogr_pagure
 from ogr.services.base import BaseGitUser
 from ogr.services.pagure.project import PagureProject
@@ -68,3 +69,9 @@ class PagureUser(BaseGitUser):
             )
             for fork in raw_forks
         ]
+
+    def get_email(self) -> str:
+        # Not supported by Pagure
+        raise OperationNotSupported(
+            "Pagure does not support retrieving of user's email address"
+        )


### PR DESCRIPTION
Chosen as a better resolution to unsupported API (previously raised an exception).

Signed-off-by: Matej Focko <mfocko@redhat.com>

Closes #126