### PR TITLE
Makefile: pass TEST_TARGET into check-in-container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check:
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 pytest --verbose --showlocals $(TEST_TARGET)
 
 check-in-container:
-	podman run --rm -it -v $(CURDIR):/src:Z -w /src $(OGR_IMAGE) make -e GITHUB_TOKEN=$(GITHUB_TOKEN) GITLAB_TOKEN=$(GITLAB_TOKEN) check
+	podman run --rm -it -v $(CURDIR):/src:Z -w /src --env TEST_TARGET $(OGR_IMAGE) make -e GITHUB_TOKEN=$(GITHUB_TOKEN) GITLAB_TOKEN=$(GITLAB_TOKEN) check
 
 shell:
 	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(OGR_IMAGE) bash


### PR DESCRIPTION
`TEST_TARGET=tests/integration/gitlab/test_forks.py make check-in-container` didn't work for me without it.