### PR TITLE
pagure: enable creating PRs from fork via fork_username

### DIFF
--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -272,6 +272,7 @@ class PagureProject(BaseGitProject):
             body=body,
             target_branch=target_branch,
             source_branch=source_branch,
+            fork_username=fork_username,
         )
 
     @if_readonly(return_function=GitProjectReadOnly.fork_create)

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -175,6 +175,16 @@ class PagurePullRequest(BasePullRequest):
 
             # running the call from the parent project
             caller = caller.parent
+        elif fork_username:
+            fork_project = project.service.get_project(
+                username=fork_username,
+                repo=project.repo,
+                namespace=project.namespace,
+                is_fork=True,
+            )
+            data["repo_from_username"] = fork_username
+            data["repo_from"] = fork_project.repo
+            data["repo_from_namespace"] = fork_project.namespace
 
         response = caller._call_project_api(
             "pull-request", "new", method="POST", data=data

--- a/tests/integration/pagure/test_data/test_pull_requests/tests.integration.pagure.test_pull_requests.PullRequests.test_pr_create_from_fork.yaml
+++ b/tests/integration/pagure/test_data/test_pull_requests/tests.integration.pagure.test_pull_requests.PullRequests.test_pr_create_from_fork.yaml
@@ -1,13 +1,13 @@
 _requre:
   DataTypes: 1
   key_strategy: StorageKeysInspectSimple
-  version_storage_file: 2
+  version_storage_file: 3
 requests.sessions:
   send:
     GET:
-      https://pagure.io/api/0/fork/mfocko/ogr-tests:
+      https://pagure.io/api/0/fork/ttomecek/ogr-tests:
       - metadata:
-          latency: 0.35820817947387695
+          latency: 0.32079267501831055
           module_call_list:
           - unittest.case
           - requre.online_replacing
@@ -35,15 +35,16 @@ requests.sessions:
               collaborator: []
               commit: []
               owner:
-              - mfocko
+              - ttomecek
               ticket: []
             close_status: []
             custom_keys: []
-            date_created: '1570604926'
-            date_modified: '1570604926'
+            date_created: '1578319442'
+            date_modified: '1578319442'
             description: Testing repository for python-ogr package.
-            fullname: forks/mfocko/ogr-tests
-            id: 6828
+            full_url: https://pagure.io/fork/ttomecek/ogr-tests
+            fullname: forks/ttomecek/ogr-tests
+            id: 7254
             milestones: {}
             name: ogr-tests
             namespace: null
@@ -68,6 +69,7 @@ requests.sessions:
               date_created: '1570568389'
               date_modified: '1570568529'
               description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/ogr-tests
               fullname: ogr-tests
               id: 6826
               milestones: {}
@@ -78,22 +80,24 @@ requests.sessions:
               tags: []
               url_path: ogr-tests
               user:
+                full_url: https://pagure.io/user/lachmanfrantisek
                 fullname: "Franti\u0161ek Lachman"
                 name: lachmanfrantisek
                 url_path: user/lachmanfrantisek
             priorities: {}
             tags: []
-            url_path: fork/mfocko/ogr-tests
+            url_path: fork/ttomecek/ogr-tests
             user:
-              fullname: Matej Focko
-              name: mfocko
-              url_path: user/mfocko
+              full_url: https://pagure.io/user/ttomecek
+              fullname: Tomas Tomecek
+              name: ttomecek
+              url_path: user/ttomecek
           _next: null
           elapsed: 0.2
           encoding: null
           headers:
             Connection: Keep-Alive
-            Content-Length: '1589'
+            Content-Length: '1876'
             Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
               https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
               object-src 'none';base-uri 'self';img-src 'self' https:;
@@ -101,10 +105,8 @@ requests.sessions:
             Date: Fri, 01 Nov 2019 13-36-03 GMT
             Keep-Alive: timeout=5, max=99
             Referrer-Policy: same-origin
-            Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_wsgi/3.4
-              Python/2.7.5
-            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWW1FM056ZzBaV1UwTmpsa01tVmxORE0xTldWa056UmxNREF5WldJeFpUTmlOMk15TkRoak9RPT0ifX0.Eikb9Q.V3gQCVMyRYCR_aNn7oMSkjgGJLo;
-              Expires=Sun, 27-Sep-2020 10:27:01 GMT; Secure; HttpOnly; Path=/
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -113,7 +115,7 @@ requests.sessions:
           reason: OK
           status_code: 200
       - metadata:
-          latency: 0.27968931198120117
+          latency: 0.3482825756072998
           module_call_list:
           - unittest.case
           - requre.online_replacing
@@ -141,15 +143,16 @@ requests.sessions:
               collaborator: []
               commit: []
               owner:
-              - mfocko
+              - ttomecek
               ticket: []
             close_status: []
             custom_keys: []
-            date_created: '1570604926'
-            date_modified: '1570604926'
+            date_created: '1578319442'
+            date_modified: '1578319442'
             description: Testing repository for python-ogr package.
-            fullname: forks/mfocko/ogr-tests
-            id: 6828
+            full_url: https://pagure.io/fork/ttomecek/ogr-tests
+            fullname: forks/ttomecek/ogr-tests
+            id: 7254
             milestones: {}
             name: ogr-tests
             namespace: null
@@ -174,6 +177,7 @@ requests.sessions:
               date_created: '1570568389'
               date_modified: '1570568529'
               description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/ogr-tests
               fullname: ogr-tests
               id: 6826
               milestones: {}
@@ -184,22 +188,24 @@ requests.sessions:
               tags: []
               url_path: ogr-tests
               user:
+                full_url: https://pagure.io/user/lachmanfrantisek
                 fullname: "Franti\u0161ek Lachman"
                 name: lachmanfrantisek
                 url_path: user/lachmanfrantisek
             priorities: {}
             tags: []
-            url_path: fork/mfocko/ogr-tests
+            url_path: fork/ttomecek/ogr-tests
             user:
-              fullname: Matej Focko
-              name: mfocko
-              url_path: user/mfocko
+              full_url: https://pagure.io/user/ttomecek
+              fullname: Tomas Tomecek
+              name: ttomecek
+              url_path: user/ttomecek
           _next: null
           elapsed: 0.2
           encoding: null
           headers:
             Connection: Keep-Alive
-            Content-Length: '1589'
+            Content-Length: '1876'
             Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
               https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
               object-src 'none';base-uri 'self';img-src 'self' https:;
@@ -207,10 +213,8 @@ requests.sessions:
             Date: Fri, 01 Nov 2019 13-36-03 GMT
             Keep-Alive: timeout=5, max=98
             Referrer-Policy: same-origin
-            Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_wsgi/3.4
-              Python/2.7.5
-            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWW1FM056ZzBaV1UwTmpsa01tVmxORE0xTldWa056UmxNREF5WldJeFpUTmlOMk15TkRoak9RPT0ifX0.Eikb9Q.V3gQCVMyRYCR_aNn7oMSkjgGJLo;
-              Expires=Sun, 27-Sep-2020 10:27:01 GMT; Secure; HttpOnly; Path=/
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -221,7 +225,7 @@ requests.sessions:
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
-          latency: 0.924203634262085
+          latency: 0.6586136817932129
           module_call_list:
           - unittest.case
           - requre.online_replacing
@@ -237,13 +241,13 @@ requests.sessions:
         output:
           __store_indicator: 2
           _content:
-            username: mfocko
+            username: ttomecek
           _next: null
           elapsed: 0.2
           encoding: null
           headers:
             Connection: Keep-Alive
-            Content-Length: '26'
+            Content-Length: '29'
             Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
               https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
               object-src 'none';base-uri 'self';img-src 'self' https:;
@@ -251,10 +255,8 @@ requests.sessions:
             Date: Fri, 01 Nov 2019 13-36-03 GMT
             Keep-Alive: timeout=5, max=100
             Referrer-Policy: same-origin
-            Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_wsgi/3.4
-              Python/2.7.5
-            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWW1FM056ZzBaV1UwTmpsa01tVmxORE0xTldWa056UmxNREF5WldJeFpUTmlOMk15TkRoak9RPT0ifX0.Eikb9Q.V3gQCVMyRYCR_aNn7oMSkjgGJLo;
-              Expires=Sun, 27-Sep-2020 10:27:01 GMT; Secure; HttpOnly; Path=/
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -264,7 +266,7 @@ requests.sessions:
           status_code: 200
       https://pagure.io/api/0/ogr-tests/pull-request/new:
       - metadata:
-          latency: 1.2303879261016846
+          latency: 0.6659791469573975
           module_call_list:
           - unittest.case
           - requre.online_replacing
@@ -291,10 +293,11 @@ requests.sessions:
             comments: []
             commit_start: null
             commit_stop: null
-            date_created: '1598524022'
-            id: 10
+            date_created: '1615384140'
+            full_url: https://pagure.io/ogr-tests/pull-request/12
+            id: 12
             initial_comment: Body of the testing PR.
-            last_updated: '1598524022'
+            last_updated: '1615384140'
             project:
               access_groups:
                 admin: []
@@ -316,6 +319,7 @@ requests.sessions:
               date_created: '1570568389'
               date_modified: '1570568529'
               description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/ogr-tests
               fullname: ogr-tests
               id: 6826
               milestones: {}
@@ -326,6 +330,7 @@ requests.sessions:
               tags: []
               url_path: ogr-tests
               user:
+                full_url: https://pagure.io/user/lachmanfrantisek
                 fullname: "Franti\u0161ek Lachman"
                 name: lachmanfrantisek
                 url_path: user/lachmanfrantisek
@@ -341,15 +346,16 @@ requests.sessions:
                 collaborator: []
                 commit: []
                 owner:
-                - mfocko
+                - ttomecek
                 ticket: []
               close_status: []
               custom_keys: []
-              date_created: '1570604926'
-              date_modified: '1570604926'
+              date_created: '1578319442'
+              date_modified: '1578319442'
               description: Testing repository for python-ogr package.
-              fullname: forks/mfocko/ogr-tests
-              id: 6828
+              full_url: https://pagure.io/fork/ttomecek/ogr-tests
+              fullname: forks/ttomecek/ogr-tests
+              id: 7254
               milestones: {}
               name: ogr-tests
               namespace: null
@@ -374,6 +380,7 @@ requests.sessions:
                 date_created: '1570568389'
                 date_modified: '1570568529'
                 description: Testing repository for python-ogr package.
+                full_url: https://pagure.io/ogr-tests
                 fullname: ogr-tests
                 id: 6826
                 milestones: {}
@@ -384,32 +391,35 @@ requests.sessions:
                 tags: []
                 url_path: ogr-tests
                 user:
+                  full_url: https://pagure.io/user/lachmanfrantisek
                   fullname: "Franti\u0161ek Lachman"
                   name: lachmanfrantisek
                   url_path: user/lachmanfrantisek
               priorities: {}
               tags: []
-              url_path: fork/mfocko/ogr-tests
+              url_path: fork/ttomecek/ogr-tests
               user:
-                fullname: Matej Focko
-                name: mfocko
-                url_path: user/mfocko
+                full_url: https://pagure.io/user/ttomecek
+                fullname: Tomas Tomecek
+                name: ttomecek
+                url_path: user/ttomecek
             status: Open
             tags: []
             threshold_reached: null
             title: Testing PR
-            uid: 4cd4de66a24f46d8948f738b42ae0274
-            updated_on: '1598524022'
+            uid: 69ac8585242a44cdac9e200cada7e9c3
+            updated_on: '1615384140'
             user:
-              fullname: Matej Focko
-              name: mfocko
-              url_path: user/mfocko
+              full_url: https://pagure.io/user/ttomecek
+              fullname: Tomas Tomecek
+              name: ttomecek
+              url_path: user/ttomecek
           _next: null
           elapsed: 0.2
           encoding: null
           headers:
             Connection: Keep-Alive
-            Content-Length: '3263'
+            Content-Length: '3839'
             Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
               https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
               object-src 'none';base-uri 'self';img-src 'self' https:;
@@ -417,10 +427,8 @@ requests.sessions:
             Date: Fri, 01 Nov 2019 13-36-03 GMT
             Keep-Alive: timeout=5, max=97
             Referrer-Policy: same-origin
-            Server: Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_wsgi/3.4
-              Python/2.7.5
-            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWW1FM056ZzBaV1UwTmpsa01tVmxORE0xTldWa056UmxNREF5WldJeFpUTmlOMk15TkRoak9RPT0ifX0.Eikb9w.ms8j2fcVvobpjvDwqQVmwdXQigo;
-              Expires=Sun, 27-Sep-2020 10:27:03 GMT; Secure; HttpOnly; Path=/
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_pull_requests/tests.integration.pagure.test_pull_requests.PullRequests.test_pr_create_from_parent.yaml
+++ b/tests/integration/pagure/test_data/test_pull_requests/tests.integration.pagure.test_pull_requests.PullRequests.test_pr_create_from_parent.yaml
@@ -1,0 +1,261 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    POST:
+      https://pagure.io/api/0/-/whoami:
+      - metadata:
+          latency: 0.5244512557983398
+          module_call_list:
+          - unittest.case
+          - requre.online_replacing
+          - tests.integration.pagure.test_pull_requests
+          - tests.integration.pagure.base
+          - ogr.services.pagure.service
+          - ogr.services.pagure.user
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: ttomecek
+          _next: null
+          elapsed: 0.2
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '29'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.37340331077575684
+          module_call_list:
+          - unittest.case
+          - requre.online_replacing
+          - tests.integration.pagure.test_pull_requests
+          - tests.integration.pagure.base
+          - ogr.services.pagure.user
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: ttomecek
+          _next: null
+          elapsed: 0.2
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '29'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://pagure.io/api/0/ogr-tests/pull-request/new:
+      - metadata:
+          latency: 11.622873306274414
+          module_call_list:
+          - unittest.case
+          - requre.online_replacing
+          - tests.integration.pagure.test_pull_requests
+          - ogr.read_only
+          - ogr.services.pagure.project
+          - ogr.services.pagure.pull_request
+          - ogr.services.pagure.project
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            assignee: null
+            branch: master
+            branch_from: master
+            cached_merge_status: unknown
+            closed_at: null
+            closed_by: null
+            comments: []
+            commit_start: null
+            commit_stop: null
+            date_created: '1615384127'
+            full_url: https://pagure.io/ogr-tests/pull-request/11
+            id: 11
+            initial_comment: Body of the testing PR.
+            last_updated: '1615384127'
+            project:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin:
+                - jscotka
+                - lbarczio
+                - mfocko
+                collaborator: []
+                commit: []
+                owner:
+                - lachmanfrantisek
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1570568389'
+              date_modified: '1570568529'
+              description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/ogr-tests
+              fullname: ogr-tests
+              id: 6826
+              milestones: {}
+              name: ogr-tests
+              namespace: null
+              parent: null
+              priorities: {}
+              tags: []
+              url_path: ogr-tests
+              user:
+                full_url: https://pagure.io/user/lachmanfrantisek
+                fullname: "Franti\u0161ek Lachman"
+                name: lachmanfrantisek
+                url_path: user/lachmanfrantisek
+            remote_git: null
+            repo_from:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin: []
+                collaborator: []
+                commit: []
+                owner:
+                - ttomecek
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1578319442'
+              date_modified: '1578319442'
+              description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/fork/ttomecek/ogr-tests
+              fullname: forks/ttomecek/ogr-tests
+              id: 7254
+              milestones: {}
+              name: ogr-tests
+              namespace: null
+              parent:
+                access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin:
+                  - jscotka
+                  - lbarczio
+                  - mfocko
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - lachmanfrantisek
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1570568389'
+                date_modified: '1570568529'
+                description: Testing repository for python-ogr package.
+                full_url: https://pagure.io/ogr-tests
+                fullname: ogr-tests
+                id: 6826
+                milestones: {}
+                name: ogr-tests
+                namespace: null
+                parent: null
+                priorities: {}
+                tags: []
+                url_path: ogr-tests
+                user:
+                  full_url: https://pagure.io/user/lachmanfrantisek
+                  fullname: "Franti\u0161ek Lachman"
+                  name: lachmanfrantisek
+                  url_path: user/lachmanfrantisek
+              priorities: {}
+              tags: []
+              url_path: fork/ttomecek/ogr-tests
+              user:
+                full_url: https://pagure.io/user/ttomecek
+                fullname: Tomas Tomecek
+                name: ttomecek
+                url_path: user/ttomecek
+            status: Open
+            tags: []
+            threshold_reached: null
+            title: Testing PR 2
+            uid: b3b3060cd5e24327a606a365ca6d7f57
+            updated_on: '1615384127'
+            user:
+              full_url: https://pagure.io/user/ttomecek
+              fullname: Tomas Tomecek
+              name: ttomecek
+              url_path: user/ttomecek
+          _next: null
+          elapsed: 0.2
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '3841'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=98
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/pagure/test_pull_requests.py
+++ b/tests/integration/pagure/test_pull_requests.py
@@ -6,7 +6,7 @@ from ogr.abstract import PRStatus, CommitStatus
 
 @record_requests_for_all_methods()
 class PullRequests(PagureTests):
-    def test_pr_create(self):
+    def test_pr_create_from_fork(self):
         pr = self.ogr_fork.create_pr(
             title="Testing PR",
             body="Body of the testing PR.",
@@ -14,6 +14,20 @@ class PullRequests(PagureTests):
             source_branch="master",
         )
         assert pr.title == "Testing PR"
+        assert pr.description == "Body of the testing PR."
+        assert pr.target_branch == "master"
+        assert pr.source_branch == "master"
+        assert pr.status == PRStatus.open
+
+    def test_pr_create_from_parent(self):
+        pr = self.ogr_project.create_pr(
+            title="Testing PR 2",
+            body="Body of the testing PR.",
+            target_branch="master",
+            source_branch="master",
+            fork_username=self.user,
+        )
+        assert pr.title == "Testing PR 2"
         assert pr.description == "Body of the testing PR."
         assert pr.target_branch == "master"
         assert pr.source_branch == "master"


### PR DESCRIPTION
PagureProject.create_pr dumped fork_username which made PR creation from
a fork by passing this kwarg not working - one had to create the PR from
an actual fork instance instead of making it the parent repo.

This commit:
* makes sure the fork_username is passed to PagurePullRequest.create
* and also sets correct `repo_from[*]` keys for the API request to
  create a PR

Worked for: https://src.fedoraproject.org/rpms/packit/pull-request/125
And also this PR -_-

Fixes #551

~~Please let me know what tests I should write.~~

* [x] Wrote a test case for this.
