### PR TITLE
Fix flexmock imports

### DIFF
--- a/tests/integration/github/test_retries.py
+++ b/tests/integration/github/test_retries.py
@@ -1,6 +1,10 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 import pytest
+
 from ogr import GithubService
-import flexmock
+from flexmock import flexmock
 from urllib3.connectionpool import HTTPSConnectionPool
 from github.GithubException import BadCredentialsException
 from github import Github


### PR DESCRIPTION
Support for plain 'import flexmock' was removed in [flexmock 0.11.0].
Get ready for this.

[flexmock 0.11.0]: https://flexmock.readthedocs.io/en/latest/changelog/#release-0110

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>