### PR TITLE
Implement getter of SHA for branches

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -1708,6 +1708,13 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
+    def get_sha_from_branch(self, branch: str) -> Optional[str]:
+        """
+        Returns:
+            Commit SHA of head of the branch. `None` if no branch was found.
+        """
+        raise NotImplementedError()
+
 
 class GitUser(OgrAbstractClass):
     """

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -574,3 +574,11 @@ class GithubProject(BaseGitProject):
 
     def get_tags(self) -> List["GitTag"]:
         return [GitTag(tag.name, tag.commit.sha) for tag in self.github_repo.get_tags()]
+
+    def get_sha_from_branch(self, branch: str) -> Optional[str]:
+        try:
+            return self.github_repo.get_branch(branch).commit.sha
+        except GithubException as ex:
+            if ex.status == 404:
+                return None
+            raise GithubAPIException from ex

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Optional, Dict, Set, Union
 
 import gitlab
+from gitlab.exceptions import GitlabGetError
 from gitlab.v4.objects import Project as GitlabObjectsProject
 
 from ogr.abstract import (
@@ -499,3 +500,11 @@ class GitlabProject(BaseGitProject):
 
     def get_web_url(self) -> str:
         return self.gitlab_repo.web_url
+
+    def get_sha_from_branch(self, branch: str) -> Optional[str]:
+        try:
+            return self.gitlab_repo.branches.get(branch).attributes["commit"]["id"]
+        except GitlabGetError as ex:
+            if ex.response_code == 404:
+                return None
+            raise GitlabAPIException from ex

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -506,3 +506,10 @@ class PagureProject(BaseGitProject):
             paths = filter_paths(paths, filter_regex)
 
         return paths
+
+    def get_sha_from_branch(self, branch: str) -> Optional[str]:
+        branches = self._call_project_api(
+            "git", "branches", params={"with_commits": True}
+        )["branches"]
+
+        return branches.get(branch)

--- a/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch.yaml
+++ b/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch.yaml
@@ -1,0 +1,341 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/hello-world:
+      - metadata:
+          latency: 0.41852259635925293
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            allow_update_branch: false
+            archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+            clone_url: https://github.com/packit/hello-world.git
+            collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+            created_at: '2019-05-02T18:54:46Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+            events_url: https://api.github.com/repos/packit/hello-world/events
+            fork: false
+            forks: 20
+            forks_count: 20
+            forks_url: https://api.github.com/repos/packit/hello-world/forks
+            full_name: packit/hello-world
+            git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+            git_url: git://github.com/packit/hello-world.git
+            has_downloads: true
+            has_issues: true
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+            html_url: https://github.com/packit/hello-world
+            id: 184635124
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/packit/hello-world/merges
+            milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 20
+            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+            notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+            open_issues: 57
+            open_issues_count: 57
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+            pushed_at: '2022-01-03T06:50:35Z'
+            releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+            size: 58
+            ssh_url: git@github.com:packit/hello-world.git
+            stargazers_count: 4
+            stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+            subscribers_count: 9
+            subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+            svn_url: https://github.com/packit/hello-world
+            tags_url: https://api.github.com/repos/packit/hello-world/tags
+            teams_url: https://api.github.com/repos/packit/hello-world/teams
+            temp_clone_token: ''
+            topics: []
+            trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+            updated_at: '2021-11-30T09:33:55Z'
+            url: https://api.github.com/repos/packit/hello-world
+            visibility: public
+            watchers: 4
+            watchers_count: 4
+          _next: null
+          elapsed: 0.41588
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Mon, 03 Jan 2022 11:57:09 GMT
+            ETag: W/"cad969bec821c8b7182c0f49a48de8b0fb5b0b1219bdd9e869c8e7d2900d72eb"
+            Last-Modified: Tue, 30 Nov 2021 09:33:55 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C3C8:6038:383A206:3A55863:61D2E495
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4997'
+            X-RateLimit-Reset: '1641214432'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '3'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/branches/test-for-flock:
+      - metadata:
+          latency: 0.18532872200012207
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              html: https://github.com/packit/hello-world/tree/test-for-flock
+              self: https://api.github.com/repos/packit/hello-world/branches/test-for-flock
+            commit:
+              author:
+                avatar_url: https://avatars.githubusercontent.com/u/633969?v=4
+                events_url: https://api.github.com/users/thrix/events{/privacy}
+                followers_url: https://api.github.com/users/thrix/followers
+                following_url: https://api.github.com/users/thrix/following{/other_user}
+                gists_url: https://api.github.com/users/thrix/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/thrix
+                id: 633969
+                login: thrix
+                node_id: MDQ6VXNlcjYzMzk2OQ==
+                organizations_url: https://api.github.com/users/thrix/orgs
+                received_events_url: https://api.github.com/users/thrix/received_events
+                repos_url: https://api.github.com/users/thrix/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/thrix/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/thrix/subscriptions
+                type: User
+                url: https://api.github.com/users/thrix
+              comments_url: https://api.github.com/repos/packit/hello-world/commits/e2282f3083a5e11e76a0a4a2d5de7c7f8afdecd0/comments
+              commit:
+                author:
+                  date: '2019-08-08T23:31:40Z'
+                  email: mvadkert@redhat.com
+                  name: Miroslav Vadkerti
+                comment_count: 0
+                committer:
+                  date: '2019-08-08T23:31:40Z'
+                  email: mvadkert@redhat.com
+                  name: Miroslav Vadkerti
+                message: 'Test for flock
+
+
+                  Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>'
+                tree:
+                  sha: 243e34c0df9eb8c61045d17f0a06abc4202ca8b4
+                  url: https://api.github.com/repos/packit/hello-world/git/trees/243e34c0df9eb8c61045d17f0a06abc4202ca8b4
+                url: https://api.github.com/repos/packit/hello-world/git/commits/e2282f3083a5e11e76a0a4a2d5de7c7f8afdecd0
+                verification:
+                  payload: null
+                  reason: unsigned
+                  signature: null
+                  verified: false
+              committer:
+                avatar_url: https://avatars.githubusercontent.com/u/633969?v=4
+                events_url: https://api.github.com/users/thrix/events{/privacy}
+                followers_url: https://api.github.com/users/thrix/followers
+                following_url: https://api.github.com/users/thrix/following{/other_user}
+                gists_url: https://api.github.com/users/thrix/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/thrix
+                id: 633969
+                login: thrix
+                node_id: MDQ6VXNlcjYzMzk2OQ==
+                organizations_url: https://api.github.com/users/thrix/orgs
+                received_events_url: https://api.github.com/users/thrix/received_events
+                repos_url: https://api.github.com/users/thrix/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/thrix/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/thrix/subscriptions
+                type: User
+                url: https://api.github.com/users/thrix
+              html_url: https://github.com/packit/hello-world/commit/e2282f3083a5e11e76a0a4a2d5de7c7f8afdecd0
+              node_id: MDY6Q29tbWl0MTg0NjM1MTI0OmUyMjgyZjMwODNhNWUxMWU3NmEwYTRhMmQ1ZGU3YzdmOGFmZGVjZDA=
+              parents:
+              - html_url: https://github.com/packit/hello-world/commit/bc88c7c257b74d3bf8a7d3e21b2baf3f342dd52f
+                sha: bc88c7c257b74d3bf8a7d3e21b2baf3f342dd52f
+                url: https://api.github.com/repos/packit/hello-world/commits/bc88c7c257b74d3bf8a7d3e21b2baf3f342dd52f
+              sha: e2282f3083a5e11e76a0a4a2d5de7c7f8afdecd0
+              url: https://api.github.com/repos/packit/hello-world/commits/e2282f3083a5e11e76a0a4a2d5de7c7f8afdecd0
+            name: test-for-flock
+            protected: false
+            protection:
+              enabled: false
+              required_status_checks:
+                checks: []
+                contexts: []
+                enforcement_level: 'off'
+            protection_url: https://api.github.com/repos/packit/hello-world/branches/test-for-flock/protection
+          _next: null
+          elapsed: 0.18387
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Mon, 03 Jan 2022 11:57:09 GMT
+            ETag: W/"fa9cf5201f9e9606c67dbd15d0d581552f13f600dcdcb1db58af6683dd862cf5"
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C3C8:6038:383A247:3A558A2:61D2E495
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4996'
+            X-RateLimit-Reset: '1641214432'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '4'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch_non_existing.yaml
+++ b/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch_non_existing.yaml
@@ -1,0 +1,257 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/hello-world:
+      - metadata:
+          latency: 0.31723451614379883
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            allow_update_branch: false
+            archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+            clone_url: https://github.com/packit/hello-world.git
+            collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+            created_at: '2019-05-02T18:54:46Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+            events_url: https://api.github.com/repos/packit/hello-world/events
+            fork: false
+            forks: 20
+            forks_count: 20
+            forks_url: https://api.github.com/repos/packit/hello-world/forks
+            full_name: packit/hello-world
+            git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+            git_url: git://github.com/packit/hello-world.git
+            has_downloads: true
+            has_issues: true
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+            html_url: https://github.com/packit/hello-world
+            id: 184635124
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/packit/hello-world/merges
+            milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 20
+            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+            notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+            open_issues: 57
+            open_issues_count: 57
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+            pushed_at: '2022-01-03T06:50:35Z'
+            releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+            size: 58
+            ssh_url: git@github.com:packit/hello-world.git
+            stargazers_count: 4
+            stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+            subscribers_count: 9
+            subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+            svn_url: https://github.com/packit/hello-world
+            tags_url: https://api.github.com/repos/packit/hello-world/tags
+            teams_url: https://api.github.com/repos/packit/hello-world/teams
+            temp_clone_token: ''
+            topics: []
+            trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+            updated_at: '2021-11-30T09:33:55Z'
+            url: https://api.github.com/repos/packit/hello-world
+            visibility: public
+            watchers: 4
+            watchers_count: 4
+          _next: null
+          elapsed: 0.315507
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Mon, 03 Jan 2022 11:57:10 GMT
+            ETag: W/"cad969bec821c8b7182c0f49a48de8b0fb5b0b1219bdd9e869c8e7d2900d72eb"
+            Last-Modified: Tue, 30 Nov 2021 09:33:55 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C3CC:6210:A9ECCB6:ACB4237:61D2E496
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4995'
+            X-RateLimit-Reset: '1641214432'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '5'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/branches/non-existing:
+      - metadata:
+          latency: 0.19494342803955078
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            documentation_url: https://docs.github.com/rest/reference/repos#get-a-branch
+            message: Branch not found
+          _next: null
+          elapsed: 0.192827
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Mon, 03 Jan 2022 11:57:10 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept-Encoding, Accept, X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C3CC:6210:A9ECD1C:ACB4294:61D2E496
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4994'
+            X-RateLimit-Reset: '1641214432'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '6'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: Not Found
+          status_code: 404

--- a/tests/integration/github/test_generic_commands.py
+++ b/tests/integration/github/test_generic_commands.py
@@ -102,6 +102,14 @@ class GenericCommands(GithubTests):
         assert isinstance(flags, list)
         assert len(flags) == 0
 
+    def test_get_sha_from_branch(self):
+        commit_sha = self.hello_world_project.get_sha_from_branch("test-for-flock")
+        assert commit_sha and commit_sha.startswith("e2282f3")
+
+    def test_get_sha_from_branch_non_existing(self):
+        commit_sha = self.hello_world_project.get_sha_from_branch("non-existing")
+        assert commit_sha is None
+
     def test_get_sha_from_tag(self):
         assert (
             self.ogr_project.get_sha_from_tag("0.0.1")

--- a/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch.yaml
+++ b/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch.yaml
@@ -1,0 +1,362 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/14233409/repository/branches/change:
+      - metadata:
+          latency: 0.27193522453308105
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            can_push: true
+            commit:
+              author_email: lbarczio@redhat.com
+              author_name: Laura Barcziova
+              authored_date: '2019-09-10T16:05:10.000+02:00'
+              committed_date: '2019-09-10T16:05:10.000+02:00'
+              committer_email: lbarczio@redhat.com
+              committer_name: Laura Barcziova
+              created_at: '2019-09-10T16:05:10.000+02:00'
+              id: d490ec67dd98f69dfdc1732b98bb3189f0e0aace
+              message: 'another change
+
+                '
+              parent_ids:
+              - 3c1fb11dd358254cc3f1588f173e54e98c1d4c09
+              short_id: d490ec67
+              title: another change
+              trailers: {}
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/commit/d490ec67dd98f69dfdc1732b98bb3189f0e0aace
+            default: false
+            developers_can_merge: false
+            developers_can_push: false
+            merged: true
+            name: change
+            protected: false
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/tree/change
+          _next: null
+          elapsed: 0.2698
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6c7c0c537aa0ee23-CDG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:11 GMT
+            Etag: W/"92c9915fa183832a485dd585c7edd292"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-10-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '3'
+            RateLimit-Remaining: '1997'
+            RateLimit-Reset: '1641211091'
+            RateLimit-ResetTime: Mon, 03 Jan 2022 11:58:11 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=MmLqfxBkdL3kO0bOlyh0qs%2FN3rZONvorStFBaONSBJ075A8179qMdgwwHU8xyqRQnt7w%2F2s873geMbRNv0AQxE8XbTQG4l4SkIXE8jpLvazM3w0m%2BIvhnypmSiI%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FRFWSW476PEY5YAR5QANNVC7
+            X-Runtime: '0.071163'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.47954392433166504
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 7
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_error: null
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-09-24T09:39:59.056Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: ogr-tests
+            name_with_namespace: packit-service / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: packit-service
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 68
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access:
+                access_level: 50
+                notification_level: 3
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runners_token: VjGdzzwZbsTY37sxUeWL
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.477278
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6c7c0c507e5cee23-CDG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:11 GMT
+            Etag: W/"68b896c4475c5bfea67734391503fd68"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-17-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '2'
+            RateLimit-Remaining: '1998'
+            RateLimit-Reset: '1641211091'
+            RateLimit-ResetTime: Mon, 03 Jan 2022 11:58:11 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=fyQzDejTgO6E6rC9K9xN59zrkV2ZsHV3ZuAO%2BDxZhznZjcj%2FH5eijQTdRoF52zxpFWpfLbOwGsJfRz2w0ycuwyig%2BbSWPbuVMsvkJ8gwoZ9veZbdrdokPjG%2Bakg%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FRFWSVT10X82QETGMJSRW9CV
+            X-Runtime: '0.123441'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.384124755859375
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+            bio: CS student @ FI MUNI (also tutoring), working in Red Hat. Fan of
+              open-source, Haskell, functional programming, containers and Linux.
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 2
+            commit_email: matej.focko@outlook.com
+            confirmed_at: '2020-07-24T20:00:33.764Z'
+            created_at: '2016-01-15T21:12:31.705Z'
+            current_sign_in_at: '2022-01-03T11:54:06.293Z'
+            email: matej.focko@outlook.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            followers: 0
+            following: 0
+            id: 375555
+            identities:
+            - extern_uid: mfocko
+              provider: group_saml
+              saml_provider_id: 2868
+            - extern_uid: 46bd3cb0-73a0-11ea-8e0e-0a58ac142609
+              provider: group_saml
+              saml_provider_id: 1769
+            - extern_uid: '8149784'
+              provider: github
+              saml_provider_id: null
+            - extern_uid: '90177795'
+              provider: twitter
+              saml_provider_id: null
+            - extern_uid: '104088596414930556092'
+              provider: google_oauth2
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2022-01-03'
+            last_sign_in_at: '2021-12-27T13:33:08.631Z'
+            linkedin: mfocko
+            local_time: 12:57 PM
+            location: Brno, Czechia
+            name: Matej Focko
+            organization: Red Hat
+            private_profile: false
+            projects_limit: 100000
+            pronouns: ''
+            public_email: ''
+            shared_runners_minutes_limit: 2000
+            skype: ''
+            state: active
+            theme_id: 11
+            twitter: MatejFocko
+            two_factor_enabled: true
+            username: mfocko
+            web_url: https://gitlab.com/mfocko
+            website_url: https://me.mfocko.xyz
+            work_information: Red Hat
+          _next: null
+          elapsed: 0.382643
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6c7c0c4e9b2aee23-CDG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:11 GMT
+            Etag: W/"d918c4a5a7932a61fd85586b2356d38a"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-08-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '1'
+            RateLimit-Remaining: '1999'
+            RateLimit-Reset: '1641211090'
+            RateLimit-ResetTime: Mon, 03 Jan 2022 11:58:10 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=gSL8BoRKTWOo0acbxqxRRd6AjqreDrnZDN5lXivb6OGyfCqlRAAjbQomn%2Fb12W5dfvKi68Myh0egKSpMDdDVJfuABgOq70tY0uoldWLnDXJTp%2FI2Bj%2F84pVUOR0%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FRFWSVCT7RW1DZVK8Q117YFH
+            X-Runtime: '0.048006'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch_non_existing.yaml
+++ b/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch_non_existing.yaml
@@ -1,0 +1,335 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/14233409/repository/branches/non-existing:
+      - metadata:
+          latency: 0.26795482635498047
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: 404 Branch Not Found
+          _next: null
+          elapsed: 0.26613
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6c7c0c5b5ce1cd7b-CDG
+            Cache-Control: no-cache
+            Connection: keep-alive
+            Content-Length: '34'
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:13 GMT
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-08-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '6'
+            RateLimit-Remaining: '1994'
+            RateLimit-Reset: '1641211093'
+            RateLimit-ResetTime: Mon, 03 Jan 2022 11:58:13 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=zAdPJnh7hcEJED%2BxeL2aYLxD6JFvA%2Bw0w0P%2Fwa%2FfLiPqC5kZhmoYIf3evffG3zlsgrWYQPD6n%2FNM5XMDFEBxz%2FhsNqiJNrQB0RVKWihTXS9Ao1fvNEwFEOFRgjs%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FRFWSXBGDZCTDQZ2Z8R03XM6
+            X-Runtime: '0.075658'
+          raw: !!binary ""
+          reason: Not Found
+          status_code: 404
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.517845869064331
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 7
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_error: null
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2021-09-24T09:39:59.056Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: ogr-tests
+            name_with_namespace: packit-service / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: packit-service
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 68
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access:
+                access_level: 50
+                notification_level: 3
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runners_token: VjGdzzwZbsTY37sxUeWL
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.515794
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6c7c0c5828f3cd7b-CDG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:12 GMT
+            Etag: W/"68b896c4475c5bfea67734391503fd68"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-06-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '5'
+            RateLimit-Remaining: '1995'
+            RateLimit-Reset: '1641211092'
+            RateLimit-ResetTime: Mon, 03 Jan 2022 11:58:12 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=kkxL1qoy9aZ9OjDfZwibT%2BvC4cxExJSeCpVXOIzYccDn4lVwjR9P%2BLtQskldl7rPx%2B0NPEPUJgljTYszEcVC24gKlFKqXg5nax5SmGdCeuoVuggYUqn7nZ2ECFs%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FRFWSWW13ZY3KB4TBS4TXH48
+            X-Runtime: '0.301179'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.36397337913513184
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+            bio: CS student @ FI MUNI (also tutoring), working in Red Hat. Fan of
+              open-source, Haskell, functional programming, containers and Linux.
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 2
+            commit_email: matej.focko@outlook.com
+            confirmed_at: '2020-07-24T20:00:33.764Z'
+            created_at: '2016-01-15T21:12:31.705Z'
+            current_sign_in_at: '2022-01-03T11:54:06.293Z'
+            email: matej.focko@outlook.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            followers: 0
+            following: 0
+            id: 375555
+            identities:
+            - extern_uid: mfocko
+              provider: group_saml
+              saml_provider_id: 2868
+            - extern_uid: 46bd3cb0-73a0-11ea-8e0e-0a58ac142609
+              provider: group_saml
+              saml_provider_id: 1769
+            - extern_uid: '8149784'
+              provider: github
+              saml_provider_id: null
+            - extern_uid: '90177795'
+              provider: twitter
+              saml_provider_id: null
+            - extern_uid: '104088596414930556092'
+              provider: google_oauth2
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2022-01-03'
+            last_sign_in_at: '2021-12-27T13:33:08.631Z'
+            linkedin: mfocko
+            local_time: 12:57 PM
+            location: Brno, Czechia
+            name: Matej Focko
+            organization: Red Hat
+            private_profile: false
+            projects_limit: 100000
+            pronouns: ''
+            public_email: ''
+            shared_runners_minutes_limit: 2000
+            skype: ''
+            state: active
+            theme_id: 11
+            twitter: MatejFocko
+            two_factor_enabled: true
+            username: mfocko
+            web_url: https://gitlab.com/mfocko
+            website_url: https://me.mfocko.xyz
+            work_information: Red Hat
+          _next: null
+          elapsed: 0.361918
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6c7c0c566ea6cd7b-CDG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:12 GMT
+            Etag: W/"d918c4a5a7932a61fd85586b2356d38a"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-02-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '4'
+            RateLimit-Remaining: '1996'
+            RateLimit-Reset: '1641211092'
+            RateLimit-ResetTime: Mon, 03 Jan 2022 11:58:12 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=tfhIp%2BmUAwRnWKLW6z3P1kTu1Abasl9CqHu6EhuUP8s7j1kCy%2F2ioogHQitanTpkQTsUgNjAacaPCqx7ZCrh3EwAxAsunjKDYqnCGGpMkPPqjvKZe3AIe97Ugvc%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FRFWSWK003GBY01JGY1V0MG1
+            X-Runtime: '0.067524'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_generic_commands.py
+++ b/tests/integration/gitlab/test_generic_commands.py
@@ -117,6 +117,14 @@ class GenericCommands(GitlabTests):
         assert urls["git"] == "https://gitlab.com/packit-service/ogr-tests.git"
         assert urls["ssh"].endswith("git@gitlab.com:packit-service/ogr-tests.git")
 
+    def test_get_sha_from_branch(self):
+        commit_sha = self.project.get_sha_from_branch("change")
+        assert commit_sha and commit_sha.startswith("d490ec67")
+
+    def test_get_sha_from_branch_non_existing(self):
+        commit_sha = self.project.get_sha_from_branch("non-existing")
+        assert commit_sha is None
+
     def test_get_sha_from_tag(self):
         assert (
             self.project.get_sha_from_tag("0.1.0")

--- a/tests/integration/pagure/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch.yaml
+++ b/tests/integration/pagure/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch.yaml
@@ -1,0 +1,117 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://pagure.io/api/0/ogr-tests/git/branches?with_commits=True:
+      - metadata:
+          latency: 0.30194807052612305
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_generic_commands
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            branches:
+              for-testing-get-files: 8d11eac1773ee032977f5ec4a86683113d6a888d
+              master: 517121273b142293807606dbd7a2e0f514b21cc8
+              testPR: 1b491a6718ca39c249e4e15a1b9d74fb2ff9d90a
+            default:
+              master: 517121273b142293807606dbd7a2e0f514b21cc8
+            total_branches: 3
+          _next: null
+          elapsed: 0.299966
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '316'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-qNt8FReQuuuC0hpUY1Oo5sqJQ';
+              style-src 'self' 'nonce-qNt8FReQuuuC0hpUY1Oo5sqJQ'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:13 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYzE5NDMyNTQxMDEwNTQ5OTBlMGMwZGM0NWU2YjAwNzYwNzEyM2IyZSJ9.FLR2GQ.ZCdrPIRpCIZpfJbdygQeouEhIJg;
+              Expires=Thu, 03-Feb-2022 11:57:13 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://pagure.io/api/0/-/whoami:
+      - metadata:
+          latency: 0.5973160266876221
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_generic_commands
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.595134
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-QQgCumXc9eGP29QtRADWMDeHR';
+              style-src 'self' 'nonce-QQgCumXc9eGP29QtRADWMDeHR'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:13 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYzE5NDMyNTQxMDEwNTQ5OTBlMGMwZGM0NWU2YjAwNzYwNzEyM2IyZSJ9.FLR2GQ.ZCdrPIRpCIZpfJbdygQeouEhIJg;
+              Expires=Thu, 03-Feb-2022 11:57:13 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/pagure/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch_non_existing.yaml
+++ b/tests/integration/pagure/test_data/test_generic_commands/GenericCommands.test_get_sha_from_branch_non_existing.yaml
@@ -1,0 +1,117 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://pagure.io/api/0/ogr-tests/git/branches?with_commits=True:
+      - metadata:
+          latency: 0.18168854713439941
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_generic_commands
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            branches:
+              for-testing-get-files: 8d11eac1773ee032977f5ec4a86683113d6a888d
+              master: 517121273b142293807606dbd7a2e0f514b21cc8
+              testPR: 1b491a6718ca39c249e4e15a1b9d74fb2ff9d90a
+            default:
+              master: 517121273b142293807606dbd7a2e0f514b21cc8
+            total_branches: 3
+          _next: null
+          elapsed: 0.180001
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '316'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-cycGuSFA57qb4Y4OVw5nr1c4w';
+              style-src 'self' 'nonce-cycGuSFA57qb4Y4OVw5nr1c4w'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:14 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZWE1NzdiOWFjNWRlZDU2MDEzZDEzZjcwNTc2Y2RkYTg1MzE2MTdkOSJ9.FLR2Gg.usI7rSUxNrNd5TuZKJkSjn4EjhA;
+              Expires=Thu, 03-Feb-2022 11:57:14 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://pagure.io/api/0/-/whoami:
+      - metadata:
+          latency: 0.4928169250488281
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_generic_commands
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.490789
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-6aL52bnLsHQTXjNR2JRQsD2Ib';
+              style-src 'self' 'nonce-6aL52bnLsHQTXjNR2JRQsD2Ib'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Mon, 03 Jan 2022 11:57:14 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZWE1NzdiOWFjNWRlZDU2MDEzZDEzZjcwNTc2Y2RkYTg1MzE2MTdkOSJ9.FLR2Gg.usI7rSUxNrNd5TuZKJkSjn4EjhA;
+              Expires=Thu, 03-Feb-2022 11:57:14 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/pagure/test_generic_commands.py
+++ b/tests/integration/pagure/test_generic_commands.py
@@ -134,3 +134,11 @@ class GenericCommands(PagureTests):
     def test_delete(self):
         project = self.service.get_project(repo="delete-project", namespace="testing")
         project.delete()
+
+    def test_get_sha_from_branch(self):
+        commit_sha = self.ogr_project.get_sha_from_branch("testPR")
+        assert commit_sha and commit_sha.startswith("1b491a6")
+
+    def test_get_sha_from_branch_non_existing(self):
+        commit_sha = self.ogr_project.get_sha_from_branch("non-existing")
+        assert commit_sha is None


### PR DESCRIPTION
Required for passing commit hashes from service to testing farm for
merging of tests that are run on their side or usage in tmt preparation.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] tests
- [x] consider shared method `get_sha_from(branch=None, tag=None) -> Optional[str]`

---

<!-- release notes for changelog/blog follow -->

We have introduced a new function into `ogr` that allows you to get commit SHA of the HEAD of the branch.