### PR TITLE
TF: check specfile with rpmlint

### DIFF
--- a/plans/linters.fmf
+++ b/plans/linters.fmf
@@ -1,0 +1,10 @@
+summary:
+  Run linters on source code and packaging files
+prepare:
+  - name: packages
+    how: install
+    package:
+    - rpmlint
+execute:
+  script:
+  - rpmlint fedora/python-ogr.spec


### PR DESCRIPTION
related: https://github.com/packit/packit.dev/issues/259

rpmlint is being executed in Fedora anyway so running it sooner in
upstream will prevent "breakages" during releases