### PR TITLE
 Add and implement GitProject.default_branch property

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-BASE_IMAGE := registry.fedoraproject.org/fedora:30
 TEST_TARGET := ./tests/
 PY_PACKAGE := ogr
 OGR_IMAGE := ogr
@@ -30,13 +29,13 @@ check-pypi-packaging:
 		'
 
 remove-response-files-github:
-	rm -rf ./tests/integration/test_data/test_github*
+	rm -rf ./tests/integration/github/test_data/
 
 remove-response-files-pagure:
-	rm -rf ./tests/integration/test_data/test_pagure*
+	rm -rf ./tests/integration/pagure/test_data/
 
 remove-response-files-gitlab:
-	rm -rf ./tests/integration/test_data/test_gitlab*
+	rm -rf ./tests/integration/gitlab/test_data/
 
 remove-response-files: remove-response-files-github remove-response-files-pagure remove-response-files-gitlab
 

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -882,6 +882,11 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
+    @property
+    def default_branch(self) -> str:
+        """ Return default branch (usually 'main' or 'master'). """
+        raise NotImplementedError()
+
     def get_description(self) -> str:
         """
         Project description.
@@ -1398,22 +1403,22 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError
 
-    def get_file_content(self, path: str, ref: str = "master") -> str:
+    def get_file_content(self, path: str, ref: str = None) -> str:
         """
         Get a content of the file in the repo.
 
