### PR TITLE
Unify behaviour for get_file_content for GitHub

### DIFF
--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -56,9 +56,5 @@ class GitlabAPIException(OgrException):
         self.gitlab_error = gitlab_error
 
 
-class OurPagureRawRequest(OgrException):
-    """ Mocking Exceptions for pagure raw request """
-
-
 class OperationNotSupported(OgrException):
     """ Raise when the operation is not supported by the backend. """

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -441,8 +441,10 @@ class GithubProject(BaseGitProject):
             return self.github_repo.get_contents(
                 path=path, ref=ref
             ).decoded_content.decode()
-        except UnknownObjectException as ex:
-            raise FileNotFoundError(f"File '{path}' on {ref} not found", ex)
+        except (UnknownObjectException, GithubException) as ex:
+            if ex.status == 404:
+                raise FileNotFoundError(f"File '{path}' on {ref} not found", ex)
+            raise GithubAPIException(ex)
 
     def get_files(
         self, ref: str = None, filter_regex: str = None, recursive: bool = False

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -389,7 +389,9 @@ class GitlabProject(BaseGitProject):
             file = self.gitlab_repo.files.get(file_path=path, ref=ref)
             return file.decode().decode()
         except gitlab.exceptions.GitlabGetError as ex:
-            raise FileNotFoundError(f"File '{path}' on {ref} not found", ex)
+            if ex.response_code == 404:
+                raise FileNotFoundError(f"File '{path}' on {ref} not found", ex)
+            raise GitlabAPIException(ex)
 
     def get_files(
         self, ref: str = None, filter_regex: str = None, recursive: bool = False

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -37,7 +37,6 @@ from ogr.abstract import (
     AccessLevel,
 )
 from ogr.exceptions import (
-    OurPagureRawRequest,
     PagureAPIException,
     OgrException,
     OperationNotSupported,
@@ -441,7 +440,7 @@ class PagureProject(BaseGitProject):
             if not result or result.reason == "NOT FOUND":
                 raise FileNotFoundError(f"File '{path}' on {ref} not found")
             return result.content.decode()
-        except OurPagureRawRequest as ex:
+        except PagureAPIException as ex:
             raise FileNotFoundError(f"Problem with getting file '{path}' on {ref}", ex)
 
     def get_sha_from_tag(self, tag_name: str) -> str:

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -433,15 +433,13 @@ class PagureProject(BaseGitProject):
 
     def get_file_content(self, path: str, ref=None) -> str:
         ref = ref or self.default_branch
-        try:
-            result = self._call_project_api_raw(
-                "raw", ref, "f", path, add_api_endpoint_part=False
-            )
-            if not result or result.reason == "NOT FOUND":
-                raise FileNotFoundError(f"File '{path}' on {ref} not found")
-            return result.content.decode()
-        except PagureAPIException as ex:
-            raise FileNotFoundError(f"Problem with getting file '{path}' on {ref}", ex)
+        result = self._call_project_api_raw(
+            "raw", ref, "f", path, add_api_endpoint_part=False
+        )
+
+        if not result or result.reason == "NOT FOUND":
+            raise FileNotFoundError(f"File '{path}' on {ref} not found")
+        return result.content.decode()
 
     def get_sha_from_tag(self, tag_name: str) -> str:
         tags_dict = self.get_tags_dict()


### PR DESCRIPTION
Catch `GithubException` in GithubProject.get_file_content as we do
for GitLab and Pagure to:
a) unify the behaviour
b) ignore unwanted 404 related to:
       https://sentry.io/organizations/red-hat-0p/issues/1809076278

Signed-off-by: Matej Focko <mfocko@redhat.com>