### PR TITLE
Correctly convert projects in GitlabService.list_projects()

### DIFF
--- a/ogr/services/gitlab/service.py
+++ b/ogr/services/gitlab/service.py
@@ -151,7 +151,6 @@ class GitlabService(BaseGitService):
             GitlabProject(
                 repo=project.attributes["path"],
                 namespace=project.attributes["namespace"]["full_path"],
-                gitlab_repo=project,
                 service=self,
             )
             for project in projects_to_convert

--- a/tests/integration/gitlab/test_data/test_service/Service.test_list_projects_get_forks.yaml
+++ b/tests/integration/gitlab/test_data/test_service/Service.test_list_projects_get_forks.yaml
@@ -1,0 +1,3065 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/groups/470642/projects:
+      - metadata:
+          latency: 1.004972219467163
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_service
+          - ogr.abstract
+          - ogr.services.gitlab.service
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - _links:
+              events: https://gitlab.com/api/v4/projects/27055706/events
+              issues: https://gitlab.com/api/v4/projects/27055706/issues
+              labels: https://gitlab.com/api/v4/projects/27055706/labels
+              members: https://gitlab.com/api/v4/projects/27055706/members
+              merge_requests: https://gitlab.com/api/v4/projects/27055706/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/27055706/repository/branches
+              self: https://gitlab.com/api/v4/projects/27055706
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/27055706/HiMXBhfcnEhRyWydQ.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: ''
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: true
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 1d
+              enabled: false
+              keep_n: 10
+              name_regex: .*
+              name_regex_keep: null
+              next_run_at: '2021-06-01T17:40:38.014Z'
+              older_than: 90d
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-board
+            created_at: '2021-05-31T17:40:37.973Z'
+            creator_id: 401528
+            default_branch: main
+            description: Inkscape board issues
+            emails_disabled: null
+            empty_repo: true
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 0
+            http_url_to_repo: https://gitlab.com/inkscape/inkscape-board.git
+            id: 27055706
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-10-08T04:17:43.430Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: Inkscape Board
+            name_with_namespace: Inkscape / Inkscape Board
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 1
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: inkscape-board
+            path_with_namespace: inkscape/inkscape-board
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: null
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-board.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/inkscape-board
+            wiki_access_level: enabled
+            wiki_enabled: true
+          - _links:
+              events: https://gitlab.com/api/v4/projects/23168514/events
+              issues: https://gitlab.com/api/v4/projects/23168514/issues
+              labels: https://gitlab.com/api/v4/projects/23168514/labels
+              members: https://gitlab.com/api/v4/projects/23168514/members
+              merge_requests: https://gitlab.com/api/v4/projects/23168514/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/23168514/repository/branches
+              self: https://gitlab.com/api/v4/projects/23168514
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/23168514/inkscape-themes.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: ''
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: true
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 1d
+              enabled: false
+              keep_n: 10
+              name_regex: .*
+              name_regex_keep: null
+              next_run_at: '2020-12-18T14:48:10.089Z'
+              older_than: 90d
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/inkscape/themes
+            created_at: '2020-12-17T14:48:10.058Z'
+            creator_id: 401528
+            default_branch: master
+            description: This repository contains all the extra themes we want to
+              test and ship in Inkscape. It works like the extensions repository inviting
+              more non-technical users/designers to get involved and permission to
+              modify things.
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 6
+            http_url_to_repo: https://gitlab.com/inkscape/themes.git
+            id: 23168514
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-11-11T01:53:09.167Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: themes
+            name_with_namespace: Inkscape / themes
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 4
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: themes
+            path_with_namespace: inkscape/themes
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/themes/-/blob/master/README.md
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups:
+            - expires_at: null
+              group_access_level: 40
+              group_full_path: inkscape/bug-wranglers
+              group_id: 4445779
+              group_name: Inkscape Bug Wranglers
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/themes.git
+            star_count: 1
+            suggestion_commit_message: null
+            tag_list:
+            - app
+            - css
+            - gtk
+            - themes
+            topics:
+            - app
+            - css
+            - gtk
+            - themes
+            visibility: public
+            web_url: https://gitlab.com/inkscape/themes
+            wiki_access_level: enabled
+            wiki_enabled: true
+          - _links:
+              events: https://gitlab.com/api/v4/projects/20961968/events
+              issues: https://gitlab.com/api/v4/projects/20961968/issues
+              labels: https://gitlab.com/api/v4/projects/20961968/labels
+              members: https://gitlab.com/api/v4/projects/20961968/members
+              merge_requests: https://gitlab.com/api/v4/projects/20961968/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/20961968/repository/branches
+              self: https://gitlab.com/api/v4/projects/20961968
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/20961968/libcroco.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: ''
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: true
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 1d
+              enabled: false
+              keep_n: 10
+              name_regex: null
+              name_regex_keep: null
+              next_run_at: '2020-10-20T23:48:03.347Z'
+              older_than: 90d
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/inkscape/libcroco
+            created_at: '2020-09-06T09:08:26.440Z'
+            creator_id: 401528
+            default_branch: master
+            description: Libcroco is a standalone css2 parsing and manipulation library.
+              The parser provides a low level event driven SAC like api and a css
+              object model like api. Libcroco provides a CSS2 selection engine and
+              an experimental xml/css rendering engine.
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 2
+            http_url_to_repo: https://gitlab.com/inkscape/libcroco.git
+            id: 20961968
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-02-17T09:49:12.486Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: libcroco
+            name_with_namespace: Inkscape / libcroco
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 0
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: libcroco
+            path_with_namespace: inkscape/libcroco
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/libcroco/-/blob/master/README
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/libcroco.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/libcroco
+            wiki_access_level: enabled
+            wiki_enabled: true
+          - _links:
+              events: https://gitlab.com/api/v4/projects/16468356/events
+              issues: https://gitlab.com/api/v4/projects/16468356/issues
+              labels: https://gitlab.com/api/v4/projects/16468356/labels
+              members: https://gitlab.com/api/v4/projects/16468356/members
+              merge_requests: https://gitlab.com/api/v4/projects/16468356/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/16468356/repository/branches
+              self: https://gitlab.com/api/v4/projects/16468356
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/16468356/ux.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 7d
+              enabled: false
+              keep_n: null
+              name_regex: null
+              name_regex_keep: null
+              next_run_at: '2020-01-29T19:45:22.293Z'
+              older_than: null
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/inkscape/ux
+            created_at: '2020-01-22T19:45:22.267Z'
+            creator_id: 401528
+            default_branch: master
+            description: Design and user experience discussion, process, testing,
+              events and decision making.
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 3
+            http_url_to_repo: https://gitlab.com/inkscape/ux.git
+            id: 16468356
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-12-12T15:08:04.228Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: Inkscape UX
+            name_with_namespace: Inkscape / Inkscape UX
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 74
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ux
+            path_with_namespace: inkscape/ux
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/ux/-/blob/master/README.md
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/ux.git
+            star_count: 5
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/ux
+            wiki_access_level: enabled
+            wiki_enabled: true
+          - _links:
+              events: https://gitlab.com/api/v4/projects/10403243/events
+              issues: https://gitlab.com/api/v4/projects/10403243/issues
+              labels: https://gitlab.com/api/v4/projects/10403243/labels
+              members: https://gitlab.com/api/v4/projects/10403243/members
+              merge_requests: https://gitlab.com/api/v4/projects/10403243/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/10403243/repository/branches
+              self: https://gitlab.com/api/v4/projects/10403243
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/10403243/temp_inbox_mountain_envelope.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: disabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: disabled
+            container_registry_enabled: false
+            container_registry_image_prefix: registry.gitlab.com/inkscape/inbox
+            created_at: '2019-01-17T03:40:33.158Z'
+            creator_id: 266859
+            default_branch: master
+            description: This inbox is a "friendly feedback zone", we welcome questions,
+              comments, ideas, and bug reports that pertain to the Inkscape software,
+              its related components, and the project in general.
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 7
+            http_url_to_repo: https://gitlab.com/inkscape/inbox.git
+            id: 10403243
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: "<!--\r\n    See our full bug reporting guidelines at\
+              \ https://inkscape.org/contribute/report-bugs/\r\n    Writing a good\
+              \ bug report will ensure we'll be able to help efficiently. \U0001F642\
+              \r\n-->\r\n\r\n#### Summary:\r\n<!-- Summarize the issue/suggestion\
+              \ concisely: -->\r\n\r\n... (write here)\r\n\r\n#### Steps to reproduce:\r\
+              \n<!-- Describe what you did (step-by-step) so we can reproduce: -->\r\
+              \n\r\n- open Inkscape\r\n- ...\r\n\r\n#### What happened?\r\n\r\n...\r\
+              \n\r\n#### What should have happened?\r\n\r\n...\r\n\r\nSample attachments:\r\
+              \n\r\n<!-- Attach the sample file(s) highlighting the issue, if appropriate.\
+              \ -->\r\n\r\n#### Version info\r\n\r\n<!--\r\n    Open 'Help > About'\
+              \ and click on the little bug icon in the bottom right corner that copies\
+              \ the debug information to your clipboard. For command line users, run\
+              \ 'inkscape --debug-info'.\r\n\r\n    For Inkscape 1.0.2 and older,\
+              \ please manually add the Inkscape Version and Operating System Version.\
+              \ The Inkscape version is listed in the About dialog. For command line\
+              \ users, run 'inkscape -V'\r\n\r\n    Paste the information in the empty\
+              \ space between the apostrophes below:\r\n-->\r\n\r\n```\r\n\r\n\r\n\
+              \r\n```\r\n\r\n<!--\r\n    \u2764\uFE0F Thank you for filling in a new\
+              \ bug report, we appreciate the help! \u2764\uFE0F\r\n    Please be\
+              \ patient while we try to find the time to look into your issue.\r\n\
+              \    Remember that Inkscape is developed by volunteers in their spare\
+              \ time, we'll try our best to respond to all reports.\r\n-->\r\n\r\n\
+              <!--\r\n    Please be careful when/after writing #  for example in logs,\
+              \ code, or versions of linux\r\n    - use inline code span - single\
+              \ backticks (`) before and after it, like this - `#1618`\r\n    - use\
+              \ multi-line code block - triple backticks (```) to fence/enclose console\
+              \ logs\r\n    - attach long logs as a text file.\r\n-->\r\n"
+            jobs_enabled: false
+            keep_latest_artifact: true
+            last_activity_at: '2021-12-14T17:16:41.296Z'
+            lfs_enabled: false
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: Inbox
+            name_with_namespace: Inkscape / Inbox
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 1431
+            operations_access_level: enabled
+            packages_enabled: false
+            pages_access_level: disabled
+            path: inbox
+            path_with_namespace: inkscape/inbox
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: null
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: false
+            shared_runners_enabled: true
+            shared_with_groups:
+            - expires_at: null
+              group_access_level: 30
+              group_full_path: inkscape/devel
+              group_id: 4575604
+              group_name: Inkscape Developers
+            - expires_at: null
+              group_access_level: 40
+              group_full_path: inkscape/bug-wranglers
+              group_id: 4445779
+              group_name: Inkscape Bug Wranglers
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/inbox.git
+            star_count: 31
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/inbox
+            wiki_access_level: disabled
+            wiki_enabled: false
+          - _links:
+              events: https://gitlab.com/api/v4/projects/5833962/events
+              issues: https://gitlab.com/api/v4/projects/5833962/issues
+              labels: https://gitlab.com/api/v4/projects/5833962/labels
+              members: https://gitlab.com/api/v4/projects/5833962/members
+              merge_requests: https://gitlab.com/api/v4/projects/5833962/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/5833962/repository/branches
+              self: https://gitlab.com/api/v4/projects/5833962
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 1
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/5833962/addons.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: disabled
+            container_registry_enabled: false
+            container_registry_image_prefix: registry.gitlab.com/inkscape/extensions
+            created_at: '2018-03-22T00:29:09.053Z'
+            creator_id: 401528
+            default_branch: master
+            description: Python extensions for Inkscape core, separated out from main
+              repository.
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 87
+            http_url_to_repo: https://gitlab.com/inkscape/extensions.git
+            id: 5833962
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-12-13T23:57:06.316Z'
+            lfs_enabled: false
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: ''
+            merge_trains_enabled: false
+            mirror: false
+            name: extensions
+            name_with_namespace: Inkscape / extensions
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: true
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 117
+            operations_access_level: enabled
+            packages_enabled: false
+            pages_access_level: enabled
+            path: extensions
+            path_with_namespace: inkscape/extensions
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/extensions/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups:
+            - expires_at: null
+              group_access_level: 30
+              group_full_path: inkscape/devel
+              group_id: 4575604
+              group_name: Inkscape Developers
+            - expires_at: null
+              group_access_level: 30
+              group_full_path: inkscape/bug-wranglers
+              group_id: 4445779
+              group_name: Inkscape Bug Wranglers
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/extensions.git
+            star_count: 41
+            suggestion_commit_message: null
+            tag_list:
+            - addin
+            - additional
+            - addon
+            - core
+            - extension
+            - inkscape
+            - python
+            topics:
+            - addin
+            - additional
+            - addon
+            - core
+            - extension
+            - inkscape
+            - python
+            visibility: public
+            web_url: https://gitlab.com/inkscape/extensions
+            wiki_access_level: enabled
+            wiki_enabled: true
+          - _links:
+              events: https://gitlab.com/api/v4/projects/3507798/events
+              issues: https://gitlab.com/api/v4/projects/3507798/issues
+              labels: https://gitlab.com/api/v4/projects/3507798/labels
+              members: https://gitlab.com/api/v4/projects/3507798/members
+              merge_requests: https://gitlab.com/api/v4/projects/3507798/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/3507798/repository/branches
+              self: https://gitlab.com/api/v4/projects/3507798
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: disabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-ci-docker
+            created_at: '2017-06-15T03:46:48.634Z'
+            creator_id: 402261
+            default_branch: master
+            description: CI Base Image for Inkscape builds
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 16
+            http_url_to_repo: https://gitlab.com/inkscape/inkscape-ci-docker.git
+            id: 3507798
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-11-22T21:09:35.721Z'
+            lfs_enabled: false
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: ff
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: ''
+            merge_trains_enabled: false
+            mirror: false
+            name: inkscape-ci-docker
+            name_with_namespace: Inkscape / inkscape-ci-docker
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 1
+            operations_access_level: disabled
+            packages_enabled: false
+            pages_access_level: disabled
+            path: inkscape-ci-docker
+            path_with_namespace: inkscape/inkscape-ci-docker
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/inkscape-ci-docker/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: null
+            shared_runners_enabled: true
+            shared_with_groups:
+            - expires_at: null
+              group_access_level: 30
+              group_full_path: inkscape/devel
+              group_id: 4575604
+              group_name: Inkscape Developers
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-ci-docker.git
+            star_count: 6
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/inkscape-ci-docker
+            wiki_access_level: disabled
+            wiki_enabled: false
+          - _links:
+              events: https://gitlab.com/api/v4/projects/3472737/events
+              issues: https://gitlab.com/api/v4/projects/3472737/issues
+              labels: https://gitlab.com/api/v4/projects/3472737/labels
+              members: https://gitlab.com/api/v4/projects/3472737/members
+              merge_requests: https://gitlab.com/api/v4/projects/3472737/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/3472737/repository/branches
+              self: https://gitlab.com/api/v4/projects/3472737
+            allow_merge_on_skipped_pipeline: false
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/3472737/inkscape.png
+            build_coverage_regex: ''
+            build_timeout: 18600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: disabled
+            container_registry_enabled: false
+            container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape
+            created_at: '2017-06-09T14:16:35.615Z'
+            creator_id: 402261
+            default_branch: master
+            description: Inkscape vector image editor
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 874
+            http_url_to_repo: https://gitlab.com/inkscape/inkscape.git
+            id: 3472737
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: "<!-- Please report new issues at https://inkscape.org/report;\
+              \ this tracker is for staff-confirmed issues only.\r\n     See our full\
+              \ bug reporting guidelines at https://inkscape.org/contribute/report-bugs/\
+              \ -->\r\n\r\n#### Steps to reproduce:\r\n<!-- Describe what you did\
+              \ (step-by-step) so we can reproduce: -->\r\n\r\n- open Inkscape\r\n\
+              - ...\r\n\r\n#### What happened?\r\n\r\n...\r\n\r\n#### What should\
+              \ have happened?\r\n\r\n...\r\n\r\n#### Inkscape Version and Operating\
+              \ System:\r\n\r\n- Inkscape Version: ... <!-- (run inkscape -V or copy\
+              \ from Help \u2192 About Inkscape, top right) -->\r\n- Operating System:\
+              \ ...\r\n- Operating System version: ...\r\n\r\n<!-- Example file:\r\
+              \nAttach a sample file (or files) highlighting the issue, if appropriate.\
+              \ -->"
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-12-14T16:05:18.739Z'
+            lfs_enabled: false
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: ff
+            merge_pipelines_enabled: true
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: ''
+            merge_trains_enabled: false
+            mirror: false
+            name: inkscape
+            name_with_namespace: Inkscape / inkscape
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: true
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 1446
+            operations_access_level: disabled
+            packages_enabled: false
+            pages_access_level: enabled
+            path: inkscape
+            path_with_namespace: inkscape/inkscape
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/inkscape/-/blob/master/README.md
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: null
+            shared_runners_enabled: true
+            shared_with_groups:
+            - expires_at: null
+              group_access_level: 30
+              group_full_path: inkscape/devel
+              group_id: 4575604
+              group_name: Inkscape Developers
+            - expires_at: null
+              group_access_level: 20
+              group_full_path: inkscape/bug-wranglers
+              group_id: 4445779
+              group_name: Inkscape Bug Wranglers
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/inkscape.git
+            star_count: 2467
+            suggestion_commit_message: ''
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/inkscape
+            wiki_access_level: disabled
+            wiki_enabled: false
+          - _links:
+              events: https://gitlab.com/api/v4/projects/2324563/events
+              issues: https://gitlab.com/api/v4/projects/2324563/issues
+              labels: https://gitlab.com/api/v4/projects/2324563/labels
+              members: https://gitlab.com/api/v4/projects/2324563/members
+              merge_requests: https://gitlab.com/api/v4/projects/2324563/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/2324563/repository/branches
+              self: https://gitlab.com/api/v4/projects/2324563
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/2324563/inkscape-web-i18n.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: private
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: disabled
+            container_registry_enabled: false
+            container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-web-i18n
+            created_at: '2017-01-17T01:07:35.318Z'
+            creator_id: 401528
+            default_branch: master
+            description: Translations for the inkscape-web project
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 18
+            http_url_to_repo: https://gitlab.com/inkscape/inkscape-web-i18n.git
+            id: 2324563
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: ''
+            jobs_enabled: false
+            keep_latest_artifact: true
+            last_activity_at: '2021-12-08T23:18:34.428Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: ff
+            merge_pipelines_enabled: true
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: ''
+            merge_trains_enabled: true
+            mirror: false
+            name: inkscape-web-i18n
+            name_with_namespace: Inkscape / inkscape-web-i18n
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 0
+            operations_access_level: enabled
+            packages_enabled: null
+            pages_access_level: enabled
+            path: inkscape-web-i18n
+            path_with_namespace: inkscape/inkscape-web-i18n
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/inkscape-web-i18n/-/blob/master/README.md
+            remove_source_branch_after_merge: false
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: null
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-web-i18n.git
+            star_count: 4
+            suggestion_commit_message: ''
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/inkscape-web-i18n
+            wiki_access_level: disabled
+            wiki_enabled: false
+          - _links:
+              events: https://gitlab.com/api/v4/projects/2313989/events
+              issues: https://gitlab.com/api/v4/projects/2313989/issues
+              labels: https://gitlab.com/api/v4/projects/2313989/labels
+              members: https://gitlab.com/api/v4/projects/2313989/members
+              merge_requests: https://gitlab.com/api/v4/projects/2313989/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/2313989/repository/branches
+              self: https://gitlab.com/api/v4/projects/2313989
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/2313989/inkscape-web.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: private
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: disabled
+            container_registry_enabled: false
+            container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-web
+            created_at: '2017-01-15T01:50:48.396Z'
+            creator_id: 401528
+            default_branch: master
+            description: The inkscape website, a django based cms with apps for uploading
+              images, managing projects.
+            emails_disabled: false
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 35
+            http_url_to_repo: https://gitlab.com/inkscape/inkscape-web.git
+            id: 2313989
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: ''
+            jobs_enabled: false
+            keep_latest_artifact: true
+            last_activity_at: '2021-12-13T15:31:55.591Z'
+            lfs_enabled: false
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: ff
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: ''
+            merge_trains_enabled: false
+            mirror: false
+            name: inkscape-web
+            name_with_namespace: Inkscape / inkscape-web
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 236
+            operations_access_level: enabled
+            packages_enabled: false
+            pages_access_level: enabled
+            path: inkscape-web
+            path_with_namespace: inkscape/inkscape-web
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/inkscape-web/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: null
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: null
+            shared_runners_enabled: true
+            shared_with_groups:
+            - expires_at: null
+              group_access_level: 40
+              group_full_path: inkscape/bug-wranglers
+              group_id: 4445779
+              group_name: Inkscape Bug Wranglers
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-web.git
+            star_count: 53
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/inkscape-web
+            wiki_access_level: enabled
+            wiki_enabled: true
+          - _links:
+              events: https://gitlab.com/api/v4/projects/839044/events
+              issues: https://gitlab.com/api/v4/projects/839044/issues
+              labels: https://gitlab.com/api/v4/projects/839044/labels
+              members: https://gitlab.com/api/v4/projects/839044/members
+              merge_requests: https://gitlab.com/api/v4/projects/839044/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/839044/repository/branches
+              self: https://gitlab.com/api/v4/projects/839044
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/839044/2geom-logo.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: disabled
+            container_registry_enabled: false
+            container_registry_image_prefix: registry.gitlab.com/inkscape/lib2geom
+            created_at: '2016-02-07T23:31:25.049Z'
+            creator_id: 119391
+            default_branch: master
+            description: Easy to use 2D geometry library in C++
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 20
+            http_url_to_repo: https://gitlab.com/inkscape/lib2geom.git
+            id: 839044
+            import_status: finished
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: ''
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-12-13T19:10:51.380Z'
+            lfs_enabled: false
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: ff
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: ''
+            merge_trains_enabled: false
+            mirror: false
+            name: lib2geom
+            name_with_namespace: Inkscape / lib2geom
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 22
+            operations_access_level: enabled
+            packages_enabled: false
+            pages_access_level: enabled
+            path: lib2geom
+            path_with_namespace: inkscape/lib2geom
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/inkscape/lib2geom/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: null
+            shared_runners_enabled: true
+            shared_with_groups:
+            - expires_at: null
+              group_access_level: 30
+              group_full_path: inkscape/devel
+              group_id: 4575604
+              group_name: Inkscape Developers
+            - expires_at: null
+              group_access_level: 20
+              group_full_path: inkscape/bug-wranglers
+              group_id: 4445779
+              group_name: Inkscape Bug Wranglers
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/lib2geom.git
+            star_count: 16
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/lib2geom
+            wiki_access_level: disabled
+            wiki_enabled: false
+          _next: null
+          elapsed: 0.905276
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6bd919cfee662780-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Tue, 14 Dec 2021 17:20:05 GMT
+            Etag: W/"bcf05241bb7d9093782cbb79bbdfe752"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-08-lb-gprd
+            GitLab-SV: localhost
+            Link: <https://gitlab.com/api/v4/groups/470642/projects?id=470642&include_subgroups=false&order_by=created_at&owned=false&page=1&per_page=20&simple=false&sort=desc&starred=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false&with_security_reports=false&with_shared=true>;
+              rel="first", <https://gitlab.com/api/v4/groups/470642/projects?id=470642&include_subgroups=false&order_by=created_at&owned=false&page=1&per_page=20&simple=false&sort=desc&starred=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false&with_security_reports=false&with_shared=true>;
+              rel="last"
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '2'
+            RateLimit-Remaining: '1998'
+            RateLimit-Reset: '1639502465'
+            RateLimit-ResetTime: Tue, 14 Dec 2021 17:21:05 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Q4R45G8H%2FvrlaaqZ%2Bd%2Fb2MxVOIzzo4MF2SwNfdZQE2f5evLBsJj%2BEgkX30FcI4Ny3jODyjXYdbfL2wRN3ospgPeG6%2Fm9LqXhEIyW5bW0thIHOV0XWHKS9xu4zBs%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Next-Page: ''
+            X-Page: '1'
+            X-Per-Page: '20'
+            X-Prev-Page: ''
+            X-Request-Id: 01FPWZAQR6B3MTB9GYZ7VPBXCT
+            X-Runtime: '0.442122'
+            X-Total: '11'
+            X-Total-Pages: '1'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/groups/inkscape:
+      - metadata:
+          latency: 0.9478054046630859
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_service
+          - ogr.abstract
+          - ogr.services.gitlab.service
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            auto_devops_enabled: null
+            avatar_url: https://gitlab.com/uploads/-/system/group/avatar/470642/inkscape.png
+            created_at: '2016-02-07T21:59:26.475Z'
+            default_branch_protection: 2
+            description: "Inkscape - Draw freely\r\n\r\nGet started: https://inkscape.org\r\
+              \nFor reporting issues, please visit https://gitlab.com/inkscape/inbox/-/issues"
+            emails_disabled: null
+            extra_shared_runners_minutes_limit: null
+            full_name: Inkscape
+            full_path: inkscape
+            id: 470642
+            ldap_access: null
+            ldap_cn: null
+            lfs_enabled: true
+            mentions_disabled: null
+            name: Inkscape
+            parent_id: null
+            path: inkscape
+            prevent_forking_outside_group: null
+            prevent_sharing_groups_outside_hierarchy: false
+            project_creation_level: developer
+            projects:
+            - _links:
+                events: https://gitlab.com/api/v4/projects/27055706/events
+                issues: https://gitlab.com/api/v4/projects/27055706/issues
+                labels: https://gitlab.com/api/v4/projects/27055706/labels
+                members: https://gitlab.com/api/v4/projects/27055706/members
+                merge_requests: https://gitlab.com/api/v4/projects/27055706/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/27055706/repository/branches
+                self: https://gitlab.com/api/v4/projects/27055706
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/27055706/HiMXBhfcnEhRyWydQ.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: ''
+              ci_default_git_depth: 50
+              ci_forward_deployment_enabled: true
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_expiration_policy:
+                cadence: 1d
+                enabled: false
+                keep_n: 10
+                name_regex: .*
+                name_regex_keep: null
+                next_run_at: '2021-06-01T17:40:38.014Z'
+                older_than: 90d
+              container_registry_access_level: enabled
+              container_registry_enabled: true
+              container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-board
+              created_at: '2021-05-31T17:40:37.973Z'
+              creator_id: 401528
+              default_branch: main
+              description: Inkscape board issues
+              emails_disabled: null
+              empty_repo: true
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 0
+              http_url_to_repo: https://gitlab.com/inkscape/inkscape-board.git
+              id: 27055706
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: null
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-10-08T04:17:43.430Z'
+              lfs_enabled: true
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: merge
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: null
+              merge_trains_enabled: false
+              mirror: false
+              name: Inkscape Board
+              name_with_namespace: Inkscape / Inkscape Board
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 1
+              operations_access_level: enabled
+              packages_enabled: true
+              pages_access_level: enabled
+              path: inkscape-board
+              path_with_namespace: inkscape/inkscape-board
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: null
+              remove_source_branch_after_merge: true
+              repository_access_level: enabled
+              request_access_enabled: true
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: true
+              shared_runners_enabled: true
+              shared_with_groups: []
+              snippets_access_level: enabled
+              snippets_enabled: true
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-board.git
+              star_count: 0
+              suggestion_commit_message: null
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/inkscape-board
+              wiki_access_level: enabled
+              wiki_enabled: true
+            - _links:
+                events: https://gitlab.com/api/v4/projects/23168514/events
+                issues: https://gitlab.com/api/v4/projects/23168514/issues
+                labels: https://gitlab.com/api/v4/projects/23168514/labels
+                members: https://gitlab.com/api/v4/projects/23168514/members
+                merge_requests: https://gitlab.com/api/v4/projects/23168514/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/23168514/repository/branches
+                self: https://gitlab.com/api/v4/projects/23168514
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/23168514/inkscape-themes.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: ''
+              ci_default_git_depth: 50
+              ci_forward_deployment_enabled: true
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_expiration_policy:
+                cadence: 1d
+                enabled: false
+                keep_n: 10
+                name_regex: .*
+                name_regex_keep: null
+                next_run_at: '2020-12-18T14:48:10.089Z'
+                older_than: 90d
+              container_registry_access_level: enabled
+              container_registry_enabled: true
+              container_registry_image_prefix: registry.gitlab.com/inkscape/themes
+              created_at: '2020-12-17T14:48:10.058Z'
+              creator_id: 401528
+              default_branch: master
+              description: This repository contains all the extra themes we want to
+                test and ship in Inkscape. It works like the extensions repository
+                inviting more non-technical users/designers to get involved and permission
+                to modify things.
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 6
+              http_url_to_repo: https://gitlab.com/inkscape/themes.git
+              id: 23168514
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: null
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-11-11T01:53:09.167Z'
+              lfs_enabled: true
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: merge
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: null
+              merge_trains_enabled: false
+              mirror: false
+              name: themes
+              name_with_namespace: Inkscape / themes
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 4
+              operations_access_level: enabled
+              packages_enabled: true
+              pages_access_level: enabled
+              path: themes
+              path_with_namespace: inkscape/themes
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/themes/-/blob/master/README.md
+              remove_source_branch_after_merge: true
+              repository_access_level: enabled
+              request_access_enabled: true
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: true
+              shared_runners_enabled: true
+              shared_with_groups:
+              - expires_at: null
+                group_access_level: 40
+                group_full_path: inkscape/bug-wranglers
+                group_id: 4445779
+                group_name: Inkscape Bug Wranglers
+              snippets_access_level: enabled
+              snippets_enabled: true
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/themes.git
+              star_count: 1
+              suggestion_commit_message: null
+              tag_list:
+              - app
+              - css
+              - gtk
+              - themes
+              topics:
+              - app
+              - css
+              - gtk
+              - themes
+              visibility: public
+              web_url: https://gitlab.com/inkscape/themes
+              wiki_access_level: enabled
+              wiki_enabled: true
+            - _links:
+                events: https://gitlab.com/api/v4/projects/20961968/events
+                issues: https://gitlab.com/api/v4/projects/20961968/issues
+                labels: https://gitlab.com/api/v4/projects/20961968/labels
+                members: https://gitlab.com/api/v4/projects/20961968/members
+                merge_requests: https://gitlab.com/api/v4/projects/20961968/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/20961968/repository/branches
+                self: https://gitlab.com/api/v4/projects/20961968
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/20961968/libcroco.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: ''
+              ci_default_git_depth: 50
+              ci_forward_deployment_enabled: true
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_expiration_policy:
+                cadence: 1d
+                enabled: false
+                keep_n: 10
+                name_regex: null
+                name_regex_keep: null
+                next_run_at: '2020-10-20T23:48:03.347Z'
+                older_than: 90d
+              container_registry_access_level: enabled
+              container_registry_enabled: true
+              container_registry_image_prefix: registry.gitlab.com/inkscape/libcroco
+              created_at: '2020-09-06T09:08:26.440Z'
+              creator_id: 401528
+              default_branch: master
+              description: Libcroco is a standalone css2 parsing and manipulation
+                library. The parser provides a low level event driven SAC like api
+                and a css object model like api. Libcroco provides a CSS2 selection
+                engine and an experimental xml/css rendering engine.
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 2
+              http_url_to_repo: https://gitlab.com/inkscape/libcroco.git
+              id: 20961968
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: null
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-02-17T09:49:12.486Z'
+              lfs_enabled: true
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: merge
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: null
+              merge_trains_enabled: false
+              mirror: false
+              name: libcroco
+              name_with_namespace: Inkscape / libcroco
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 0
+              operations_access_level: enabled
+              packages_enabled: true
+              pages_access_level: enabled
+              path: libcroco
+              path_with_namespace: inkscape/libcroco
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/libcroco/-/blob/master/README
+              remove_source_branch_after_merge: true
+              repository_access_level: enabled
+              request_access_enabled: true
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: true
+              shared_runners_enabled: true
+              shared_with_groups: []
+              snippets_access_level: enabled
+              snippets_enabled: true
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/libcroco.git
+              star_count: 0
+              suggestion_commit_message: null
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/libcroco
+              wiki_access_level: enabled
+              wiki_enabled: true
+            - _links:
+                events: https://gitlab.com/api/v4/projects/16468356/events
+                issues: https://gitlab.com/api/v4/projects/16468356/issues
+                labels: https://gitlab.com/api/v4/projects/16468356/labels
+                members: https://gitlab.com/api/v4/projects/16468356/members
+                merge_requests: https://gitlab.com/api/v4/projects/16468356/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/16468356/repository/branches
+                self: https://gitlab.com/api/v4/projects/16468356
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/16468356/ux.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: 50
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_expiration_policy:
+                cadence: 7d
+                enabled: false
+                keep_n: null
+                name_regex: null
+                name_regex_keep: null
+                next_run_at: '2020-01-29T19:45:22.293Z'
+                older_than: null
+              container_registry_access_level: enabled
+              container_registry_enabled: true
+              container_registry_image_prefix: registry.gitlab.com/inkscape/ux
+              created_at: '2020-01-22T19:45:22.267Z'
+              creator_id: 401528
+              default_branch: master
+              description: Design and user experience discussion, process, testing,
+                events and decision making.
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 3
+              http_url_to_repo: https://gitlab.com/inkscape/ux.git
+              id: 16468356
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: null
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-12-12T15:08:04.228Z'
+              lfs_enabled: true
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: merge
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: null
+              merge_trains_enabled: false
+              mirror: false
+              name: Inkscape UX
+              name_with_namespace: Inkscape / Inkscape UX
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 74
+              operations_access_level: enabled
+              packages_enabled: true
+              pages_access_level: enabled
+              path: ux
+              path_with_namespace: inkscape/ux
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/ux/-/blob/master/README.md
+              remove_source_branch_after_merge: true
+              repository_access_level: enabled
+              request_access_enabled: true
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: true
+              shared_runners_enabled: true
+              shared_with_groups: []
+              snippets_access_level: enabled
+              snippets_enabled: true
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/ux.git
+              star_count: 5
+              suggestion_commit_message: null
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/ux
+              wiki_access_level: enabled
+              wiki_enabled: true
+            - _links:
+                events: https://gitlab.com/api/v4/projects/10403243/events
+                issues: https://gitlab.com/api/v4/projects/10403243/issues
+                labels: https://gitlab.com/api/v4/projects/10403243/labels
+                members: https://gitlab.com/api/v4/projects/10403243/members
+                merge_requests: https://gitlab.com/api/v4/projects/10403243/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/10403243/repository/branches
+                self: https://gitlab.com/api/v4/projects/10403243
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/10403243/temp_inbox_mountain_envelope.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: disabled
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: null
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_registry_access_level: disabled
+              container_registry_enabled: false
+              container_registry_image_prefix: registry.gitlab.com/inkscape/inbox
+              created_at: '2019-01-17T03:40:33.158Z'
+              creator_id: 266859
+              default_branch: master
+              description: This inbox is a "friendly feedback zone", we welcome questions,
+                comments, ideas, and bug reports that pertain to the Inkscape software,
+                its related components, and the project in general.
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 7
+              http_url_to_repo: https://gitlab.com/inkscape/inbox.git
+              id: 10403243
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: "<!--\r\n    See our full bug reporting guidelines\
+                \ at https://inkscape.org/contribute/report-bugs/\r\n    Writing a\
+                \ good bug report will ensure we'll be able to help efficiently. \U0001F642\
+                \r\n-->\r\n\r\n#### Summary:\r\n<!-- Summarize the issue/suggestion\
+                \ concisely: -->\r\n\r\n... (write here)\r\n\r\n#### Steps to reproduce:\r\
+                \n<!-- Describe what you did (step-by-step) so we can reproduce: -->\r\
+                \n\r\n- open Inkscape\r\n- ...\r\n\r\n#### What happened?\r\n\r\n\
+                ...\r\n\r\n#### What should have happened?\r\n\r\n...\r\n\r\nSample\
+                \ attachments:\r\n\r\n<!-- Attach the sample file(s) highlighting\
+                \ the issue, if appropriate. -->\r\n\r\n#### Version info\r\n\r\n\
+                <!--\r\n    Open 'Help > About' and click on the little bug icon in\
+                \ the bottom right corner that copies the debug information to your\
+                \ clipboard. For command line users, run 'inkscape --debug-info'.\r\
+                \n\r\n    For Inkscape 1.0.2 and older, please manually add the Inkscape\
+                \ Version and Operating System Version. The Inkscape version is listed\
+                \ in the About dialog. For command line users, run 'inkscape -V'\r\
+                \n\r\n    Paste the information in the empty space between the apostrophes\
+                \ below:\r\n-->\r\n\r\n```\r\n\r\n\r\n\r\n```\r\n\r\n<!--\r\n    \u2764\
+                \uFE0F Thank you for filling in a new bug report, we appreciate the\
+                \ help! \u2764\uFE0F\r\n    Please be patient while we try to find\
+                \ the time to look into your issue.\r\n    Remember that Inkscape\
+                \ is developed by volunteers in their spare time, we'll try our best\
+                \ to respond to all reports.\r\n-->\r\n\r\n<!--\r\n    Please be careful\
+                \ when/after writing #  for example in logs, code, or versions of\
+                \ linux\r\n    - use inline code span - single backticks (`) before\
+                \ and after it, like this - `#1618`\r\n    - use multi-line code block\
+                \ - triple backticks (```) to fence/enclose console logs\r\n    -\
+                \ attach long logs as a text file.\r\n-->\r\n"
+              jobs_enabled: false
+              keep_latest_artifact: true
+              last_activity_at: '2021-12-14T17:16:41.296Z'
+              lfs_enabled: false
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: merge
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: null
+              merge_trains_enabled: false
+              mirror: false
+              name: Inbox
+              name_with_namespace: Inkscape / Inbox
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 1431
+              operations_access_level: enabled
+              packages_enabled: false
+              pages_access_level: disabled
+              path: inbox
+              path_with_namespace: inkscape/inbox
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: null
+              remove_source_branch_after_merge: null
+              repository_access_level: enabled
+              request_access_enabled: false
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: false
+              shared_runners_enabled: true
+              shared_with_groups:
+              - expires_at: null
+                group_access_level: 30
+                group_full_path: inkscape/devel
+                group_id: 4575604
+                group_name: Inkscape Developers
+              - expires_at: null
+                group_access_level: 40
+                group_full_path: inkscape/bug-wranglers
+                group_id: 4445779
+                group_name: Inkscape Bug Wranglers
+              snippets_access_level: disabled
+              snippets_enabled: false
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/inbox.git
+              star_count: 31
+              suggestion_commit_message: null
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/inbox
+              wiki_access_level: disabled
+              wiki_enabled: false
+            - _links:
+                events: https://gitlab.com/api/v4/projects/5833962/events
+                issues: https://gitlab.com/api/v4/projects/5833962/issues
+                labels: https://gitlab.com/api/v4/projects/5833962/labels
+                members: https://gitlab.com/api/v4/projects/5833962/members
+                merge_requests: https://gitlab.com/api/v4/projects/5833962/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/5833962/repository/branches
+                self: https://gitlab.com/api/v4/projects/5833962
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 1
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/5833962/addons.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: null
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_registry_access_level: disabled
+              container_registry_enabled: false
+              container_registry_image_prefix: registry.gitlab.com/inkscape/extensions
+              created_at: '2018-03-22T00:29:09.053Z'
+              creator_id: 401528
+              default_branch: master
+              description: Python extensions for Inkscape core, separated out from
+                main repository.
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 87
+              http_url_to_repo: https://gitlab.com/inkscape/extensions.git
+              id: 5833962
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: null
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-12-13T23:57:06.316Z'
+              lfs_enabled: false
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: merge
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: ''
+              merge_trains_enabled: false
+              mirror: false
+              name: extensions
+              name_with_namespace: Inkscape / extensions
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: true
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 117
+              operations_access_level: enabled
+              packages_enabled: false
+              pages_access_level: enabled
+              path: extensions
+              path_with_namespace: inkscape/extensions
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/extensions/-/blob/master/README.md
+              remove_source_branch_after_merge: null
+              repository_access_level: enabled
+              request_access_enabled: false
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: true
+              shared_runners_enabled: true
+              shared_with_groups:
+              - expires_at: null
+                group_access_level: 30
+                group_full_path: inkscape/devel
+                group_id: 4575604
+                group_name: Inkscape Developers
+              - expires_at: null
+                group_access_level: 30
+                group_full_path: inkscape/bug-wranglers
+                group_id: 4445779
+                group_name: Inkscape Bug Wranglers
+              snippets_access_level: disabled
+              snippets_enabled: false
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/extensions.git
+              star_count: 41
+              suggestion_commit_message: null
+              tag_list:
+              - addin
+              - additional
+              - addon
+              - core
+              - extension
+              - inkscape
+              - python
+              topics:
+              - addin
+              - additional
+              - addon
+              - core
+              - extension
+              - inkscape
+              - python
+              visibility: public
+              web_url: https://gitlab.com/inkscape/extensions
+              wiki_access_level: enabled
+              wiki_enabled: true
+            - _links:
+                events: https://gitlab.com/api/v4/projects/3507798/events
+                issues: https://gitlab.com/api/v4/projects/3507798/issues
+                labels: https://gitlab.com/api/v4/projects/3507798/labels
+                members: https://gitlab.com/api/v4/projects/3507798/members
+                merge_requests: https://gitlab.com/api/v4/projects/3507798/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/3507798/repository/branches
+                self: https://gitlab.com/api/v4/projects/3507798
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: disabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: null
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: null
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_registry_access_level: enabled
+              container_registry_enabled: true
+              container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-ci-docker
+              created_at: '2017-06-15T03:46:48.634Z'
+              creator_id: 402261
+              default_branch: master
+              description: CI Base Image for Inkscape builds
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 16
+              http_url_to_repo: https://gitlab.com/inkscape/inkscape-ci-docker.git
+              id: 3507798
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: null
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-11-22T21:09:35.721Z'
+              lfs_enabled: false
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: ff
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: ''
+              merge_trains_enabled: false
+              mirror: false
+              name: inkscape-ci-docker
+              name_with_namespace: Inkscape / inkscape-ci-docker
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 1
+              operations_access_level: disabled
+              packages_enabled: false
+              pages_access_level: disabled
+              path: inkscape-ci-docker
+              path_with_namespace: inkscape/inkscape-ci-docker
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/inkscape-ci-docker/-/blob/master/README.md
+              remove_source_branch_after_merge: null
+              repository_access_level: enabled
+              request_access_enabled: false
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: null
+              shared_runners_enabled: true
+              shared_with_groups:
+              - expires_at: null
+                group_access_level: 30
+                group_full_path: inkscape/devel
+                group_id: 4575604
+                group_name: Inkscape Developers
+              snippets_access_level: disabled
+              snippets_enabled: false
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-ci-docker.git
+              star_count: 6
+              suggestion_commit_message: null
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/inkscape-ci-docker
+              wiki_access_level: disabled
+              wiki_enabled: false
+            - _links:
+                events: https://gitlab.com/api/v4/projects/3472737/events
+                issues: https://gitlab.com/api/v4/projects/3472737/issues
+                labels: https://gitlab.com/api/v4/projects/3472737/labels
+                members: https://gitlab.com/api/v4/projects/3472737/members
+                merge_requests: https://gitlab.com/api/v4/projects/3472737/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/3472737/repository/branches
+                self: https://gitlab.com/api/v4/projects/3472737
+              allow_merge_on_skipped_pipeline: false
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/3472737/inkscape.png
+              build_coverage_regex: ''
+              build_timeout: 18600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: null
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_registry_access_level: disabled
+              container_registry_enabled: false
+              container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape
+              created_at: '2017-06-09T14:16:35.615Z'
+              creator_id: 402261
+              default_branch: master
+              description: Inkscape vector image editor
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 874
+              http_url_to_repo: https://gitlab.com/inkscape/inkscape.git
+              id: 3472737
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: "<!-- Please report new issues at https://inkscape.org/report;\
+                \ this tracker is for staff-confirmed issues only.\r\n     See our\
+                \ full bug reporting guidelines at https://inkscape.org/contribute/report-bugs/\
+                \ -->\r\n\r\n#### Steps to reproduce:\r\n<!-- Describe what you did\
+                \ (step-by-step) so we can reproduce: -->\r\n\r\n- open Inkscape\r\
+                \n- ...\r\n\r\n#### What happened?\r\n\r\n...\r\n\r\n#### What should\
+                \ have happened?\r\n\r\n...\r\n\r\n#### Inkscape Version and Operating\
+                \ System:\r\n\r\n- Inkscape Version: ... <!-- (run inkscape -V or\
+                \ copy from Help \u2192 About Inkscape, top right) -->\r\n- Operating\
+                \ System: ...\r\n- Operating System version: ...\r\n\r\n<!-- Example\
+                \ file:\r\nAttach a sample file (or files) highlighting the issue,\
+                \ if appropriate. -->"
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-12-14T16:05:18.739Z'
+              lfs_enabled: false
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: ff
+              merge_pipelines_enabled: true
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: ''
+              merge_trains_enabled: false
+              mirror: false
+              name: inkscape
+              name_with_namespace: Inkscape / inkscape
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: true
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 1446
+              operations_access_level: disabled
+              packages_enabled: false
+              pages_access_level: enabled
+              path: inkscape
+              path_with_namespace: inkscape/inkscape
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/inkscape/-/blob/master/README.md
+              remove_source_branch_after_merge: true
+              repository_access_level: enabled
+              request_access_enabled: false
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: null
+              shared_runners_enabled: true
+              shared_with_groups:
+              - expires_at: null
+                group_access_level: 30
+                group_full_path: inkscape/devel
+                group_id: 4575604
+                group_name: Inkscape Developers
+              - expires_at: null
+                group_access_level: 20
+                group_full_path: inkscape/bug-wranglers
+                group_id: 4445779
+                group_name: Inkscape Bug Wranglers
+              snippets_access_level: disabled
+              snippets_enabled: false
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/inkscape.git
+              star_count: 2467
+              suggestion_commit_message: ''
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/inkscape
+              wiki_access_level: disabled
+              wiki_enabled: false
+            - _links:
+                events: https://gitlab.com/api/v4/projects/2324563/events
+                issues: https://gitlab.com/api/v4/projects/2324563/issues
+                labels: https://gitlab.com/api/v4/projects/2324563/labels
+                members: https://gitlab.com/api/v4/projects/2324563/members
+                merge_requests: https://gitlab.com/api/v4/projects/2324563/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/2324563/repository/branches
+                self: https://gitlab.com/api/v4/projects/2324563
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/2324563/inkscape-web-i18n.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: private
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: null
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_registry_access_level: disabled
+              container_registry_enabled: false
+              container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-web-i18n
+              created_at: '2017-01-17T01:07:35.318Z'
+              creator_id: 401528
+              default_branch: master
+              description: Translations for the inkscape-web project
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 18
+              http_url_to_repo: https://gitlab.com/inkscape/inkscape-web-i18n.git
+              id: 2324563
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: ''
+              jobs_enabled: false
+              keep_latest_artifact: true
+              last_activity_at: '2021-12-08T23:18:34.428Z'
+              lfs_enabled: true
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: ff
+              merge_pipelines_enabled: true
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: ''
+              merge_trains_enabled: true
+              mirror: false
+              name: inkscape-web-i18n
+              name_with_namespace: Inkscape / inkscape-web-i18n
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 0
+              operations_access_level: enabled
+              packages_enabled: null
+              pages_access_level: enabled
+              path: inkscape-web-i18n
+              path_with_namespace: inkscape/inkscape-web-i18n
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/inkscape-web-i18n/-/blob/master/README.md
+              remove_source_branch_after_merge: false
+              repository_access_level: enabled
+              request_access_enabled: true
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: null
+              shared_runners_enabled: true
+              shared_with_groups: []
+              snippets_access_level: disabled
+              snippets_enabled: false
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-web-i18n.git
+              star_count: 4
+              suggestion_commit_message: ''
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/inkscape-web-i18n
+              wiki_access_level: disabled
+              wiki_enabled: false
+            - _links:
+                events: https://gitlab.com/api/v4/projects/2313989/events
+                issues: https://gitlab.com/api/v4/projects/2313989/issues
+                labels: https://gitlab.com/api/v4/projects/2313989/labels
+                members: https://gitlab.com/api/v4/projects/2313989/members
+                merge_requests: https://gitlab.com/api/v4/projects/2313989/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/2313989/repository/branches
+                self: https://gitlab.com/api/v4/projects/2313989
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/2313989/inkscape-web.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: private
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: null
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_registry_access_level: disabled
+              container_registry_enabled: false
+              container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-web
+              created_at: '2017-01-15T01:50:48.396Z'
+              creator_id: 401528
+              default_branch: master
+              description: The inkscape website, a django based cms with apps for
+                uploading images, managing projects.
+              emails_disabled: false
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 35
+              http_url_to_repo: https://gitlab.com/inkscape/inkscape-web.git
+              id: 2313989
+              import_status: none
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: ''
+              jobs_enabled: false
+              keep_latest_artifact: true
+              last_activity_at: '2021-12-13T15:31:55.591Z'
+              lfs_enabled: false
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: ff
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: ''
+              merge_trains_enabled: false
+              mirror: false
+              name: inkscape-web
+              name_with_namespace: Inkscape / inkscape-web
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 236
+              operations_access_level: enabled
+              packages_enabled: false
+              pages_access_level: enabled
+              path: inkscape-web
+              path_with_namespace: inkscape/inkscape-web
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/inkscape-web/-/blob/master/README.md
+              remove_source_branch_after_merge: null
+              repository_access_level: enabled
+              request_access_enabled: true
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: null
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: null
+              shared_runners_enabled: true
+              shared_with_groups:
+              - expires_at: null
+                group_access_level: 40
+                group_full_path: inkscape/bug-wranglers
+                group_id: 4445779
+                group_name: Inkscape Bug Wranglers
+              snippets_access_level: disabled
+              snippets_enabled: false
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-web.git
+              star_count: 53
+              suggestion_commit_message: null
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/inkscape-web
+              wiki_access_level: enabled
+              wiki_enabled: true
+            - _links:
+                events: https://gitlab.com/api/v4/projects/839044/events
+                issues: https://gitlab.com/api/v4/projects/839044/issues
+                labels: https://gitlab.com/api/v4/projects/839044/labels
+                members: https://gitlab.com/api/v4/projects/839044/members
+                merge_requests: https://gitlab.com/api/v4/projects/839044/merge_requests
+                repo_branches: https://gitlab.com/api/v4/projects/839044/repository/branches
+                self: https://gitlab.com/api/v4/projects/839044
+              allow_merge_on_skipped_pipeline: null
+              analytics_access_level: enabled
+              approvals_before_merge: 0
+              archived: false
+              auto_cancel_pending_pipelines: enabled
+              auto_devops_deploy_strategy: continuous
+              auto_devops_enabled: false
+              autoclose_referenced_issues: true
+              avatar_url: https://gitlab.com/uploads/-/system/project/avatar/839044/2geom-logo.png
+              build_coverage_regex: null
+              build_timeout: 3600
+              builds_access_level: enabled
+              can_create_merge_request_in: true
+              ci_config_path: null
+              ci_default_git_depth: null
+              ci_forward_deployment_enabled: null
+              ci_job_token_scope_enabled: false
+              compliance_frameworks: []
+              container_registry_access_level: disabled
+              container_registry_enabled: false
+              container_registry_image_prefix: registry.gitlab.com/inkscape/lib2geom
+              created_at: '2016-02-07T23:31:25.049Z'
+              creator_id: 119391
+              default_branch: master
+              description: Easy to use 2D geometry library in C++
+              emails_disabled: null
+              empty_repo: false
+              external_authorization_classification_label: ''
+              forking_access_level: enabled
+              forks_count: 20
+              http_url_to_repo: https://gitlab.com/inkscape/lib2geom.git
+              id: 839044
+              import_status: finished
+              issues_access_level: enabled
+              issues_enabled: true
+              issues_template: ''
+              jobs_enabled: true
+              keep_latest_artifact: true
+              last_activity_at: '2021-12-13T19:10:51.380Z'
+              lfs_enabled: false
+              marked_for_deletion_at: null
+              marked_for_deletion_on: null
+              merge_commit_template: null
+              merge_method: ff
+              merge_pipelines_enabled: false
+              merge_requests_access_level: enabled
+              merge_requests_enabled: true
+              merge_requests_template: ''
+              merge_trains_enabled: false
+              mirror: false
+              name: lib2geom
+              name_with_namespace: Inkscape / lib2geom
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+                full_path: inkscape
+                id: 470642
+                kind: group
+                name: Inkscape
+                parent_id: null
+                path: inkscape
+                web_url: https://gitlab.com/groups/inkscape
+              only_allow_merge_if_all_discussions_are_resolved: false
+              only_allow_merge_if_pipeline_succeeds: false
+              open_issues_count: 22
+              operations_access_level: enabled
+              packages_enabled: false
+              pages_access_level: enabled
+              path: lib2geom
+              path_with_namespace: inkscape/lib2geom
+              printing_merge_request_link_enabled: true
+              public_jobs: true
+              readme_url: https://gitlab.com/inkscape/lib2geom/-/blob/master/README.md
+              remove_source_branch_after_merge: null
+              repository_access_level: enabled
+              request_access_enabled: false
+              requirements_enabled: true
+              resolve_outdated_diff_discussions: false
+              restrict_user_defined_variables: false
+              security_and_compliance_enabled: false
+              service_desk_enabled: null
+              shared_runners_enabled: true
+              shared_with_groups:
+              - expires_at: null
+                group_access_level: 30
+                group_full_path: inkscape/devel
+                group_id: 4575604
+                group_name: Inkscape Developers
+              - expires_at: null
+                group_access_level: 20
+                group_full_path: inkscape/bug-wranglers
+                group_id: 4445779
+                group_name: Inkscape Bug Wranglers
+              snippets_access_level: disabled
+              snippets_enabled: false
+              squash_commit_template: null
+              squash_option: default_off
+              ssh_url_to_repo: git@gitlab.com:inkscape/lib2geom.git
+              star_count: 16
+              suggestion_commit_message: null
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/inkscape/lib2geom
+              wiki_access_level: disabled
+              wiki_enabled: false
+            request_access_enabled: false
+            require_two_factor_authentication: false
+            share_with_group_lock: false
+            shared_projects: []
+            shared_runners_minutes_limit: 2000
+            shared_with_groups: []
+            subgroup_creation_level: owner
+            two_factor_grace_period: 48
+            visibility: public
+            web_url: https://gitlab.com/groups/inkscape
+          _next: null
+          elapsed: 0.845759
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6bd919c9eaf22780-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Tue, 14 Dec 2021 17:20:04 GMT
+            Etag: W/"80e5404034369fb0dc1205728b7ffdc4"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-01-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '2'
+            RateLimit-Remaining: '1998'
+            RateLimit-Reset: '1639502464'
+            RateLimit-ResetTime: Tue, 14 Dec 2021 17:21:04 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=yYzPoQEkdDjUi4XvMHzyoJwtAn3aYKekqp0UB4PIoOKVTTrAZBLcYW8VtChr2aX%2B3fp4wvDGHLRKjMDM9%2BxWMNIibIZyUl7uINHX1jB%2BAxRFh5EQTHiB9cLZ4mI%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FPWZAPSZVKCQ4ECVC1BCEHMZ
+            X-Runtime: '0.392311'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/27055706/forks:
+      - metadata:
+          latency: 0.25130152702331543
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_service
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content: []
+          _next: null
+          elapsed: 0.250128
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6bd919d858822780-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Length: '2'
+            Content-Type: application/json
+            Date: Tue, 14 Dec 2021 17:20:06 GMT
+            Etag: W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-18-lb-gprd
+            GitLab-SV: localhost
+            Link: <https://gitlab.com/api/v4/projects/27055706/forks?id=27055706&membership=false&order_by=created_at&owned=false&page=1&per_page=20&repository_checksum_failed=false&simple=false&sort=desc&starred=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+              rel="first", <https://gitlab.com/api/v4/projects/27055706/forks?id=27055706&membership=false&order_by=created_at&owned=false&page=1&per_page=20&repository_checksum_failed=false&simple=false&sort=desc&starred=false&wiki_checksum_failed=false&with_custom_attributes=false&with_issues_enabled=false&with_merge_requests_enabled=false>;
+              rel="last"
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '3'
+            RateLimit-Remaining: '1997'
+            RateLimit-Reset: '1639502466'
+            RateLimit-ResetTime: Tue, 14 Dec 2021 17:21:06 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=P0oVw4F0x%2BI%2FDhnCivg%2BCkRhwbE0To3OHHlJ71Iqe%2BwrKc%2BXMPKPf54nrg0%2BVgA8AUTub%2BVvoTPIW6YF2ADqxi6FQSENu5%2BUdrUOhKAyj9sA5rm1faAAnJTDQKU%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Next-Page: ''
+            X-Page: '1'
+            X-Per-Page: '20'
+            X-Prev-Page: ''
+            X-Request-Id: 01FPWZARWYBRHCW66QYCC0B3D7
+            X-Runtime: '0.068180'
+            X-Total: '0'
+            X-Total-Pages: '1'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/inkscape%2Finkscape-board:
+      - metadata:
+          latency: 0.32398080825805664
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_service
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/27055706/events
+              issues: https://gitlab.com/api/v4/projects/27055706/issues
+              labels: https://gitlab.com/api/v4/projects/27055706/labels
+              members: https://gitlab.com/api/v4/projects/27055706/members
+              merge_requests: https://gitlab.com/api/v4/projects/27055706/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/27055706/repository/branches
+              self: https://gitlab.com/api/v4/projects/27055706
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/27055706/HiMXBhfcnEhRyWydQ.png
+            build_coverage_regex: null
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: ''
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: true
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 1d
+              enabled: false
+              keep_n: 10
+              name_regex: .*
+              name_regex_keep: null
+              next_run_at: '2021-06-01T17:40:38.014Z'
+              older_than: 90d
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/inkscape/inkscape-board
+            created_at: '2021-05-31T17:40:37.973Z'
+            creator_id: 401528
+            default_branch: main
+            description: Inkscape board issues
+            emails_disabled: null
+            empty_repo: true
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 0
+            http_url_to_repo: https://gitlab.com/inkscape/inkscape-board.git
+            id: 27055706
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-10-08T04:17:43.430Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: Inkscape Board
+            name_with_namespace: Inkscape / Inkscape Board
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/470642/inkscape.png
+              full_path: inkscape
+              id: 470642
+              kind: group
+              name: Inkscape
+              parent_id: null
+              path: inkscape
+              web_url: https://gitlab.com/groups/inkscape
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 1
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: inkscape-board
+            path_with_namespace: inkscape/inkscape-board
+            permissions:
+              group_access: null
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: null
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:inkscape/inkscape-board.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/inkscape/inkscape-board
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.322508
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6bd919d63c392780-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Tue, 14 Dec 2021 17:20:06 GMT
+            Etag: W/"6208ebcbbff258baaf8b5b87b1b99940"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-13-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '2'
+            RateLimit-Remaining: '1998'
+            RateLimit-Reset: '1639502466'
+            RateLimit-ResetTime: Tue, 14 Dec 2021 17:21:06 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=YA8rsaP8Dn8OHlkd1eOMG8Z9IIXO4S%2BfY0eVKxugRiwWx%2FRQ3vJ3wTAgtdng42i7p4xN2uAyXjzgbGX69fLwjLUANwDfF8T0vB9XCayxolLBtzs5e5Nb%2FxWn6nM%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FPWZARJ43WNMVQPXEBQT7S9G
+            X-Runtime: '0.146883'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.45853328704833984
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_service
+          - ogr.abstract
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://secure.gravatar.com/avatar/eff1ae69a40d35559a382d36b53b72d2?s=80&d=identicon
+            bio: ''
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 1
+            commit_email: jpopelka@redhat.com
+            confirmed_at: '2018-10-08T14:26:41.419Z'
+            created_at: '2018-10-08T14:26:41.721Z'
+            current_sign_in_at: '2021-12-13T16:36:48.234Z'
+            email: jpopelka@redhat.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            followers: 0
+            following: 0
+            id: 2952463
+            identities:
+            - extern_uid: 78e344c6-0d75-11e7-80dc-28d244ea5a6d
+              provider: group_saml
+              saml_provider_id: 1769
+            - extern_uid: '115977727485665327598'
+              provider: google_oauth2
+              saml_provider_id: null
+            - extern_uid: '288686'
+              provider: github
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2021-12-14'
+            last_sign_in_at: '2021-12-10T14:53:21.908Z'
+            linkedin: https://www.linkedin.com/in/ji%C5%99%C3%AD-popelka-6301345
+            local_time: 6:20 PM
+            location: Brno
+            name: Jiri Popelka
+            organization: Red Hat, inc.
+            private_profile: false
+            projects_limit: 100000
+            pronouns: null
+            public_email: ''
+            shared_runners_minutes_limit: null
+            skype: ''
+            state: active
+            theme_id: 1
+            twitter: ''
+            two_factor_enabled: true
+            username: jpopelka
+            web_url: https://gitlab.com/jpopelka
+            website_url: ''
+            work_information: Red Hat, inc.
+          _next: null
+          elapsed: 0.457443
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6bd919c8483a2780-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Tue, 14 Dec 2021 17:20:04 GMT
+            Etag: W/"59864ca33a20611ef44980f6a6e6efdc"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-14-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '1'
+            RateLimit-Remaining: '1999'
+            RateLimit-Reset: '1639502464'
+            RateLimit-ResetTime: Tue, 14 Dec 2021 17:21:04 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=IfbGRHGcWY3mr2p02C62t6UKDoHrPtz58ylCOu6KMR4lgRBEbSiOfMngvPYnX6Or1LoliDmaQ2Dee%2BrXiADVFaXFZ%2F9MHo9KRrjoBk4QRbMw%2FUIOiNJeXBjhAF0%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FPWZAPCS7PEV0A27ES54NGV9
+            X-Runtime: '0.040001'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_service.py
+++ b/tests/integration/gitlab/test_service.py
@@ -123,6 +123,11 @@ class Service(GitlabTests):
         )
         assert len(projects) == number_of_projects
 
+    def test_list_projects_get_forks(self):
+        projects = self.service.list_projects(namespace="inkscape")
+        assert projects
+        assert isinstance(projects[0].get_forks(), list)
+
     def test_wrong_auth(self):
         with pytest.raises(GitlabAPIException):
             self.service.project_create("test")


### PR DESCRIPTION
Problem was that by specifying `gitlab_repo=project` we passed in `GroupProject` which is very limited and doesn't provide all the features of `Project` object. See also Note in [python-gitlab's docs](https://python-gitlab.readthedocs.io/en/stable/gl_objects/groups.html).

Previously:
```python
gls = GitlabService(token=token, instance_url="https://gitlab.com")
prs = gls.list_projects(namespace="packit-service/src")
print(prs[0].get_forks())
```
Resulted in:
```python
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/gitlab/base.py", line 77, in __getattr__
    return self.__dict__["_updated_attrs"][name]
KeyError: 'forks'
```
Now it results in:
```python
[<GitlabProject(namespace="jpopelka", repo="luksmeta")>]
```

---

`GitlabService.list_projects()` was fixed to return correct type of objects.