-        :param ref: branch or commit (defaults to master)
+        :param ref: branch or commit (defaults to repo's default branch)
         :param path: str
         :return: str or FileNotFoundError if there is no such file
         """
         raise NotImplementedError
 
     def get_files(
-        self, ref: str = "master", filter_regex: str = None, recursive: bool = False
+        self, ref: str = None, filter_regex: str = None, recursive: bool = False
     ) -> List[str]:
         """
         Get a list of file paths of the repo.
-        :param ref: branch or commit (defaults to master)
+        :param ref: branch or commit (defaults to repo's default branch)
         :param filter_regex: filter the paths with re.search
         :param recursive: whether to return only top directory files or all files recursively
         :return: [str]

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -160,6 +160,10 @@ class GithubProject(BaseGitProject):
             else None
         )
 
+    @property
+    def default_branch(self):
+        return self.github_repo.default_branch
+
     def get_branches(self) -> List[str]:
         return [branch.name for branch in self.github_repo.get_branches()]
 
@@ -421,7 +425,8 @@ class GithubProject(BaseGitProject):
     def change_token(self, new_token: str):
         raise NotImplementedError
 
-    def get_file_content(self, path: str, ref="master") -> str:
+    def get_file_content(self, path: str, ref=None) -> str:
+        ref = ref or self.default_branch
         try:
             return self.github_repo.get_contents(
                 path=path, ref=ref
@@ -430,15 +435,16 @@ class GithubProject(BaseGitProject):
             raise FileNotFoundError(f"File '{path}' on {ref} not found", ex)
 
     def get_files(
-        self, ref: str = "master", filter_regex: str = None, recursive: bool = False
+        self, ref: str = None, filter_regex: str = None, recursive: bool = False
     ) -> List[str]:
         """
         Get a list of file paths of the repo.
-        :param ref: branch or commit (defaults to master)
+        :param ref: branch or commit (defaults to repo's default branch)
         :param filter_regex: filter the paths with re.search
         :param recursive: whether to return only top directory files or all files recursively
         :return: [str]
         """
+        ref = ref or self.default_branch
         paths = []
         contents = self.github_repo.get_contents(path="", ref=ref)
 

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -178,6 +178,11 @@ class PagureProject(BaseGitProject):
         return_value = self._call_project_api("git", "branches", method="GET")
         return return_value["branches"]
 
+    @property
+    def default_branch(self) -> str:
+        return_value = self._call_project_api("git", "branches", method="GET")
+        return return_value["default"]
+
     def get_description(self) -> str:
         return self.get_project_info()["description"]
 
@@ -426,7 +431,8 @@ class PagureProject(BaseGitProject):
         """
         self.service.change_token(new_token)
 
-    def get_file_content(self, path: str, ref="master") -> str:
+    def get_file_content(self, path: str, ref=None) -> str:
+        ref = ref or self.default_branch
         try:
             result = self._call_project_api_raw(
                 "raw", ref, "f", path, add_api_endpoint_part=False

--- a/tests/integration/pagure/test_data/test_generic_commands/tests.integration.pagure.test_generic_commands.GenericCommands.test_get_file.yaml
+++ b/tests/integration/pagure/test_data/test_generic_commands/tests.integration.pagure.test_generic_commands.GenericCommands.test_get_file.yaml
@@ -5,9 +5,55 @@ _requre:
 requests.sessions:
   send:
     GET:
+      https://pagure.io/api/0/ogr-tests/git/branches:
+      - metadata:
+          latency: 0.2878444194793701
+          module_call_list:
+          - unittest.case
+          - requre.online_replacing
+          - tests.integration.pagure.test_generic_commands
+          - ogr.services.pagure.project
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            branches:
+            - master
+            - testPR
+            default: master
+            total_branches: 2
+          _next: null
+          elapsed: 0.2
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '100'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiN2RjNDI0NzQyMWFmZTY5NGNmMGZmMzRkZjJlYTU1ZDVhMDQ0ZDE5OCJ9.Er4kGQ.2WMJMZhj60eh7S_2GKP8UaLaUis;
+              Expires=Mon, 18-Jan-2021 11:29:29 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
       https://pagure.io/ogr-tests/raw/master/f/README.md:
       - metadata:
-          latency: 0.2514309883117676
+          latency: 0.24428677558898926
           module_call_list:
           - unittest.case
           - requre.online_replacing
@@ -31,23 +77,23 @@ requests.sessions:
             '
           _next: null
           elapsed: 0.2
-          encoding: ascii
+          encoding: utf-8
           headers:
             Connection: Keep-Alive
             Content-Length: '77'
             Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
               https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
               object-src 'none';base-uri 'self';img-src 'self' https:;
-            Content-Type: text/plain; charset=ascii
+            Content-Type: text/markdown; charset=utf-8
             Date: Fri, 01 Nov 2019 13-36-03 GMT
-            Keep-Alive: timeout=5, max=99
+            Keep-Alive: timeout=5, max=98
             Referrer-Policy: same-origin
-            Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_wsgi/3.4
-              Python/2.7.5
-            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWWpkaFlqZG1NREF6TlRreFlXRTRZelUxTmpkbE1XUm1NV0l5TjJKak9UUTRPVEJpWVRFM1pnPT0ifX0.Eikaew.kjs60VLNsX_isbzOY_jOGf77UIw;
-              Expires=Sun, 27-Sep-2020 10:20:43 GMT; Secure; HttpOnly; Path=/
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiN2RjNDI0NzQyMWFmZTY5NGNmMGZmMzRkZjJlYTU1ZDVhMDQ0ZDE5OCJ9.Er4kGQ.2WMJMZhj60eh7S_2GKP8UaLaUis;
+              Expires=Mon, 18-Jan-2021 11:29:29 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-            X-Content-Type-Options: nosniff
+            X-Content-Type-Options: nosniff, nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
             X-Xss-Protection: 1; mode=block
           raw: !!binary ""
@@ -56,7 +102,7 @@ requests.sessions:
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
-          latency: 0.8299000263214111
+          latency: 0.9431819915771484
           module_call_list:
           - unittest.case
           - requre.online_replacing
@@ -73,13 +119,13 @@ requests.sessions:
         output:
           __store_indicator: 2
           _content:
-            username: mfocko
+            username: jpopelka
           _next: null
           elapsed: 0.2
           encoding: null
           headers:
             Connection: Keep-Alive
-            Content-Length: '26'
+            Content-Length: '29'
             Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
               https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
               object-src 'none';base-uri 'self';img-src 'self' https:;
@@ -87,10 +133,10 @@ requests.sessions:
             Date: Fri, 01 Nov 2019 13-36-03 GMT
             Keep-Alive: timeout=5, max=100
             Referrer-Policy: same-origin
-            Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_wsgi/3.4
-              Python/2.7.5
-            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWWpkaFlqZG1NREF6TlRreFlXRTRZelUxTmpkbE1XUm1NV0l5TjJKak9UUTRPVEJpWVRFM1pnPT0ifX0.Eikaew.kjs60VLNsX_isbzOY_jOGf77UIw;
-              Expires=Sun, 27-Sep-2020 10:20:43 GMT; Secure; HttpOnly; Path=/
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiN2RjNDI0NzQyMWFmZTY5NGNmMGZmMzRkZjJlYTU1ZDVhMDQ0ZDE5OCJ9.Er4kGQ.2WMJMZhj60eh7S_2GKP8UaLaUis;
+              Expires=Mon, 18-Jan-2021 11:29:29 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/


### PR DESCRIPTION
All git forges support changing of a default branch of a repo/project.
All newly created Github projects have had 'main' as a default branch instead of 'master' since Oct 2020.

- https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/changing-the-default-branch
- https://docs.gitlab.com/ee/user/project/repository/branches/#default-branch
- https://pagure.io/api/0/#projects-tab (List git branches)