### PR TITLE
Add PagurePullRequest.get_comment by its id

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -34,7 +34,6 @@ In case you find any error, please [create a new issue](https://github.com/packi
 | `add_label`       |   ✔    |   ✔    |   ✘    |
 | `get_all_commits` |   ✔    |   ✔    |   ✘    |
 | `labels`          |   ✔    |   ✔    |   ✘    |
-| `get_comment`     |   ✔    |   ✔    |   ✘    |
 
 ## Release
 

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -125,6 +125,7 @@ class Comment(OgrAbstractClass):
         raw_comment: Optional[Any] = None,
         parent: Optional[Any] = None,
         body: Optional[str] = None,
+        id_: Optional[int] = None,
         author: Optional[str] = None,
         created: Optional[datetime.datetime] = None,
         edited: Optional[datetime.datetime] = None,
@@ -133,6 +134,7 @@ class Comment(OgrAbstractClass):
             self._from_raw_comment(raw_comment)
         elif body and author:
             self._body = body
+            self._id = id_
             self._author = author
             self._created = created
             self._edited = edited
@@ -163,6 +165,10 @@ class Comment(OgrAbstractClass):
     @body.setter
     def body(self, new_body: str) -> None:
         self._body = new_body
+
+    @property
+    def id(self) -> int:
+        return self._id
 
     @property
     def author(self) -> str:

--- a/ogr/services/github/comments.py
+++ b/ogr/services/github/comments.py
@@ -8,7 +8,7 @@ from github.IssueComment import IssueComment as _GithubIssueComment
 from github.PullRequestComment import PullRequestComment as _GithubPullRequestComment
 from github.Reaction import Reaction as _Reaction
 
-from ogr.abstract import IssueComment, PRComment, Reaction
+from ogr.abstract import Comment, IssueComment, PRComment, Reaction
 
 
 class GithubReaction(Reaction):
@@ -21,11 +21,12 @@ class GithubReaction(Reaction):
         self._raw_reaction.delete()
 
 
-class GithubComment:
+class GithubComment(Comment):
     def _from_raw_comment(
         self, raw_comment: Union[_GithubIssueComment, _GithubPullRequestComment]
     ) -> None:
         self._raw_comment = raw_comment
+        self._id = raw_comment.id
         self._author = raw_comment.user.login
         self._created = raw_comment.created_at
 

--- a/ogr/services/gitlab/comments.py
+++ b/ogr/services/gitlab/comments.py
@@ -13,7 +13,7 @@ from gitlab.v4.objects import (
     ProjectMergeRequestAwardEmoji,
 )
 
-from ogr.abstract import IssueComment, PRComment, Reaction
+from ogr.abstract import Comment, IssueComment, PRComment, Reaction
 from ogr.exceptions import GitlabAPIException
 
 logger = logging.getLogger(__name__)
@@ -29,11 +29,12 @@ class GitlabReaction(Reaction):
         self._raw_reaction.delete()
 
 
-class GitlabComment:
+class GitlabComment(Comment):
     def _from_raw_comment(
         self, raw_comment: Union[ProjectIssueNote, ProjectMergeRequestNote]
     ) -> None:
         self._raw_comment = raw_comment
+        self._id = raw_comment.get_id()
         self._author = raw_comment.author["username"]
         self._created = raw_comment.created_at
 

--- a/ogr/services/pagure/comments.py
+++ b/ogr/services/pagure/comments.py
@@ -11,6 +11,7 @@ from ogr.exceptions import OperationNotSupported
 class PagureComment(Comment):
     def _from_raw_comment(self, raw_comment: Dict[str, Any]) -> None:
         self._body = raw_comment["comment"]
+        self._id = raw_comment["id"]
         self._author = raw_comment["user"]["name"]
         self._created = self.__datetime_from_timestamp(raw_comment["date_created"])
         self._edited = self.__datetime_from_timestamp(raw_comment["edited_on"])

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -302,3 +302,12 @@ class PagurePullRequest(BasePullRequest):
         if uid is not None:
             data["uid"] = uid
         return self.__call_api("flag", method="POST", data=data)
+
+    def get_comment(self, comment_id: int) -> PRComment:
+        for comment in self._get_all_comments():
+            if comment.id == comment_id:
+                return comment
+
+        raise PagureAPIException(
+            f"No comment with id#{comment_id} in PR#{self.id} found."
+        )

--- a/tests/integration/pagure/test_data/test_pull_requests/PullRequests.test_get_comment.yaml
+++ b/tests/integration/pagure/test_data/test_pull_requests/PullRequests.test_get_comment.yaml
@@ -1,0 +1,215 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://pagure.io/api/0/ogr-tests/pull-request/5:
+      - metadata:
+          latency: 0.4050896167755127
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_pull_requests
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.pull_request
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            assignee: null
+            branch: master
+            branch_from: test_pr
+            cached_merge_status: unknown
+            closed_at: '1574794962'
+            closed_by:
+              full_url: https://pagure.io/user/mfocko
+              fullname: Matej Focko
+              name: mfocko
+              url_path: user/mfocko
+            comments:
+            - comment: Pull-Request has been merged by mfocko
+              commit: null
+              date_created: '1574794962'
+              edited_on: null
+              editor: null
+              filename: null
+              id: 103456
+              line: null
+              notification: true
+              parent: null
+              reactions: {}
+              tree: null
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            - comment: "Billy: what the hell is going on up there?\r\nBilly: hey Ron\r\
+                \nRon: hey Billy!\r\nRon: ...that hurt\r\n"
+              commit: null
+              date_created: '1638270677'
+              edited_on: null
+              editor: null
+              filename: null
+              id: 162373
+              line: null
+              notification: false
+              parent: null
+              reactions: {}
+              tree: null
+              user:
+                full_url: https://pagure.io/user/nikromen
+                fullname: Jiri Kyjovsky
+                name: nikromen
+                url_path: user/nikromen
+            commit_start: 517121273b142293807606dbd7a2e0f514b21cc8
+            commit_stop: 517121273b142293807606dbd7a2e0f514b21cc8
+            date_created: '1574794929'
+            full_url: https://pagure.io/ogr-tests/pull-request/5
+            id: 5
+            initial_comment: ''
+            last_updated: '1638270677'
+            project:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin:
+                - jscotka
+                - lbarczio
+                - mfocko
+                - nikromen
+                collaborator: []
+                commit: []
+                owner:
+                - lachmanfrantisek
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1570568389'
+              date_modified: '1638271116'
+              description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/ogr-tests
+              fullname: ogr-tests
+              id: 6826
+              milestones: {}
+              name: ogr-tests
+              namespace: null
+              parent: null
+              priorities: {}
+              tags: []
+              url_path: ogr-tests
+              user:
+                full_url: https://pagure.io/user/lachmanfrantisek
+                fullname: "Franti\u0161ek Lachman"
+                name: lachmanfrantisek
+                url_path: user/lachmanfrantisek
+            remote_git: null
+            repo_from: null
+            status: Merged
+            tags: []
+            threshold_reached: null
+            title: Test PR
+            uid: 7aa9105db74241e18a268d0fccb6bd86
+            updated_on: '1638270677'
+            user:
+              full_url: https://pagure.io/user/mfocko
+              fullname: Matej Focko
+              name: mfocko
+              url_path: user/mfocko
+          _next: null
+          elapsed: 0.404392
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '3140'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-QUYZf73joORsUyNK2kZ2IGShx';
+              style-src 'self' 'nonce-QUYZf73joORsUyNK2kZ2IGShx'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Tue, 30 Nov 2021 11:32:47 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZDg4NzliMGJiZjRjZjhkZTkwM2RjNDIwZGU3MmJkZmEwMmMyOTU4MSJ9.FIedXw.JMYYghgo7Z1zqhBvZ3SxOT8ftqw;
+              Expires=Fri, 31-Dec-2021 11:32:47 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://pagure.io/api/0/-/whoami:
+      - metadata:
+          latency: 0.7755906581878662
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_pull_requests
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: nikromen
+          _next: null
+          elapsed: 0.77499
+          encoding: null
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '29'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-ylQ8Fk6Fl5lu0QRPzi37NSf2B';
+              style-src 'self' 'nonce-ylQ8Fk6Fl5lu0QRPzi37NSf2B'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Tue, 30 Nov 2021 11:32:47 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZDg4NzliMGJiZjRjZjhkZTkwM2RjNDIwZGU3MmJkZmEwMmMyOTU4MSJ9.FIedXw.JMYYghgo7Z1zqhBvZ3SxOT8ftqw;
+              Expires=Fri, 31-Dec-2021 11:32:47 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/pagure/test_pull_requests.py
+++ b/tests/integration/pagure/test_pull_requests.py
@@ -105,3 +105,7 @@ class PullRequests(PagureTests):
         assert (
             pr.commits_url == "https://pagure.io/ogr-tests/pull-request/5#commit_list"
         )
+
+    def test_get_comment(self):
+        comment = self.ogr_project.get_pr(5).get_comment(comment_id=162373)
+        assert "Billy: what the hell is going on up there?" in comment.body


### PR DESCRIPTION
I want to implement this even Pagure API doesn't support it because this will solve annoying thing in packit-service for me - we have `comment_object` for github and gitlab and pagure but not for pagure PR :see_no_evil: 

Related to #640 

(i am uncertain if the release note below is useful for users but I'll write it down anyway just to be sure)

---

OGR now fully supports getting PR comments by its id.