### PR TITLE
[ci.fmf] remove old TF specific code

### DIFF
--- a/ci.fmf
+++ b/ci.fmf
@@ -12,4 +12,4 @@
       execute:
         how: shell
         script:
-        - cd ~/git-source || :; pwd && ls -lah && make check
+        - pwd; ls -lah; make check


### PR DESCRIPTION
This was amended in cf86074e to be compatible with both old/new TF, but can be removed completely now since the old TF no longer exists.