### PR TITLE
Get PR and Issue comment by its ID

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -34,6 +34,7 @@ In case you find any error, please [create a new issue](https://github.com/packi
 | `add_label`       |   ✔    |   ✔    |   ✘    |
 | `get_all_commits` |   ✔    |   ✔    |   ✘    |
 | `labels`          |   ✔    |   ✔    |   ✘    |
+| `get_comment`     |   ✔    |   ✔    |   ✘    |
 
 ## Release
 

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -337,6 +337,18 @@ class Issue(OgrAbstractClass):
         """
         raise NotImplementedError()
 
+    def get_comment(self, comment_id: int) -> IssueComment:
+        """
+        Returns an issue comment.
+
+        Args:
+            comment_id: id of a comment
+
+        Returns:
+            Object representing an issue comment.
+        """
+        raise NotImplementedError()
+
 
 class PRStatus(IntEnum):
     open = 1
@@ -639,6 +651,18 @@ class PullRequest(OgrAbstractClass):
         Returns statuses for latest commit on pull request.
 
         :return: [CommitFlag]
+        """
+        raise NotImplementedError()
+
+    def get_comment(self, comment_id: int) -> PRComment:
+        """
+        Returns a PR comment.
+
+        Args:
+            comment_id: id of comment
+
+        Returns:
+            Object representing a PR comment.
         """
         raise NotImplementedError()
 

--- a/ogr/services/github/issue.py
+++ b/ogr/services/github/issue.py
@@ -167,3 +167,6 @@ class GithubIssue(BaseIssue):
 
     def add_assignee(self, *assignees: str) -> None:
         self._raw_issue.edit(assignees=list(assignees))
+
+    def get_comment(self, comment_id: int) -> IssueComment:
+        return GithubIssueComment(self._raw_issue.get_comment(comment_id))

--- a/ogr/services/github/pull_request.py
+++ b/ogr/services/github/pull_request.py
@@ -260,3 +260,6 @@ class GithubPullRequest(BasePullRequest):
     def add_label(self, *labels: str) -> None:
         for label in labels:
             self._raw_pr.add_to_labels(label)
+
+    def get_comment(self, comment_id: int) -> PRComment:
+        return GithubPRComment(self._raw_pr.get_issue_comment(comment_id))

--- a/ogr/services/gitlab/issue.py
+++ b/ogr/services/gitlab/issue.py
@@ -189,3 +189,6 @@ class GitlabIssue(BaseIssue):
 
         self._raw_issue.assignee_ids = assignee_ids
         self._raw_issue.save()
+
+    def get_comment(self, comment_id: int) -> IssueComment:
+        return GitlabIssueComment(self._raw_issue.notes.get(comment_id))

--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -293,3 +293,6 @@ class GitlabPullRequest(BasePullRequest):
     def add_label(self, *labels: str) -> None:
         self._raw_pr.labels += labels
         self._raw_pr.save()
+
+    def get_comment(self, comment_id: int) -> PRComment:
+        return GitlabPRComment(self._raw_pr.notes.get(comment_id))

--- a/ogr/services/pagure/issue.py
+++ b/ogr/services/pagure/issue.py
@@ -214,3 +214,10 @@ class PagureIssue(BaseIssue):
         self.project._call_project_api(
             "issue", str(self.id), "assign", data=payload, method="POST"
         )
+
+    def get_comment(self, comment_id: int) -> IssueComment:
+        return PagureIssueComment(
+            self.project._call_project_api(
+                "issue", str(self.id), "comment", str(comment_id), method="GET"
+            )
+        )

--- a/tests/integration/github/test_data/test_issues/Issues.test_get_comment.yaml
+++ b/tests/integration/github/test_data/test_issues/Issues.test_get_comment.yaml
@@ -1,0 +1,381 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/hello-world:
+      - metadata:
+          latency: 0.3958423137664795
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_issues
+          - ogr.utils
+          - ogr.services.github.issue
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+            clone_url: https://github.com/packit/hello-world.git
+            collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+            created_at: '2019-05-02T18:54:46Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+            events_url: https://api.github.com/repos/packit/hello-world/events
+            fork: false
+            forks: 19
+            forks_count: 19
+            forks_url: https://api.github.com/repos/packit/hello-world/forks
+            full_name: packit/hello-world
+            git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+            git_url: git://github.com/packit/hello-world.git
+            has_downloads: true
+            has_issues: true
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+            html_url: https://github.com/packit/hello-world
+            id: 184635124
+            issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/packit/hello-world/merges
+            milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 19
+            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+            notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+            open_issues: 48
+            open_issues_count: 48
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            permissions:
+              admin: false
+              maintain: false
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+            pushed_at: '2021-09-24T05:37:58Z'
+            releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+            size: 48
+            ssh_url: git@github.com:packit/hello-world.git
+            stargazers_count: 3
+            stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+            subscribers_count: 9
+            subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+            svn_url: https://github.com/packit/hello-world
+            tags_url: https://api.github.com/repos/packit/hello-world/tags
+            teams_url: https://api.github.com/repos/packit/hello-world/teams
+            temp_clone_token: ''
+            trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+            updated_at: '2021-08-01T14:29:07Z'
+            url: https://api.github.com/repos/packit/hello-world
+            watchers: 3
+            watchers_count: 3
+          _next: null
+          elapsed: 0.395216
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, Deprecation, Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 24 Sep 2021 10:02:35 GMT
+            ETag: W/"cd54cecab89c7def705ff9c0880bf5cc2d0b4088257e8dc4dfd42727b7a840f3"
+            Last-Modified: Sun, 01 Aug 2021 14:29:07 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: B4EE:10632:419C14:42FF14:614DA23A
+            X-OAuth-Scopes: admin:org, manage_billing:enterprise, repo, write:discussion,
+              write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4997'
+            X-RateLimit-Reset: '1632481108'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '3'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/issues/297:
+      - metadata:
+          latency: 0.190565824508667
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_issues
+          - ogr.utils
+          - ogr.services.github.issue
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            active_lock_reason: null
+            assignee: null
+            assignees: []
+            author_association: NONE
+            body: This is a description
+            closed_at: null
+            closed_by: null
+            comments: 1
+            comments_url: https://api.github.com/repos/packit/hello-world/issues/297/comments
+            created_at: '2021-04-12T15:04:48Z'
+            events_url: https://api.github.com/repos/packit/hello-world/issues/297/events
+            html_url: https://github.com/packit/hello-world/issues/297
+            id: 856071373
+            labels: []
+            labels_url: https://api.github.com/repos/packit/hello-world/issues/297/labels{/name}
+            locked: false
+            milestone: null
+            node_id: MDU6SXNzdWU4NTYwNzEzNzM=
+            number: 297
+            performed_via_github_app: null
+            repository_url: https://api.github.com/repos/packit/hello-world
+            state: open
+            timeline_url: https://api.github.com/repos/packit/hello-world/issues/297/timeline
+            title: This is a title
+            updated_at: '2021-09-23T18:02:02Z'
+            url: https://api.github.com/repos/packit/hello-world/issues/297
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/20273495?v=4
+              events_url: https://api.github.com/users/bcrocker15/events{/privacy}
+              followers_url: https://api.github.com/users/bcrocker15/followers
+              following_url: https://api.github.com/users/bcrocker15/following{/other_user}
+              gists_url: https://api.github.com/users/bcrocker15/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/bcrocker15
+              id: 20273495
+              login: bcrocker15
+              node_id: MDQ6VXNlcjIwMjczNDk1
+              organizations_url: https://api.github.com/users/bcrocker15/orgs
+              received_events_url: https://api.github.com/users/bcrocker15/received_events
+              repos_url: https://api.github.com/users/bcrocker15/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/bcrocker15/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/bcrocker15/subscriptions
+              type: User
+              url: https://api.github.com/users/bcrocker15
+          _next: null
+          elapsed: 0.190071
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, Deprecation, Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 24 Sep 2021 10:02:35 GMT
+            ETag: W/"d1700bbc3a9d2561a3dfb6204693170214f8668c056dcddd2bec2d97a6228dad"
+            Last-Modified: Thu, 23 Sep 2021 18:02:02 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: B4EE:10632:419CB1:42FFB9:614DA23B
+            X-OAuth-Scopes: admin:org, manage_billing:enterprise, repo, write:discussion,
+              write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4996'
+            X-RateLimit-Reset: '1632481108'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '4'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/issues/comments/926035728:
+      - metadata:
+          latency: 0.27924251556396484
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_issues
+          - ogr.services.github.issue
+          - github.Issue
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            author_association: MEMBER
+            body: this is a comment
+            created_at: '2021-09-23T18:02:02Z'
+            html_url: https://github.com/packit/hello-world/issues/297#issuecomment-926035728
+            id: 926035728
+            issue_url: https://api.github.com/repos/packit/hello-world/issues/297
+            node_id: IC_kwDOCwFO9M43Mi8Q
+            performed_via_github_app: null
+            updated_at: '2021-09-23T18:02:02Z'
+            url: https://api.github.com/repos/packit/hello-world/issues/comments/926035728
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/70757578?u=46aa1242156b152c00c419f596535012962c1fff&v=4
+              events_url: https://api.github.com/users/nikromen/events{/privacy}
+              followers_url: https://api.github.com/users/nikromen/followers
+              following_url: https://api.github.com/users/nikromen/following{/other_user}
+              gists_url: https://api.github.com/users/nikromen/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/nikromen
+              id: 70757578
+              login: nikromen
+              node_id: MDQ6VXNlcjcwNzU3NTc4
+              organizations_url: https://api.github.com/users/nikromen/orgs
+              received_events_url: https://api.github.com/users/nikromen/received_events
+              repos_url: https://api.github.com/users/nikromen/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/nikromen/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/nikromen/subscriptions
+              type: User
+              url: https://api.github.com/users/nikromen
+          _next: null
+          elapsed: 0.278726
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, Deprecation, Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 24 Sep 2021 10:02:35 GMT
+            ETag: W/"ceb9561ea16b51efa4bd583e9defbfd5dc5d5a9de78d59c1e01858def86b27ce"
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: B4EE:10632:419D01:430001:614DA23B
+            X-OAuth-Scopes: admin:org, manage_billing:enterprise, repo, write:discussion,
+              write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4995'
+            X-RateLimit-Reset: '1632481108'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '5'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/github/test_data/test_pull_requests/PullRequests.test_get_comment.yaml
+++ b/tests/integration/github/test_data/test_pull_requests/PullRequests.test_get_comment.yaml
@@ -1,0 +1,659 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/hello-world:
+      - metadata:
+          latency: 0.2838301658630371
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.utils
+          - ogr.services.github.pull_request
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+            clone_url: https://github.com/packit/hello-world.git
+            collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+            created_at: '2019-05-02T18:54:46Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+            events_url: https://api.github.com/repos/packit/hello-world/events
+            fork: false
+            forks: 19
+            forks_count: 19
+            forks_url: https://api.github.com/repos/packit/hello-world/forks
+            full_name: packit/hello-world
+            git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+            git_url: git://github.com/packit/hello-world.git
+            has_downloads: true
+            has_issues: true
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+            html_url: https://github.com/packit/hello-world
+            id: 184635124
+            issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/packit/hello-world/merges
+            milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 19
+            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+            notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+            open_issues: 48
+            open_issues_count: 48
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            permissions:
+              admin: false
+              maintain: false
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+            pushed_at: '2021-09-24T05:37:58Z'
+            releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+            size: 48
+            ssh_url: git@github.com:packit/hello-world.git
+            stargazers_count: 3
+            stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+            subscribers_count: 9
+            subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+            svn_url: https://github.com/packit/hello-world
+            tags_url: https://api.github.com/repos/packit/hello-world/tags
+            teams_url: https://api.github.com/repos/packit/hello-world/teams
+            temp_clone_token: ''
+            trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+            updated_at: '2021-08-01T14:29:07Z'
+            url: https://api.github.com/repos/packit/hello-world
+            watchers: 3
+            watchers_count: 3
+          _next: null
+          elapsed: 0.283265
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, Deprecation, Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 24 Sep 2021 10:03:13 GMT
+            ETag: W/"cd54cecab89c7def705ff9c0880bf5cc2d0b4088257e8dc4dfd42727b7a840f3"
+            Last-Modified: Sun, 01 Aug 2021 14:29:07 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: B4F0:DA25:4432A68:460AA8A:614DA261
+            X-OAuth-Scopes: admin:org, manage_billing:enterprise, repo, write:discussion,
+              write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4994'
+            X-RateLimit-Reset: '1632481108'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '6'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/issues/comments/559765628:
+      - metadata:
+          latency: 0.3006432056427002
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.services.github.pull_request
+          - github.PullRequest
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            author_association: MEMBER
+            body: "check comment updates\r\n\r\nedit"
+            created_at: '2019-11-29T11:51:21Z'
+            html_url: https://github.com/packit/hello-world/pull/72#issuecomment-559765628
+            id: 559765628
+            issue_url: https://api.github.com/repos/packit/hello-world/issues/72
+            node_id: MDEyOklzc3VlQ29tbWVudDU1OTc2NTYyOA==
+            performed_via_github_app: null
+            updated_at: '2021-06-18T13:59:20Z'
+            url: https://api.github.com/repos/packit/hello-world/issues/comments/559765628
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/8149784?u=9055c961b26d575df5b8376637210e7b05e537b0&v=4
+              events_url: https://api.github.com/users/mfocko/events{/privacy}
+              followers_url: https://api.github.com/users/mfocko/followers
+              following_url: https://api.github.com/users/mfocko/following{/other_user}
+              gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/mfocko
+              id: 8149784
+              login: mfocko
+              node_id: MDQ6VXNlcjgxNDk3ODQ=
+              organizations_url: https://api.github.com/users/mfocko/orgs
+              received_events_url: https://api.github.com/users/mfocko/received_events
+              repos_url: https://api.github.com/users/mfocko/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+              type: User
+              url: https://api.github.com/users/mfocko
+          _next: null
+          elapsed: 0.300191
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, Deprecation, Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 24 Sep 2021 10:03:14 GMT
+            ETag: W/"490616ade29e4517a933b5cc7cfdca572580543ab16eaf4cd36e2394b6012c5f"
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: B4F0:DA25:4432B38:460AB70:614DA261
+            X-OAuth-Scopes: admin:org, manage_billing:enterprise, repo, write:discussion,
+              write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4992'
+            X-RateLimit-Reset: '1632481108'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '8'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/pulls/72:
+      - metadata:
+          latency: 0.4013195037841797
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.utils
+          - ogr.services.github.pull_request
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              comments:
+                href: https://api.github.com/repos/packit/hello-world/issues/72/comments
+              commits:
+                href: https://api.github.com/repos/packit/hello-world/pulls/72/commits
+              html:
+                href: https://github.com/packit/hello-world/pull/72
+              issue:
+                href: https://api.github.com/repos/packit/hello-world/issues/72
+              review_comment:
+                href: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+              review_comments:
+                href: https://api.github.com/repos/packit/hello-world/pulls/72/comments
+              self:
+                href: https://api.github.com/repos/packit/hello-world/pulls/72
+              statuses:
+                href: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            active_lock_reason: null
+            additions: 0
+            assignee: null
+            assignees: []
+            author_association: MEMBER
+            auto_merge: null
+            base:
+              label: packit:main
+              ref: main
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+                clone_url: https://github.com/packit/hello-world.git
+                collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+                created_at: '2019-05-02T18:54:46Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+                events_url: https://api.github.com/repos/packit/hello-world/events
+                fork: false
+                forks: 19
+                forks_count: 19
+                forks_url: https://api.github.com/repos/packit/hello-world/forks
+                full_name: packit/hello-world
+                git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+                git_url: git://github.com/packit/hello-world.git
+                has_downloads: true
+                has_issues: true
+                has_pages: false
+                has_projects: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+                html_url: https://github.com/packit/hello-world
+                id: 184635124
+                issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/packit/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/packit/hello-world/merges
+                milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+                open_issues: 48
+                open_issues_count: 48
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                  events_url: https://api.github.com/users/packit/events{/privacy}
+                  followers_url: https://api.github.com/users/packit/followers
+                  following_url: https://api.github.com/users/packit/following{/other_user}
+                  gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/packit
+                  id: 46870917
+                  login: packit
+                  node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                  organizations_url: https://api.github.com/users/packit/orgs
+                  received_events_url: https://api.github.com/users/packit/received_events
+                  repos_url: https://api.github.com/users/packit/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/packit/subscriptions
+                  type: Organization
+                  url: https://api.github.com/users/packit
+                private: false
+                pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+                pushed_at: '2021-09-24T05:37:58Z'
+                releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+                size: 48
+                ssh_url: git@github.com:packit/hello-world.git
+                stargazers_count: 3
+                stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+                svn_url: https://github.com/packit/hello-world
+                tags_url: https://api.github.com/repos/packit/hello-world/tags
+                teams_url: https://api.github.com/repos/packit/hello-world/teams
+                trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+                updated_at: '2021-08-01T14:29:07Z'
+                url: https://api.github.com/repos/packit/hello-world
+                watchers: 3
+                watchers_count: 3
+              sha: d5f6efe7c6fbd6c224d31618c208c924a406fedf
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+            body: This test case is used for testing OGR project - updating the pr
+              info
+            changed_files: 1
+            closed_at: null
+            comments: 1
+            comments_url: https://api.github.com/repos/packit/hello-world/issues/72/comments
+            commits: 3
+            commits_url: https://api.github.com/repos/packit/hello-world/pulls/72/commits
+            created_at: '2019-11-27T11:19:20Z'
+            deletions: 26
+            diff_url: https://github.com/packit/hello-world/pull/72.diff
+            draft: false
+            head:
+              label: packit:test_source
+              ref: test_source
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+                clone_url: https://github.com/packit/hello-world.git
+                collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+                created_at: '2019-05-02T18:54:46Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+                events_url: https://api.github.com/repos/packit/hello-world/events
+                fork: false
+                forks: 19
+                forks_count: 19
+                forks_url: https://api.github.com/repos/packit/hello-world/forks
+                full_name: packit/hello-world
+                git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+                git_url: git://github.com/packit/hello-world.git
+                has_downloads: true
+                has_issues: true
+                has_pages: false
+                has_projects: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+                html_url: https://github.com/packit/hello-world
+                id: 184635124
+                issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/packit/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/packit/hello-world/merges
+                milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+                open_issues: 48
+                open_issues_count: 48
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                  events_url: https://api.github.com/users/packit/events{/privacy}
+                  followers_url: https://api.github.com/users/packit/followers
+                  following_url: https://api.github.com/users/packit/following{/other_user}
+                  gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/packit
+                  id: 46870917
+                  login: packit
+                  node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                  organizations_url: https://api.github.com/users/packit/orgs
+                  received_events_url: https://api.github.com/users/packit/received_events
+                  repos_url: https://api.github.com/users/packit/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/packit/subscriptions
+                  type: Organization
+                  url: https://api.github.com/users/packit
+                private: false
+                pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+                pushed_at: '2021-09-24T05:37:58Z'
+                releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+                size: 48
+                ssh_url: git@github.com:packit/hello-world.git
+                stargazers_count: 3
+                stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+                svn_url: https://github.com/packit/hello-world
+                tags_url: https://api.github.com/repos/packit/hello-world/tags
+                teams_url: https://api.github.com/repos/packit/hello-world/teams
+                trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+                updated_at: '2021-08-01T14:29:07Z'
+                url: https://api.github.com/repos/packit/hello-world
+                watchers: 3
+                watchers_count: 3
+              sha: 7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+            html_url: https://github.com/packit/hello-world/pull/72
+            id: 346187823
+            issue_url: https://api.github.com/repos/packit/hello-world/issues/72
+            labels: []
+            locked: false
+            maintainer_can_modify: false
+            merge_commit_sha: 919658de01745f4dcdfac66d247cd37a91988fb1
+            mergeable: false
+            mergeable_state: dirty
+            merged: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            node_id: MDExOlB1bGxSZXF1ZXN0MzQ2MTg3ODIz
+            number: 72
+            patch_url: https://github.com/packit/hello-world/pull/72.patch
+            rebaseable: false
+            requested_reviewers: []
+            requested_teams: []
+            review_comment_url: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+            review_comments: 0
+            review_comments_url: https://api.github.com/repos/packit/hello-world/pulls/72/comments
+            state: open
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            title: 'Ogr test case: Test pull request for updating PR info'
+            updated_at: '2021-06-18T14:04:38Z'
+            url: https://api.github.com/repos/packit/hello-world/pulls/72
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/8149784?v=4
+              events_url: https://api.github.com/users/mfocko/events{/privacy}
+              followers_url: https://api.github.com/users/mfocko/followers
+              following_url: https://api.github.com/users/mfocko/following{/other_user}
+              gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/mfocko
+              id: 8149784
+              login: mfocko
+              node_id: MDQ6VXNlcjgxNDk3ODQ=
+              organizations_url: https://api.github.com/users/mfocko/orgs
+              received_events_url: https://api.github.com/users/mfocko/received_events
+              repos_url: https://api.github.com/users/mfocko/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+              type: User
+              url: https://api.github.com/users/mfocko
+          _next: null
+          elapsed: 0.400728
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, Deprecation, Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 24 Sep 2021 10:03:13 GMT
+            ETag: W/"3237010d3c38ee5ede7e100cd1325f927f833dca852ec72bf87c7761939c374c"
+            Last-Modified: Mon, 13 Sep 2021 16:50:20 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: B4F0:DA25:4432AAE:460AADE:614DA261
+            X-OAuth-Scopes: admin:org, manage_billing:enterprise, repo, write:discussion,
+              write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4993'
+            X-RateLimit-Reset: '1632481108'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '7'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/github/test_issues.py
+++ b/tests/integration/github/test_issues.py
@@ -171,3 +171,7 @@ class Issues(GithubTests):
 
         issue.description = old_description
         assert issue.description == old_description
+
+    def test_get_comment(self):
+        comment = self.hello_world_project.get_issue(297).get_comment(926035728)
+        assert comment.body == "this is a comment"

--- a/tests/integration/github/test_pull_requests.py
+++ b/tests/integration/github/test_pull_requests.py
@@ -348,3 +348,7 @@ class PullRequests(GithubTests):
         patch = pr.patch
         assert isinstance(patch, bytes)
         assert "\nDate: Mon, 18 Nov 2019 12:42:35 +0100\n" in patch.decode()
+
+    def test_get_comment(self):
+        comment = self.hello_world_project.get_pr(72).get_comment(559765628)
+        assert comment.body == "check comment updates\r\n\r\nedit"

--- a/tests/integration/gitlab/test_data/test_issues/Issues.test_get_comment.yaml
+++ b/tests/integration/gitlab/test_data/test_issues/Issues.test_get_comment.yaml
@@ -1,0 +1,437 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/14233409/issues/102:
+      - metadata:
+          latency: 0.30450868606567383
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_issues
+          - ogr.utils
+          - ogr.services.gitlab.issue
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/102/award_emoji
+              notes: https://gitlab.com/api/v4/projects/14233409/issues/102/notes
+              project: https://gitlab.com/api/v4/projects/14233409
+              self: https://gitlab.com/api/v4/projects/14233409/issues/102
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_issues_count: 0
+            closed_at: null
+            closed_by: null
+            confidential: false
+            created_at: '2021-04-12T21:11:16.556Z'
+            description: Description for issue
+            discussion_locked: null
+            downvotes: 0
+            due_date: null
+            has_tasks: false
+            health_status: null
+            id: 85072456
+            iid: 102
+            issue_type: issue
+            labels: []
+            merge_requests_count: 0
+            milestone: null
+            moved_to_id: null
+            project_id: 14233409
+            references:
+              full: packit-service/ogr-tests#102
+              relative: '#102'
+              short: '#102'
+            service_desk_reply_to: null
+            state: opened
+            subscribed: true
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: This is a example issue on gitlab
+            type: ISSUE
+            updated_at: '2021-09-24T09:39:58.954Z'
+            upvotes: 0
+            user_notes_count: 1
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/102
+            weight: null
+          _next: null
+          elapsed: 0.303827
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b371f18b438be-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:06 GMT
+            Etag: W/"a2c860296da52b8044e95272f0998f78"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-11-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '3'
+            RateLimit-Remaining: '1997'
+            RateLimit-Reset: '1632478206'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:06 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMFBYT969J7XNQHMF54QRH
+            X-Runtime: '0.096277'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/14233409/issues/102/notes/686264162:
+      - metadata:
+          latency: 0.5130319595336914
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_issues
+          - ogr.services.gitlab.issue
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            attachment: null
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/6b309d0b529f4fc4946923d7d049c598?s=80&d=identicon
+              id: 9288169
+              name: nikromen
+              state: active
+              username: nikromen
+              web_url: https://gitlab.com/nikromen
+            body: issue comment
+            commands_changes: {}
+            confidential: false
+            created_at: '2021-09-24T09:39:58.912Z'
+            id: 686264162
+            noteable_id: 85072456
+            noteable_iid: 102
+            noteable_type: Issue
+            resolvable: false
+            system: false
+            type: null
+            updated_at: '2021-09-24T09:39:58.912Z'
+          _next: null
+          elapsed: 0.512491
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b37212ce338be-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:07 GMT
+            Etag: W/"b2bbdb44b43626bad8c374e0b0e8cc9d"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-16-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '4'
+            RateLimit-Remaining: '1996'
+            RateLimit-Reset: '1632478206'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:06 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMFC9EVNV5683M9RGRW8VQ
+            X-Runtime: '0.122162'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.8165926933288574
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_issues
+          - ogr.utils
+          - ogr.services.gitlab.issue
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 7
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-09-24T09:39:59.056Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: ogr-tests
+            name_with_namespace: packit-service / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: packit-service
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 68
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access: null
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_address: incoming+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.81609
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b3719fdf238be-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:06 GMT
+            Etag: W/"aa7c9eb6fa762fdeb15c77ffc964e372"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-09-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '2'
+            RateLimit-Remaining: '1998'
+            RateLimit-Reset: '1632478206'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:06 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMFBA4B7RFSEH9T8J7E25E
+            X-Runtime: '0.418512'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.6493573188781738
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_issues
+          - ogr.utils
+          - ogr.services.gitlab.issue
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://secure.gravatar.com/avatar/6b309d0b529f4fc4946923d7d049c598?s=80&d=identicon
+            bio: ''
+            bio_html: ''
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 1
+            commit_email: j1.kyjovsky@gmail.com
+            confirmed_at: '2021-07-09T12:48:35.134Z'
+            created_at: '2021-07-09T12:48:35.203Z'
+            current_sign_in_at: '2021-09-23T15:40:00.566Z'
+            email: j1.kyjovsky@gmail.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            followers: 0
+            following: 0
+            id: 9288169
+            identities:
+            - extern_uid: '70757578'
+              provider: github
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2021-09-24'
+            last_sign_in_at: '2021-08-11T12:00:18.932Z'
+            linkedin: ''
+            location: null
+            name: nikromen
+            organization: null
+            private_profile: false
+            projects_limit: 100000
+            pronouns: null
+            public_email: ''
+            shared_runners_minutes_limit: null
+            skype: ''
+            state: active
+            theme_id: 1
+            twitter: ''
+            two_factor_enabled: false
+            username: nikromen
+            web_url: https://gitlab.com/nikromen
+            website_url: ''
+            work_information: null
+          _next: null
+          elapsed: 0.648685
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b37162d1c38be-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:05 GMT
+            Etag: W/"d35f6cf1b106e621174afcec26c1b89f"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-15-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '1'
+            RateLimit-Remaining: '1999'
+            RateLimit-Reset: '1632478205'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:05 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMFAWG0865DXZESTSPWMD0
+            X-Runtime: '0.048273'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_get_comment.yaml
+++ b/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_get_comment.yaml
@@ -1,0 +1,464 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/14233409/merge_requests/1:
+      - metadata:
+          latency: 0.30625009536743164
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.utils
+          - ogr.services.gitlab.pull_request
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            approvals_before_merge: 0
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            blocking_discussions_resolved: true
+            changes_count: '1'
+            closed_at: null
+            closed_by: null
+            created_at: '2019-09-10T14:03:24.365Z'
+            description: description of mergerequest
+            diff_refs:
+              base_sha: 24c86d0704694f686329b2ea636c5b7522cfdc40
+              head_sha: d490ec67dd98f69dfdc1732b98bb3189f0e0aace
+              start_sha: 24c86d0704694f686329b2ea636c5b7522cfdc40
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            first_contribution: false
+            first_deployed_to_production_at: null
+            force_remove_source_branch: false
+            has_conflicts: false
+            head_pipeline: null
+            id: 36948617
+            iid: 1
+            labels:
+            - test_lb1
+            - test_lb2
+            latest_build_finished_at: null
+            latest_build_started_at: null
+            merge_commit_sha: 101a42bbbe174d04b465d49caf274dc3b4defeca
+            merge_error: null
+            merge_status: can_be_merged
+            merge_when_pipeline_succeeds: false
+            merged_at: '2019-09-11T08:55:32.822Z'
+            merged_by:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            milestone: null
+            pipeline: null
+            project_id: 14233409
+            reference: '!1'
+            references:
+              full: packit-service/ogr-tests!1
+              relative: '!1'
+              short: '!1'
+            reviewers: []
+            sha: d490ec67dd98f69dfdc1732b98bb3189f0e0aace
+            should_remove_source_branch: null
+            source_branch: change
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            state: merged
+            subscribed: false
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: change
+            updated_at: '2020-10-12T10:29:20.574Z'
+            upvotes: 0
+            user:
+              can_merge: false
+            user_notes_count: 3
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/1
+            work_in_progress: false
+          _next: null
+          elapsed: 0.306079
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b37b2ab11fca5-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:30 GMT
+            Etag: W/"ed497aba09a68017b0186e3bc4a2ed49"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-10-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '7'
+            RateLimit-Remaining: '1993'
+            RateLimit-Reset: '1632478230'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:30 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMG30GXAMYCC5P9HKTCFVC
+            X-Runtime: '0.128462'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/14233409/merge_requests/1/notes/214842329:
+      - metadata:
+          latency: 0.30745816230773926
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.services.gitlab.pull_request
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            attachment: null
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            body: first comment of mergerequest
+            commands_changes: {}
+            confidential: false
+            created_at: '2019-09-10T14:04:20.585Z'
+            id: 214842329
+            noteable_id: 36948617
+            noteable_iid: 1
+            noteable_type: MergeRequest
+            resolvable: false
+            system: false
+            type: null
+            updated_at: '2019-09-10T14:04:20.585Z'
+          _next: null
+          elapsed: 0.306939
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b37b49dddfca5-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:30 GMT
+            Etag: W/"2bea2ddcf53e6a7d31d0a5996e33094a"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-12-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '8'
+            RateLimit-Remaining: '1992'
+            RateLimit-Reset: '1632478230'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:30 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMG3ACTHRN4EA97HRW9YVJ
+            X-Runtime: '0.079909'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.4013841152191162
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.utils
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 7
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-09-24T09:39:59.056Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: ogr-tests
+            name_with_namespace: packit-service / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: packit-service
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 68
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access: null
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_address: incoming+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.40072
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b37b01d7afca5-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:29 GMT
+            Etag: W/"aa7c9eb6fa762fdeb15c77ffc964e372"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-17-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '6'
+            RateLimit-Remaining: '1994'
+            RateLimit-Reset: '1632478229'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:29 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMG2KHT6PVCH7YNHDFNXAX
+            X-Runtime: '0.118823'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.287125825881958
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.utils
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://secure.gravatar.com/avatar/6b309d0b529f4fc4946923d7d049c598?s=80&d=identicon
+            bio: ''
+            bio_html: ''
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 1
+            commit_email: j1.kyjovsky@gmail.com
+            confirmed_at: '2021-07-09T12:48:35.134Z'
+            created_at: '2021-07-09T12:48:35.203Z'
+            current_sign_in_at: '2021-09-23T15:40:00.566Z'
+            email: j1.kyjovsky@gmail.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            followers: 0
+            following: 0
+            id: 9288169
+            identities:
+            - extern_uid: '70757578'
+              provider: github
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2021-09-24'
+            last_sign_in_at: '2021-08-11T12:00:18.932Z'
+            linkedin: ''
+            location: null
+            name: nikromen
+            organization: null
+            private_profile: false
+            projects_limit: 100000
+            pronouns: null
+            public_email: ''
+            shared_runners_minutes_limit: null
+            skype: ''
+            state: active
+            theme_id: 1
+            twitter: ''
+            two_factor_enabled: false
+            username: nikromen
+            web_url: https://gitlab.com/nikromen
+            website_url: ''
+            work_information: null
+          _next: null
+          elapsed: 0.286564
+          encoding: null
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 693b37ae6aa4fca5-VIE
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 10:09:29 GMT
+            Etag: W/"d35f6cf1b106e621174afcec26c1b89f"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-02-lb-gprd
+            GitLab-SV: localhost
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '5'
+            RateLimit-Remaining: '1995'
+            RateLimit-Reset: '1632478229'
+            RateLimit-ResetTime: Fri, 24 Sep 2021 10:10:29 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FGBMG2BJ98GDE1DFN0W2G0BK
+            X-Runtime: '0.046718'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_issues.py
+++ b/tests/integration/gitlab/test_issues.py
@@ -216,3 +216,7 @@ class Issues(GitlabTests):
 
         issue.description = old_description
         assert issue.description == old_description
+
+    def test_get_comment(self):
+        comment = self.project.get_issue(102).get_comment(686264162)
+        assert comment.body == "issue comment"

--- a/tests/integration/gitlab/test_pull_requests.py
+++ b/tests/integration/gitlab/test_pull_requests.py
@@ -376,3 +376,7 @@ class PullRequests(GitlabTests):
         patch = pr.patch
         assert isinstance(patch, bytes)
         assert "\nDate: Wed, 11 Sep 2019 14:50:41 +0200\n" in patch.decode()
+
+    def test_get_comment(self):
+        comment = self.project.get_pr(1).get_comment(214842329)
+        assert comment.body == "first comment of mergerequest"

--- a/tests/integration/pagure/test_data/test_issues/Issues.test_get_comment.yaml
+++ b/tests/integration/pagure/test_data/test_issues/Issues.test_get_comment.yaml
@@ -1,0 +1,147 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://pagure.io/api/0/my-playground/issue/1:
+      - metadata:
+          latency: 0.6882052421569824
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.utils
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            assignee: null
+            blocks: []
+            close_status: null
+            closed_at: null
+            closed_by: null
+            comments:
+            - comment: example issue comment
+              date_created: '1632485834'
+              edited_on: null
+              editor: null
+              id: 753462
+              notification: false
+              parent: null
+              reactions: {}
+              user:
+                full_url: https://pagure.io/user/nikromen
+                fullname: Jiri Kyjovsky
+                name: nikromen
+                url_path: user/nikromen
+            content: issue
+            custom_fields: []
+            date_created: '1632485822'
+            depends: []
+            full_url: https://pagure.io/my-playground/issue/1
+            id: 1
+            last_updated: '1632485834'
+            milestone: null
+            priority: null
+            private: false
+            related_prs: []
+            status: Open
+            tags: []
+            title: ogr test issue
+            user:
+              full_url: https://pagure.io/user/nikromen
+              fullname: Jiri Kyjovsky
+              name: nikromen
+              url_path: user/nikromen
+          _next: null
+          elapsed: 0.687664
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '1067'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-6zVukatOw0fXtShDau55F1Vy6';
+              style-src 'self' 'nonce-6zVukatOw0fXtShDau55F1Vy6'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 12:43:56 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMzc5OTYxOGVmYjhjYzEyYjE1NjMwMjFhNDQ0ZDcyMGQzMmMxY2ZlMiJ9.FC9ZjA.v0yYlcwqXRpi5uWYeVufLeJf3Qo;
+              Expires=Mon, 25-Oct-2021 12:43:56 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://pagure.io/api/0/my-playground/issue/1/comment/753462:
+      - metadata:
+          latency: 0.23948907852172852
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://seccdn.libravatar.org/avatar/7ef0bb1e405fa2873b0b6ccd7a5c218faa8dded98f928c0d5a50ee85c26d1f10?s=16&d=retro
+            comment: example issue comment
+            comment_date: '2021-09-24 12:17:14'
+            date_created: '1632485834'
+            edited_on: null
+            editor: null
+            id: 753462
+            notification: false
+            parent: null
+            reactions: {}
+            user:
+              full_url: https://pagure.io/user/nikromen
+              fullname: Jiri Kyjovsky
+              name: nikromen
+              url_path: user/nikromen
+          _next: null
+          elapsed: 0.238873
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '535'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-aFHG8JRUTNraj961vbX5cGinN';
+              style-src 'self' 'nonce-aFHG8JRUTNraj961vbX5cGinN'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Fri, 24 Sep 2021 12:43:56 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMzc5OTYxOGVmYjhjYzEyYjE1NjMwMjFhNDQ0ZDcyMGQzMmMxY2ZlMiJ9.FC9ZjA.v0yYlcwqXRpi5uWYeVufLeJf3Qo;
+              Expires=Mon, 25-Oct-2021 12:43:56 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/pagure/test_issues.py
+++ b/tests/integration/pagure/test_issues.py
@@ -107,3 +107,10 @@ class Issues(PagureTests):
         issue = project.create_issue(title=title, body=description)
         assert issue.title == title
         assert issue.description == description
+
+    def test_get_comment(self):
+        project = self.service.get_project(
+            repo="my-playground", namespace=None, username="nikromen"
+        )
+        comment = project.get_issue(1).get_comment(753462)
+        assert comment.body == "example issue comment"


### PR DESCRIPTION
<!-- notes for reviewers -->
I implemented this feature because my PR [packit-service/1222](https://github.com/packit/packit-service/pull/1222) needs to get a comment by its ID but OGR doesn't support that.

This `get_comment` method just simply returns a comment which is identified by comment's ID. Works for PullRequest (not Pagure) and Issue as well.

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

---

<!-- release notes for changelog/blog follow -->
Added support for getting issue and pull request comments by their ID. Pagure currently does not support getting pull request comments.
