### PR TITLE
Implement retry mechanism for Github

### DIFF
--- a/ogr/services/github/auth_providers/token.py
+++ b/ogr/services/github/auth_providers/token.py
@@ -1,7 +1,8 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from typing import Optional
+from typing import Optional, Union
+from urllib3.util import Retry
 
 import github
 
@@ -9,9 +10,9 @@ from ogr.services.github.auth_providers.abstract import GithubAuthentication
 
 
 class TokenAuthentication(GithubAuthentication):
-    def __init__(self, token: str, **_) -> None:
+    def __init__(self, token: str, max_retries: Union[int, Retry]=0, **_) -> None:
         self._token = token
-        self._pygithub_instance = github.Github(login_or_token=token)
+        self._pygithub_instance = github.Github(login_or_token=token, retry=max_retries)
 
     def __eq__(self, o: object) -> bool:
         return issubclass(o.__class__, TokenAuthentication) and (
@@ -32,5 +33,7 @@ class TokenAuthentication(GithubAuthentication):
         return self._token
 
     @staticmethod
-    def try_create(token: str = None, **_) -> Optional["TokenAuthentication"]:
-        return TokenAuthentication(token)
+    def try_create(
+        token: str = None, max_retries: Union[int, Retry]=0, **_
+    ) -> Optional["TokenAuthentication"]:
+        return TokenAuthentication(token, max_retries=max_retries)

--- a/ogr/services/github/auth_providers/token.py
+++ b/ogr/services/github/auth_providers/token.py
@@ -10,7 +10,7 @@ from ogr.services.github.auth_providers.abstract import GithubAuthentication
 
 
 class TokenAuthentication(GithubAuthentication):
-    def __init__(self, token: str, max_retries: Union[int, Retry]=0, **_) -> None:
+    def __init__(self, token: str, max_retries: Union[int, Retry] = 0, **_) -> None:
         self._token = token
         self._pygithub_instance = github.Github(login_or_token=token, retry=max_retries)
 
@@ -34,6 +34,6 @@ class TokenAuthentication(GithubAuthentication):
 
     @staticmethod
     def try_create(
-        token: str = None, max_retries: Union[int, Retry]=0, **_
+        token: str = None, max_retries: Union[int, Retry] = 0, **_
     ) -> Optional["TokenAuthentication"]:
         return TokenAuthentication(token, max_retries=max_retries)

--- a/tests/integration/github/test_retries.py
+++ b/tests/integration/github/test_retries.py
@@ -1,0 +1,26 @@
+import pytest
+from ogr import GithubService
+import flexmock
+from urllib3.connectionpool import HTTPSConnectionPool
+from github.GithubException import BadCredentialsException
+from github import Github
+
+
+@pytest.mark.skip(reason="Will fail until flexmock is fixed")
+@pytest.mark.parametrize("max_retries", [0, 2])
+def test_bad_credentials(max_retries):
+
+    flexmock(HTTPSConnectionPool).should_call("urlopen").times(max_retries + 1)
+
+    flexmock(Github).should_call("get_repo").and_raise(
+        BadCredentialsException,
+        401,
+        {
+            "message": "Bad credentials",
+            "documentation_url": "https://docs.github.com/rest",
+        },
+    )
+
+    service = GithubService(token="invalid_token", max_retries=max_retries)
+    project = service.get_project(namespace="mmuzila", repo="playground")
+    project.github_repo


### PR DESCRIPTION
This update implements retry mechanism for Github requests.

Number of retry attempts can be set in `GithubService()` and  instances dictionary (used by `get_instances_from_dict()`), eg:
```
{                                                                   
    "github.com": {                                                 
                    "token": "abcd",                                            
                    "max_retries": "3", 
    }                                   
}   
``` 
This allows to enable request retries in packit/packit-service by adding  key `max_retries` to configuration (`authentication -> github -> max_retries`). I'm not sure If this is an acceptable solution, as far as it may be a bit confusing to set number of request retries not necessarily related to authentication in authentication section of config.


