### PR TITLE
Turn off requre in pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # HOWTO: https://pre-commit.com/#usage
 # pip3 install pre-commit
-# pre-commit install
+# pre-commit install -t pre-commit -t pre-push
 
 repos:
   - repo: https://github.com/psf/black
@@ -37,7 +37,9 @@ repos:
       - id: check-rebase
         args:
           - git://github.com/packit-service/ogr.git
+        stages: [manual, push]
   - repo: https://github.com/packit/requre
     rev: 0.2.2
     hooks:
       - id: requre-purge
+        stages: [manual, push]

--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,4 @@ remove-response-files-gitlab:
 remove-response-files: remove-response-files-github remove-response-files-pagure remove-response-files-gitlab
 
 requre-purge-files:
-	pre-commit run --all-files requre-purge --verbose
+	pre-commit run --all-files requre-purge --verbose --hook-stage manual


### PR DESCRIPTION
Turn off requre clean up in pre-commit CI since it times out.

Signed-off-by: Matej Focko <mfocko@redhat.com>

not sure how much it changes running locally, I run manually and had to use `pre-commit run --hook-stage manual --all`

- [x] Check if is not skipped in zuul; gotta add `--hook-stage manual` to zuul too
- [x] What's wrong with the rebase??? (no network)
       There are no remotes in pre-commit CI?