### PR TITLE
packit: create downstream %changelog from git-log

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,7 +8,7 @@ upstream_project_url: https://github.com/packit/ogr
 # we are setting this so we can use packit from ogr's dist-git
 # packit can't know what's the upstream name when running from distgit
 upstream_package_name: ogr
-copy_upstream_release_description: true
+copy_upstream_release_description: false
 actions:
   # we need this b/c `git archive` doesn't put all the metadata in the tarball:
   #   LookupError: setuptools-scm was unable to detect version for '/builddir/build/BUILD/ogr-0.11.1'.


### PR DESCRIPTION
Hunor is correct, our upstream release description used as a %changelog
violates Fedora guidelines, so let packit assemble %changelog from
git-log.

https://docs.fedoraproject.org/en-US/packaging-guidelines/#changelogs

https://packit.dev/docs/configuration/#copy_upstream_release_description