### PR TITLE
ignored kwargs: set log to debug and only log if set

### DIFF
--- a/ogr/services/github/service.py
+++ b/ogr/services/github/service.py
@@ -99,7 +99,8 @@ class GithubService(BaseGitService):
                 max_retries=self._max_retries,
             )
 
-        logger.warning(f"Ignored keyword arguments: {kwargs}")
+        if kwargs:
+            logger.warning(f"Ignored keyword arguments: {kwargs}")
 
     def __set_authentication(self, **kwargs):
         auth_methods = [

--- a/ogr/services/gitlab/service.py
+++ b/ogr/services/gitlab/service.py
@@ -45,7 +45,8 @@ class GitlabService(BaseGitService):
         self.ssl_verify = ssl_verify
         self._gitlab_instance = None
 
-        logger.warning(f"Ignored keyword arguments: {kwargs}")
+        if kwargs:
+            logger.warning(f"Ignored keyword arguments: {kwargs}")
 
     @property
     def gitlab_instance(self) -> gitlab.Gitlab:

--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -67,7 +67,8 @@ class PagureService(BaseGitService):
 
         self.header = {"Authorization": "token " + self._token} if self._token else {}
 
-        logger.warning(f"Ignored keyword arguments: {kwargs}")
+        if kwargs:
+            logger.warning(f"Ignored keyword arguments: {kwargs}")
 
     def __str__(self) -> str:
         token_str = (


### PR DESCRIPTION
I'm tired of

    Ignored keyword arguments: {}

and since this change was requested by me, finally decided to improve
the behavior:

1. log only when some kwargs are set

2. set log to debug