### PR TITLE
Export types in the package (PEP-561)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,9 @@ setup_requires =
 testing =
     pytest
 
+[options.package_data]
+* = py.typed
+
 [options.packages.find]
 exclude =
     tests*


### PR DESCRIPTION
This is the fix for [issue #559](https://github.com/packit/ogr/issues/559)

The file py.typed need to be added at the root of the ogr package for
the package to be PEP-561 compliant and have mypy be able to use the
type information when importing the package in other projects.