### PR TITLE
Set project_dir when zuul is not defined

### DIFF
--- a/files/tasks/project-dir.yaml
+++ b/files/tasks/project-dir.yaml
@@ -1,0 +1,17 @@
+---
+- set_fact:
+    project_dir: "{{ playbook_dir }}/.."
+  when: zuul is not defined
+- set_fact:
+    project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+  when: zuul is defined
+- name: stat {{ project_dir }}
+  stat:
+    path: "{{ project_dir }}"
+  tags:
+    - no-cache
+  register: src_path
+- name: Make sure {{ project_dir }} is present
+  assert:
+    that:
+      - src_path.stat.isdir

--- a/files/zuul-install-requirements-rpms.yaml
+++ b/files/zuul-install-requirements-rpms.yaml
@@ -2,8 +2,7 @@
 - name: Install RPM dependencies for ogr
   hosts: all
   tasks:
-    - set_fact:
-        project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+    - include_tasks: tasks/project-dir.yaml
     - include_tasks: tasks/generic-dnf-requirements.yaml
     - include_tasks: tasks/build-rpm-deps.yaml
     - name: Install deps as RPMs

--- a/files/zuul-reverse-dep-packit.yaml
+++ b/files/zuul-reverse-dep-packit.yaml
@@ -4,8 +4,7 @@
   tasks:
     - set_fact:
         reverse_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/packit/packit'].src_dir }}"
-    - set_fact:
-        project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+    - include_tasks: tasks/project-dir.yaml
     - include_tasks: tasks/generic-dnf-requirements.yaml
     - include_tasks: tasks/rpm-test-deps.yaml
     - include_tasks: tasks/packit-requirements.yaml

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -2,8 +2,7 @@
 - name: This is a recipe for how to run ogr tests
   hosts: all
   tasks:
-    - set_fact:
-        project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
+    - include_tasks: tasks/project-dir.yaml
     - include_tasks: tasks/rpm-test-deps.yaml
     - include_tasks: tasks/install-ogr.yaml
     - include_tasks: tasks/configure-git.yaml

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -50,10 +50,10 @@
       tags:
         - no-cache
       register: src_path
-    - name: Let's make sure {{ project_dir }} is present
+    - name: Make sure {{ project_dir }} is present
       assert:
         that:
-          - "src_path.stat.isdir"
+          - src_path.stat.isdir
     # this requires to have sources mounted inside at /src
     - name: Install ogr from {{ project_dir }}
       pip:


### PR DESCRIPTION
This is supposed to fix `requre-reverse-dep-ogr-tests` in requre where we run the ogr tests via ansible-playbook which, I think, creates new environment, where `zuul` variable is not defined.

https://softwarefactory-project.io/zuul/t/packit-service/build/baa15a374a384e759a74a9cf655e80e8