### PR TITLE
Build the development version in packit-dev

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -51,7 +51,8 @@ jobs:
     metadata:
       branch: main
       targets:
-        - fedora-stable
+        - fedora-all
+        - epel-8
       project: packit-dev
       list_on_homepage: True
       preserve_project: True
@@ -59,7 +60,8 @@ jobs:
     trigger: release
     metadata:
       targets:
-        - fedora-stable
+        - fedora-all
+        - epel-8
       project: packit-releases
       list_on_homepage: True
       preserve_project: True

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -49,10 +49,10 @@ jobs:
   - job: copr_build
     trigger: commit
     metadata:
-      branch: master
+      branch: main
       targets:
         - fedora-stable
-      project: packit-master
+      project: packit-dev
       list_on_homepage: True
       preserve_project: True
   - job: copr_build

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Or from PyPI:
 $ pip3 install --user ogr
 ```
 
-You can also install OGR from `master` branch, if you are brave enough:
+You can also install OGR from the `main` branch, if you are brave enough:
 
-You can use our [`packit-master` Copr repository](https://copr.fedorainfracloud.org/coprs/packit/packit-master/)
-(contains `master` version of [ogr](https://github.com/packit/ogr)):
+You can use our [`packit-dev` Copr repository](https://copr.fedorainfracloud.org/coprs/packit/packit-dev/)
+(contains the latest development version of [ogr](https://github.com/packit/ogr)):
 
 ```
-$ dnf copr enable packit/packit-master
+$ dnf copr enable packit/packit-dev
 $ dnf install python3-ogr
 ```
 
@@ -127,4 +127,4 @@ For more info about contributing to our project see [our contribution guide](/CO
 
 # Deprecation policy
 
-For more info about deprecation policy see [Deprecation policy](https://github.com/packit/research/tree/master/deprecation)
+For more info about deprecation policy see [Deprecation policy](https://github.com/packit/research/tree/main/deprecation)


### PR DESCRIPTION
This is to get rid of the 'packit-master' name.

Also fix the configuration to build 'ogr' in Copr, whenever there is a
new commit on the _main_ branch (not on _master_).

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>