### PR TITLE
Enable build and test for epel-8

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,21 +20,26 @@ actions:
 jobs:
   - job: sync_from_downstream
     trigger: commit
+
   - job: propose_downstream
     trigger: release
     metadata:
-      dist_git_branches: fedora-all
+      dist_git_branches:
+        - fedora-all
+        - epel-8
 
   - job: copr_build
     trigger: pull_request
     metadata:
       targets:
         - fedora-all
+        - epel-8
   - job: tests
     trigger: pull_request
     metadata:
       targets:
         - fedora-all
+        - epel-8
 
   - job: production_build
     trigger: pull_request


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1905223

Requires all the dependencies to be in epel-8 as well.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>