### PR TITLE
Transition to pdoc from pdoc3 #535

### DIFF
--- a/ogr/__init__.py
+++ b/ogr/__init__.py
@@ -13,9 +13,10 @@ from ogr.factory import (
     get_service_class_or_none,
     get_instances_from_dict,
 )
-from ogr.services.github import GithubService
-from ogr.services.gitlab import GitlabService
-from ogr.services.pagure import PagureService
+
+from ogr.services.github import *
+from ogr.services.gitlab import *
+from ogr.services.pagure import *
 
 try:
     __version__ = get_distribution(__name__).version
@@ -24,11 +25,39 @@ except DistributionNotFound:
     pass
 
 __all__ = [
+    #services.github
     GithubService.__name__,
-    PagureService.__name__,
+    GithubCheckRun.__name__,
+    GithubPullRequest.__name__,
+    GithubIssueComment.__name__,
+    GithubPRComment.__name__,
+    GithubIssue.__name__,
+    GithubRelease.__name__,
+    GithubUser.__name__,
+    GithubProject.__name__,
+
+    #services.gitlab
     GitlabService.__name__,
+    GitlabIssue.__name__,
+    GitlabPullRequest.__name__,
+    GitlabIssueComment.__name__,
+    GitlabPRComment.__name__,
+    GitlabRelease.__name__,
+    GitlabUser.__name__,
+    GitlabProject.__name__,
+
+    PagureService.__name__,
+    PagurePullRequest.__name__,
+    PagureIssueComment.__name__,
+    PagurePRComment.__name__,
+    PagureIssue.__name__,
+    PagureRelease.__name__,
+    PagureUser.__name__,
+    PagureProject.__name__,
+
     get_project.__name__,
     get_service_class.__name__,
     get_service_class_or_none.__name__,
     get_instances_from_dict.__name__,
 ]
+

--- a/ogr/__init__.py
+++ b/ogr/__init__.py
@@ -25,7 +25,7 @@ except DistributionNotFound:
     pass
 
 __all__ = [
-    #services.github
+    # services.github
     GithubService.__name__,
     GithubCheckRun.__name__,
     GithubPullRequest.__name__,
@@ -35,8 +35,7 @@ __all__ = [
     GithubRelease.__name__,
     GithubUser.__name__,
     GithubProject.__name__,
-
-    #services.gitlab
+    # services.gitlab
     GitlabService.__name__,
     GitlabIssue.__name__,
     GitlabPullRequest.__name__,
@@ -45,7 +44,6 @@ __all__ = [
     GitlabRelease.__name__,
     GitlabUser.__name__,
     GitlabProject.__name__,
-
     PagureService.__name__,
     PagurePullRequest.__name__,
     PagureIssueComment.__name__,
@@ -54,10 +52,8 @@ __all__ = [
     PagureRelease.__name__,
     PagureUser.__name__,
     PagureProject.__name__,
-
     get_project.__name__,
     get_service_class.__name__,
     get_service_class_or_none.__name__,
     get_instances_from_dict.__name__,
 ]
-


### PR DESCRIPTION
Switching from pdoc3 to pdoc since pdoc provides a cleaner UI and built-in search functionality.

TODO:

- [ ] improve the importing (e.g. __init__.py, etc.), since pdoc does only what sees, right now if you generate for ogr it will show only services and everything nested is ignored

- [ ] Transition the Github Action
