### PR TITLE
Allow ignoring custom instances when creating a project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,16 @@ Running tests locally:
 make prepare-check && make check
 ```
 
+Or you can run them in a container:
+
+    make build
+    make check-in-container
+
+The above builds a local image with all the dependencies using
+[ansible-bender](https://github.com/ansible-community/ansible-bender), and
+runs the tests in a container created from that image. `TEST_TARGET` can be
+set to select a subset of the tests.
+
 As a CI we use [Zuul](https://softwarefactory-project.io/zuul/t/local/builds?project=packit-service/ogr) with a configuration in [.zuul.yaml](.zuul.yaml).
 If you want to re-run CI/tests in a pull request, just include `recheck` in a comment.
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BASE_IMAGE := fedora:latest
 TEST_TARGET := ./tests/
 PY_PACKAGE := ogr
 OGR_IMAGE := ogr
@@ -12,6 +13,9 @@ check:
 	@#`python3 -m pytest` doesn't work here b/c the way requre overrides import system:
 	@#`AttributeError: module 'importlib_metadata' has no attribute 'distributions'
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 pytest-3 --verbose --showlocals $(TEST_TARGET)
+
+check-in-container:
+	podman run --rm -it -v $(CURDIR):/src:Z -w /src $(OGR_IMAGE) pytest-3 $(TEST_TARGET)
 
 shell:
 	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(OGR_IMAGE) bash
@@ -41,3 +45,5 @@ remove-response-files: remove-response-files-github remove-response-files-pagure
 
 requre-purge-files:
 	pre-commit run --all-files requre-purge --verbose --hook-stage manual
+
+.PHONY: build

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -12,6 +12,8 @@
     - name: Install all packages needed to hack on ogr.
       dnf:
         name:
+          - make
+          - python3-flexmock
           - python3-pip
           - python3-setuptools
           - git-core
@@ -26,6 +28,12 @@
         name:
           - twine # we need newest twine, b/c of the check command
           - readme_renderer[md]
+        state: latest
+      become: true
+    - name: Install requre
+      pip:
+        name:
+          - git+https://github.com/packit/requre
         state: latest
       become: true
     - name: Install dependencies for git APIs

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -59,12 +59,13 @@ def test_get_service_class_not_found(url, mapping):
 
 
 @pytest.mark.parametrize(
-    "url,mapping,instances,result",
+    "url,mapping,instances,force_custom_instance,result",
     [
         (
             "https://github.com/packit-service/ogr",
             None,
             None,
+            True,
             GithubProject(
                 namespace="packit-service", repo="ogr", service=GithubService()
             ),
@@ -73,6 +74,7 @@ def test_get_service_class_not_found(url, mapping):
             "github.com/packit-service/ogr",
             None,
             None,
+            True,
             GithubProject(
                 namespace="packit-service", repo="ogr", service=GithubService()
             ),
@@ -81,6 +83,7 @@ def test_get_service_class_not_found(url, mapping):
             "git@github.com:packit-service/ogr.git",
             None,
             None,
+            True,
             GithubProject(
                 namespace="packit-service", repo="ogr", service=GithubService()
             ),
@@ -89,6 +92,7 @@ def test_get_service_class_not_found(url, mapping):
             "https://some-url/packit-service/ogr",
             {"some-url": GithubService},
             None,
+            True,
             GithubProject(
                 namespace="packit-service", repo="ogr", service=GithubService()
             ),
@@ -97,6 +101,7 @@ def test_get_service_class_not_found(url, mapping):
             "https://github.com/packit-service/ogr",
             {"github.com": PagureService},
             None,
+            True,
             PagureProject(
                 namespace="packit-service",
                 repo="ogr",
@@ -107,6 +112,7 @@ def test_get_service_class_not_found(url, mapping):
             "https://src.fedoraproject.org/rpms/python-ogr",
             None,
             None,
+            True,
             PagureProject(
                 namespace="rpms",
                 repo="python-ogr",
@@ -117,6 +123,7 @@ def test_get_service_class_not_found(url, mapping):
             "https://pagure.io/ogr",
             None,
             None,
+            True,
             PagureProject(
                 repo="ogr",
                 namespace=None,
@@ -133,6 +140,7 @@ def test_get_service_class_not_found(url, mapping):
                     get_project_from_url=lambda url: "project",
                 )
             ],
+            True,
             "project",
         ),
         (
@@ -150,12 +158,14 @@ def test_get_service_class_not_found(url, mapping):
                     get_project_from_url=lambda url: "right-project",
                 ),
             ],
+            True,
             "right-project",
         ),
         (
             "https://gitlab.gnome.org/lbarcziova/testing-ogr-repo",
             None,
             None,
+            True,
             GitlabProject(
                 repo="testing-ogr-repo",
                 namespace="lbarcziova",
@@ -166,6 +176,7 @@ def test_get_service_class_not_found(url, mapping):
             "https://src.stg.fedoraproject.org/rpms/python-dockerpty.git",
             None,
             [PagureService(instance_url="https://src.stg.fedoraproject.org")],
+            True,
             PagureProject(
                 repo="python-dockerpty",
                 namespace="rpms",
@@ -179,17 +190,34 @@ def test_get_service_class_not_found(url, mapping):
                 PagureService(instance_url="https://src.stg.fedoraproject.org"),
                 PagureService(instance_url="https://src.fedoraproject.org"),
             ],
+            False,
             PagureProject(
                 repo="python-dockerpty",
                 namespace="rpms",
                 service=PagureService(instance_url="https://src.fedoraproject.org"),
             ),
         ),
+        (
+            "https://github.com/packit/ogr",
+            None,
+            [
+                PagureService(instance_url="https://src.fedoraproject.org"),
+            ],
+            False,
+            GithubProject(
+                repo="ogr",
+                namespace="packit",
+                service=GithubService(instance_url="https://github.com/packit/ogr"),
+            ),
+        ),
     ],
 )
-def test_get_project(url, mapping, instances, result):
+def test_get_project(url, mapping, instances, force_custom_instance, result):
     project = get_project(
-        url=url, service_mapping_update=mapping, custom_instances=instances
+        url=url,
+        service_mapping_update=mapping,
+        custom_instances=instances,
+        force_custom_instance=force_custom_instance,
     )
     assert project == result
 


### PR DESCRIPTION
The current behaviour of 'ogr.get_project()', when a list of
'custom_instances' (already created GitService objects) is provided, is
to raise an OgrException if none of these matches the project URL.

Introduce a 'force_custom_instance' flag, defaulting to True to keep
backwards compatibility, in order to support the use case where the user
would like to retrieve an existing service *or create a new one* if none
is matching in the 'custom_instances' list.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>