### PR TITLE
Add pkgs.[stg.]fedoraproject.org to the list of hosts PagureService is used for

### DIFF
--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -38,8 +38,11 @@ logger = logging.getLogger(__name__)
 
 @use_for_service("pagure")
 @use_for_service("src.fedoraproject.org")
-@use_for_service("git.stg.centos.org")
+@use_for_service("src.stg.fedoraproject.org")
+@use_for_service("pkgs.fedoraproject.org")
+@use_for_service("pkgs.stg.fedoraproject.org")
 @use_for_service("git.centos.org")
+@use_for_service("git.stg.centos.org")
 class PagureService(BaseGitService):
     def __init__(
         self,


### PR DESCRIPTION
When I `fedpkg[-stage] clone a-package` its remote is `pkgs.[stg.]fedoraproject.org`.