### PR TITLE
Add autogeneration of docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Deploy documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+      - name: Build and push docs
+        run: |
+          git config user.name Packit
+          git config user.email user-cont-team@redhat.com
+
+          python3 -m pip install --upgrade pip
+          python3 -m pip install setuptools
+          python3 -m pip install .
+          python3 -m pip install pdoc3 pygments
+
+          python3 -m pdoc --html -o built_docs ogr
+          mv built_docs/ogr docs
+          touch .nojekyll
+
+          COMMIT_SHA=$(git log -1 --format=%h)
+          git checkout --orphan gh-pages
+          git rm --cached '*'
+          git add docs .nojekyll
+
+          git commit -m "Update docs for $COMMIT_SHA"
+          git push --force origin gh-pages
+        shell: bash


### PR DESCRIPTION
# TODO

- [ ] decide between `pdoc` and `pdoc3` (they seem to be separate packages)
   oh, there's the tea https://github.com/mitmproxy/pdoc#pdoc-vs-pdoc3
- [ ] we currently use Sphinx markup that doesn't really work well with either of `pdoc`s
- [ ] since we use `__all__` it seems to be harder to navigate the docs

Signed-off-by: Matej Focko <mfocko@redhat.com>