### PR TITLE
Remove old deprecated methods

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -3,7 +3,6 @@
 
 import datetime
 import functools
-import warnings
 from enum import Enum, IntEnum
 from typing import (
     Optional,
@@ -156,14 +155,6 @@ class Comment(OgrAbstractClass):
     def _from_raw_comment(self, raw_comment: Any) -> None:
         """Constructs Comment object from raw_comment given from API."""
         raise NotImplementedError()
-
-    @property
-    def comment(self) -> str:
-        warnings.warn(
-            "Using deprecated property, that will be removed in 0.14.0"
-            " (or 1.0.0 if it comes sooner). Please use body. "
-        )
-        return self.body
 
     @property
     def body(self) -> str:

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -22,7 +22,6 @@ import github
 import gitlab
 import requests
 
-from ogr.deprecation import deprecate_and_set_removal
 from ogr.exceptions import (
     OgrException,
     GitlabAPIException,
@@ -504,38 +503,19 @@ class MergeCommitStatus(Enum):
 
 
 class PullRequest(OgrAbstractClass):
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use PullRequestReadOnly from ogr.read_only to use a static and offline "
-        "representation of the pull-request. The subclasses of this class are not static anymore.",
-    )
-    def __init__(
-        self,
-        title: str,
-        description: str,
-        target_branch: str,
-        source_branch: str,
-        id: int,
-        status: PRStatus,
-        url: str,
-        author: str,
-        created: datetime.datetime,
-    ) -> None:
-        self._title = title
-        self._description = description
-        self._target_branch = target_branch
-        self._source_branch = source_branch
-        self._id = id
-        self._status = PRStatus.open
-        self._url = url
-        self._author = author
-        self._created = created
+    """
+    Attributes:
+        project (GitProject): Project of the pull request.
+    """
+
+    def __init__(self, raw_pr: Any, project: "GitProject") -> None:
+        self._raw_pr = raw_pr
+        self._target_project = project
 
     @property
     def title(self) -> str:
         """Title of the pull request."""
-        return self._title
+        raise NotImplementedError()
 
     @title.setter
     def title(self, new_title: str) -> None:
@@ -544,22 +524,22 @@ class PullRequest(OgrAbstractClass):
     @property
     def id(self) -> int:
         """ID of the pull request."""
-        return self._id
+        raise NotImplementedError()
 
     @property
     def status(self) -> PRStatus:
         """Status of the pull request."""
-        return self._status
+        raise NotImplementedError()
 
     @property
     def url(self) -> str:
         """Web URL of the pull request."""
-        return self._url
+        raise NotImplementedError()
 
     @property
     def description(self) -> str:
         """Description of the pull request."""
-        return self._description
+        raise NotImplementedError()
 
     @description.setter
     def description(self, new_description: str) -> None:
@@ -568,22 +548,22 @@ class PullRequest(OgrAbstractClass):
     @property
     def author(self) -> str:
         """Login of the author of the pull request."""
-        return self._author
+        raise NotImplementedError()
 
     @property
     def source_branch(self) -> str:
         """Name of the source branch (from which the changes are pulled)."""
-        return self._source_branch
+        raise NotImplementedError()
 
     @property
     def target_branch(self) -> str:
         """Name of the target branch (where the changes are being merged)."""
-        return self._target_branch
+        raise NotImplementedError()
 
     @property
     def created(self) -> datetime.datetime:
         """Datetime of creating the pull request."""
-        return self._created
+        raise NotImplementedError()
 
     @property
     def labels(self) -> List[Any]:
@@ -627,7 +607,7 @@ class PullRequest(OgrAbstractClass):
     @property
     def target_project(self) -> "GitProject":
         """Object that represents target project (where changes are merged)."""
-        raise NotImplementedError()
+        return self._target_project
 
     @property
     def commits_url(self) -> str:

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -919,7 +919,7 @@ class CommitFlag(OgrAbstractClass):
         raise NotImplementedError()
 
     @classmethod
-    def _validate_state(cls, state: Union[CommitStatus, str]) -> CommitStatus:
+    def _validate_state(cls, state: CommitStatus) -> CommitStatus:
         """
         Validates state of the commit status (if it can be used with forge).
         """

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -1343,17 +1343,6 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
-    def can_close_issue(self, username: str, issue: Issue) -> bool:
-        """
-        Args:
-            username: Username.
-            issue: Specific issue object.
-
-        Returns:
-            `True` if user can close given issue, `False` otherwise.
-        """
-        raise NotImplementedError()
-
     def can_merge_pr(self, username: str) -> bool:
         """
         Args:
@@ -1445,59 +1434,6 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
-    def _get_all_issue_comments(self, issue_id: int) -> List["IssueComment"]:
-        """
-        Get list of all issue comments.
-
-        Args:
-            issue_id: ID of the issue.
-
-        Returns:
-            List of all comments on the issue.
-        """
-        raise NotImplementedError()
-
-    def get_issue_comments(
-        self,
-        issue_id: int,
-        filter_regex: Optional[str] = None,
-        reverse: bool = False,
-        author: Optional[str] = None,
-    ) -> List["IssueComment"]:
-        """
-        Get list of issue comments.
-
-        Args:
-            issue_id: ID of the issue.
-            filter_regex: Filter the comments' content with `re.search`.
-
-                Defaults to `None`, which means no filtering.
-            reverse: Whether the comments are to be returned in
-                reversed order.
-
-                Defaults to `False`.
-            author: Filter the comments by author.
-
-                Defaults to `None`, which means no filtering.
-
-        Returns:
-            List of issue comments.
-        """
-        raise NotImplementedError()
-
-    def issue_comment(self, issue_id: int, body: str) -> "IssueComment":
-        """
-        Add new comment to the issue.
-
-        Args:
-            issue_id: ID of the issue to comment on.
-            body: Body of the comment.
-
-        Returns:
-            Object that represents newly created issue comment.
-        """
-        raise NotImplementedError()
-
     def create_issue(
         self,
         title: str,
@@ -1530,40 +1466,6 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
-    def issue_close(self, issue_id: int) -> Issue:
-        """
-        Close the issue.
-
-        Args:
-            issue_id: ID of the issue to close.
-
-        Returns:
-            Issue object that was closed.
-        """
-        raise NotImplementedError()
-
-    def get_issue_labels(self, issue_id: int) -> List[Any]:
-        """
-        Get list of labels on the issue.
-
-        Args:
-            issue_id: ID of the pull request.
-
-        Returns:
-            List of issue labels.
-        """
-        raise NotImplementedError()
-
-    def add_issue_labels(self, issue_id: int, labels: List[str]) -> None:
-        """
-        Add labels to the issue.
-
-        Args:
-            issue_id: ID of the issue that is to be modified.
-            labels: List of labels that are to be added.
-        """
-        raise NotImplementedError()
-
     def get_pr_list(self, status: PRStatus = PRStatus.open) -> List["PullRequest"]:
         """
         List of pull requests.
@@ -1587,38 +1489,6 @@ class GitProject(OgrAbstractClass):
 
         Returns:
             Object that represents requested pull request.
-        """
-        raise NotImplementedError()
-
-    def get_pr_info(self, pr_id: int) -> "PullRequest":
-        """
-        Get pull request info.
-
-        Args:
-            pr_id: ID of the pull request.
-
-        Returns:
-            Object that represents requested pull request.
-        """
-        raise NotImplementedError()
-
-    def update_pr_info(
-        self, pr_id: int, title: Optional[str] = None, description: Optional[str] = None
-    ) -> PullRequest:
-        """
-        Update pull request information.
-
-        Args:
-            pr_id: The ID of the pull request.
-            title: The new title of the pull request.
-
-                Defaults to `None`, which means title is not being updated.
-            description: The description of the pull request.
-
-                Defaults to `None`, which means description is not being updated.
-
-        Returns:
-            Pull request object that represents updated pull request.
         """
         raise NotImplementedError()
 
@@ -1678,108 +1548,6 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
-    def _get_all_pr_comments(self, pr_id: int) -> List[PRComment]:
-        """
-        Get list of all pull request comments.
-
-        Args:
-            pr_id: ID of the pull request.
-
-        Returns:
-            List of all comments on the pull request.
-        """
-        raise NotImplementedError()
-
-    def get_pr_comments(
-        self,
-        pr_id: int,
-        filter_regex: Optional[str] = None,
-        reverse: bool = False,
-        author: Optional[str] = None,
-    ) -> List["PRComment"]:
-        """
-        Get list of pull request comments.
-
-        Args:
-            pr_id: ID of the pull request.
-            filter_regex: Filter the comments' content with `re.search`.
-
-                Defaults to `None`, which means no filtering.
-            reverse: Whether the comments are to be returned in
-                reversed order.
-
-                Defaults to `False`.
-            author: Filter the comments by author.
-
-                Defaults to `None`, which means no filtering.
-
-        Returns:
-            List of pull request comments.
-        """
-        raise NotImplementedError()
-
-    def get_all_pr_commits(self, pr_id: int) -> List[str]:
-        """
-        Get all commits on requested pull request.
-
-        Args:
-            pr_id: ID of the pull request.
-
-        Returns:
-            List of the commit hashes.
-        """
-        raise NotImplementedError()
-
-    def search_in_pr(
-        self,
-        pr_id: int,
-        filter_regex: str,
-        reverse: bool = False,
-        description: bool = True,
-    ) -> Optional[Match[str]]:
-        """
-        Find match in pull request description or comments.
-
-        Args:
-            pr_id: ID of the pull request to search in.
-            filter_regex: Regex that is used to filter the comments' content with `re.search`.
-            reverse: Reverse order of the comments.
-
-                Defaults to `False`.
-            description: Whether description is included in the search.
-
-                Defaults to `True`.
-
-        Returns:
-            `re.Match` if found, `None` otherwise.
-        """
-        raise NotImplementedError()
-
-    def pr_create(
-        self,
-        title: str,
-        body: str,
-        target_branch: str,
-        source_branch: str,
-        fork_username: str = None,
-    ) -> "PullRequest":
-        """
-        Create new pull request.
-
-        Args:
-            title: Title of the pull request.
-            body: Description of the pull request.
-            target_branch: Name of the branch where the changes are merged.
-            source_branch: Name of the branch from which the changes are pulled.
-            fork_username: The username of forked repository.
-
-                Defaults to `None`.
-
-        Returns:
-            Object that represents newly created pull request.
-        """
-        raise NotImplementedError()
-
     def create_pr(
         self,
         title: str,
@@ -1802,35 +1570,6 @@ class GitProject(OgrAbstractClass):
 
         Returns:
             Object that represents newly created pull request.
-        """
-        raise NotImplementedError()
-
-    def pr_comment(
-        self,
-        pr_id: int,
-        body: str,
-        commit: Optional[str] = None,
-        filename: Optional[str] = None,
-        row: Optional[int] = None,
-    ) -> "PRComment":
-        """
-        Add new comment to the pull request.
-
-        Args:
-            pr_id: ID of the pull request to comment on.
-            body: Body of the comment.
-            commit: Commit hash, if comment is related to specific commit.
-
-                Defaults to `None`, which means normal comment on the pull request.
-            filename: Name of the file that is related to the comment.
-
-                Defaults to `None`, which means no relation to file.
-            row: Number of the row that the comment is related to.
-
-                Defaults to `None`, which means no relation to the row.
-
-        Returns:
-            Object that represents newly created PR comment.
         """
         raise NotImplementedError()
 
@@ -1895,52 +1634,6 @@ class GitProject(OgrAbstractClass):
 
         Returns:
             List of all commit statuses on the commit.
-        """
-        raise NotImplementedError()
-
-    def pr_close(self, pr_id: int) -> "PullRequest":
-        """
-        Close the pull request.
-
-        Args:
-            pr_id: ID of the pull request to close.
-
-        Returns:
-            Pull request object that was closed.
-        """
-        raise NotImplementedError()
-
-    def pr_merge(self, pr_id: int) -> "PullRequest":
-        """
-        Merge the pull request.
-
-        Args:
-            pr_id: ID of the pull request to merge.
-
-        Returns:
-            Pull request object that was merged.
-        """
-        raise NotImplementedError()
-
-    def get_pr_labels(self, pr_id: int) -> List[Any]:
-        """
-        Get list of labels on the pull request.
-
-        Args:
-            pr_id: ID of the pull request.
-
-        Returns:
-            List of PR labels.
-        """
-        raise NotImplementedError()
-
-    def add_pr_labels(self, pr_id: int, labels: List[str]) -> None:
-        """
-        Add labels to the pull request.
-
-        Args:
-            pr_id: ID of the pull request that is to be modified.
-            labels: List of labels that are to be added.
         """
         raise NotImplementedError()
 

--- a/ogr/read_only.py
+++ b/ogr/read_only.py
@@ -17,7 +17,6 @@ from ogr.abstract import (
     CommitStatus,
 )
 from ogr.constant import DEFAULT_RO_PREFIX_STRING
-from ogr.deprecation import deprecate_and_set_removal
 
 
 def log_output(
@@ -166,29 +165,6 @@ class GitProjectReadOnly:
     url = "url://ReadOnlyURL"
 
     @classmethod
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use create_pr",
-    )
-    def pr_create(
-        cls,
-        original_object: Any,
-        title: str,
-        body: str,
-        target_branch: str,
-        source_branch: str,
-        fork_username: str = None,
-    ) -> "PullRequest":
-        return GitProjectReadOnly.create_pr(
-            original_object=original_object,
-            title=title,
-            body=body,
-            target_branch=target_branch,
-            source_branch=source_branch,
-        )
-
-    @classmethod
     def create_pr(
         cls,
         original_object: Any,
@@ -220,7 +196,7 @@ class GitProjectReadOnly:
         filename: str = None,
         row: int = None,
     ) -> "PRComment":
-        pull_request = original_object.get_pr_info(pr_id)
+        pull_request = original_object.get_pr(pr_id)
         log_output(pull_request)
         return PRComment(
             parent=pull_request,
@@ -232,13 +208,13 @@ class GitProjectReadOnly:
 
     @classmethod
     def pr_close(cls, original_object: Any, pr_id: int) -> "PullRequest":
-        pull_request = original_object.get_pr_info(pr_id)
+        pull_request = original_object.get_pr(pr_id)
         pull_request._status = PRStatus.closed
         return pull_request
 
     @classmethod
     def pr_merge(cls, original_object: Any, pr_id: int) -> "PullRequest":
-        pull_request = original_object.get_pr_info(pr_id)
+        pull_request = original_object.get_pr(pr_id)
         pull_request._status = PRStatus.merged
         return pull_request
 
@@ -246,7 +222,7 @@ class GitProjectReadOnly:
     def issue_comment(
         cls, original_object: Any, issue_id: int, body: str
     ) -> "IssueComment":
-        issue = original_object.get_issue_info(issue_id)
+        issue = original_object.get_issue(issue_id)
         log_output(issue)
         return IssueComment(
             parent=issue,

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -1,14 +1,12 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import datetime
 from typing import List, Optional, Any
 
 from ogr.abstract import (
     GitService,
     GitProject,
     GitUser,
-    PRStatus,
     IssueComment,
     Issue,
     PullRequest,
@@ -48,62 +46,6 @@ class BaseGitProject(GitProject):
 
 
 class BasePullRequest(PullRequest):
-    def __init__(self, raw_pr: Any, project: "GitProject") -> None:
-        self._raw_pr = raw_pr
-        self._target_project = project
-
-    @property
-    def title(self) -> str:
-        raise NotImplementedError()
-
-    @title.setter
-    def title(self, new_title: str) -> None:
-        raise NotImplementedError()
-
-    @property
-    def id(self) -> int:
-        raise NotImplementedError()
-
-    @property
-    def status(self) -> PRStatus:
-        raise NotImplementedError()
-
-    @property
-    def url(self) -> str:
-        raise NotImplementedError()
-
-    @property
-    def description(self) -> str:
-        raise NotImplementedError()
-
-    @description.setter
-    def description(self, new_description: str) -> None:
-        raise NotImplementedError
-
-    @property
-    def author(self) -> str:
-        raise NotImplementedError()
-
-    @property
-    def source_branch(self) -> str:
-        raise NotImplementedError()
-
-    @property
-    def target_branch(self) -> str:
-        raise NotImplementedError()
-
-    @property
-    def created(self) -> datetime.datetime:
-        raise NotImplementedError()
-
-    @property
-    def labels(self) -> List[Any]:
-        raise NotImplementedError()
-
-    @property
-    def target_project(self) -> "GitProject":
-        return self._target_project
-
     def get_comments(
         self, filter_regex: str = None, reverse: bool = False, author: str = None
     ):

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -2,13 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import datetime
-from typing import List, Optional, Match, Any
+from typing import List, Optional, Any
 
 from ogr.abstract import (
     GitService,
     GitProject,
     GitUser,
-    PRComment,
     PRStatus,
     IssueComment,
     Issue,
@@ -16,10 +15,8 @@ from ogr.abstract import (
     CommitFlag,
     CommitStatus,
 )
-from ogr.deprecation import deprecate_and_set_removal
 from ogr.exceptions import OgrException
 from ogr.parsing import parse_git_repo
-from ogr.read_only import if_readonly, GitProjectReadOnly
 from ogr.utils import search_in_comments, filter_comments
 
 try:
@@ -48,208 +45,6 @@ class BaseGitProject(GitProject):
     @property
     def full_repo_name(self) -> str:
         return f"{self.namespace}/{self.repo}"
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def get_pr_comments(
-        self, pr_id, filter_regex: str = None, reverse: bool = False, author: str = None
-    ) -> List[PRComment]:
-        return self.get_pr(pr_id).get_comments(filter_regex, reverse, author)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def search_in_pr(
-        self,
-        pr_id: int,
-        filter_regex: str,
-        reverse: bool = False,
-        description: bool = True,
-    ) -> Optional[Match[str]]:
-        return self.get_pr(pr_id).search(filter_regex, reverse, description)
-
-    @if_readonly(return_function=GitProjectReadOnly.pr_close)
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def pr_close(self, pr_id: int) -> "PullRequest":
-        return self.get_pr(pr_id).close()
-
-    @if_readonly(return_function=GitProjectReadOnly.pr_merge)
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def pr_merge(self, pr_id: int) -> "PullRequest":
-        return self.get_pr(pr_id).merge()
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def get_pr_labels(self, pr_id: int) -> List[Any]:
-        return self.get_pr(pr_id).labels
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def add_pr_labels(self, pr_id: int, labels: List[str]) -> None:
-        return self.get_pr(pr_id).add_label(*labels)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def get_pr_info(self, pr_id: int) -> "PullRequest":
-        return self.get_pr(pr_id)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def update_pr_info(
-        self, pr_id: int, title: Optional[str] = None, description: Optional[str] = None
-    ) -> "PullRequest":
-        return self.get_pr(pr_id).update_info(title, description)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def get_all_pr_commits(self, pr_id: int) -> List[str]:
-        return self.get_pr(pr_id).get_all_commits()
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def _get_all_pr_comments(self, pr_id: int) -> List[PRComment]:
-        return self.get_pr(pr_id)._get_all_comments()
-
-    @if_readonly(
-        return_function=GitProjectReadOnly.pr_comment,
-        log_message="Create Comment to PR",
-    )
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on PullRequest objects",
-    )
-    def pr_comment(
-        self,
-        pr_id: int,
-        body: str,
-        commit: str = None,
-        filename: str = None,
-        row: int = None,
-    ) -> PRComment:
-        return self.get_pr(pr_id).comment(body, commit, filename, row)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def get_issue_comments(
-        self,
-        issue_id,
-        filter_regex: str = None,
-        reverse: bool = False,
-        author: str = None,
-    ) -> List[IssueComment]:
-        return self.get_issue(issue_id).get_comments(filter_regex, reverse, author)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use create_pr",
-    )
-    def pr_create(
-        self,
-        title: str,
-        body: str,
-        target_branch: str,
-        source_branch: str,
-        fork_username: str = None,
-    ) -> "PullRequest":
-        return self.create_pr(
-            title=title,
-            body=body,
-            target_branch=target_branch,
-            source_branch=source_branch,
-            fork_username=fork_username,
-        )
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def can_close_issue(self, username: str, issue: Issue) -> bool:
-        return issue.can_close(username)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def get_issue_info(self, issue_id: int) -> Issue:
-        return self.get_issue(issue_id)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def _get_all_issue_comments(self, issue_id: int) -> List["IssueComment"]:
-        return self.get_issue(issue_id)._get_all_comments()
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def issue_comment(self, issue_id: int, body: str) -> "IssueComment":
-        return self.get_issue(issue_id).comment(body)
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def issue_close(self, issue_id: int) -> Issue:
-        return self.get_issue(issue_id).close()
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def get_issue_labels(self, issue_id: int) -> List[Any]:
-        return self.get_issue(issue_id).labels
-
-    @deprecate_and_set_removal(
-        since="0.9.0",
-        remove_in="0.14.0 (or 1.0.0 if it comes sooner)",
-        message="Use methods on Issue objects",
-    )
-    def add_issue_labels(self, issue_id: int, labels: List[str]) -> None:
-        self.get_issue(issue_id).add_label(*labels)
 
 
 class BasePullRequest(PullRequest):

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -310,14 +310,6 @@ class BasePullRequest(PullRequest):
     def target_project(self) -> "GitProject":
         return self._target_project
 
-    @property
-    def project(self) -> "GitProject":
-        warnings.warn(
-            "Using deprecated property, that will be removed in 0.16.0"
-            " (or 1.0.0 if it comes sooner). Please use target_project."
-        )
-        return self.target_project
-
     def get_comments(
         self, filter_regex: str = None, reverse: bool = False, author: str = None
     ):

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import datetime
-from typing import List, Optional, Match, Any, Union
-import warnings
+from typing import List, Optional, Match, Any
 
 from ogr.abstract import (
     GitService,
@@ -357,14 +356,7 @@ class BaseCommitFlag(CommitFlag):
         return cls._states[state]
 
     @classmethod
-    def _validate_state(cls, state: Union[CommitStatus, str]) -> CommitStatus:
-        if isinstance(state, str):
-            warnings.warn(
-                "Using the string representation of commit states, that will be removed in 0.14.0"
-                " (or 1.0.0 if it comes sooner). Please use CommitStatus enum instead. "
-            )
-            state = cls._state_from_str(state)
-
+    def _validate_state(cls, state: CommitStatus) -> CommitStatus:
         if state not in cls._states.values():
             raise ValueError("Invalid state given")
 

--- a/ogr/services/github/flag.py
+++ b/ogr/services/github/flag.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import datetime
-from typing import List, Union
+from typing import List
 
 from github import UnknownObjectException
 
@@ -47,7 +47,7 @@ class GithubCommitFlag(BaseCommitFlag):
     def set(
         project: "ogr_github.GithubProject",
         commit: str,
-        state: Union[CommitStatus, str],
+        state: CommitStatus,
         target_url: str,
         description: str,
         context: str,

--- a/ogr/services/gitlab/flag.py
+++ b/ogr/services/gitlab/flag.py
@@ -3,7 +3,7 @@
 
 import logging
 import datetime
-from typing import List, Union
+from typing import List
 
 import gitlab
 
@@ -66,7 +66,7 @@ class GitlabCommitFlag(BaseCommitFlag):
     def set(
         project: "ogr_gitlab.GitlabProject",
         commit: str,
-        state: Union[CommitStatus, str],
+        state: CommitStatus,
         target_url: str,
         description: str,
         context: str,

--- a/ogr/services/pagure/flag.py
+++ b/ogr/services/pagure/flag.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import datetime
-from typing import List, Dict, Any, Union
+from typing import List, Dict, Any
 
 
 from ogr.abstract import CommitFlag, CommitStatus
@@ -41,7 +41,7 @@ class PagureCommitFlag(BaseCommitFlag):
     def set(
         project: "ogr_pagure.PagureProject",
         commit: str,
-        state: Union[CommitStatus, str],
+        state: CommitStatus,
         target_url: str,
         description: str,
         context: str,

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -236,7 +236,9 @@ class PagurePullRequest(BasePullRequest):
         self.__call_api("comment", method="POST", data=payload)
         self.__dirty = True
         return PagurePRComment(
-            parent=self, body=body, author=self.project.service.user.get_username()
+            parent=self,
+            body=body,
+            author=self.target_project.service.user.get_username(),
         )
 
     def close(self) -> "PullRequest":


### PR DESCRIPTION
Cleanup of methods and properties which have been marked as deprecated for a long time

Related to https://github.com/packit/packit-service/pull/1262

Merge before/after

---
Methods which have been marked as deprecated and should have already been removed in version 0.14.0 are now removed.