### PR TITLE
Releases rework

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -16,7 +16,6 @@ from typing import (
     Union,
     Callable,
 )
-from urllib.request import urlopen
 
 import github
 import gitlab
@@ -1028,52 +1027,16 @@ class Release(OgrAbstractClass):
     Object that represents release.
 
     Attributes:
-        tag_name (str): Name of the related tag.
-        url (str, optional): URL of the release.
-        created_at (str): Datetime of creating the release.
-        tarball_url (str): URL of the tarball.
-        git_tag (GitTag): Object that represents related tag.
         project (GitProject): Project on which the release is created.
     """
 
     def __init__(
         self,
-        tag_name: str,
-        url: Optional[str],
-        created_at: str,
-        tarball_url: str,
-        git_tag: GitTag,
+        raw_release: Any,
         project: "GitProject",
     ) -> None:
-        self.tag_name = tag_name
-        self.url = url
-        self.created_at = created_at
-        self.tarball_url = tarball_url
-        self.git_tag = git_tag
+        self._raw_release = raw_release
         self.project = project
-
-    @property
-    def title(self) -> str:
-        """Title of the release."""
-        raise NotImplementedError()
-
-    @property
-    def body(self) -> str:
-        """Body of the release."""
-        raise NotImplementedError()
-
-    def save_archive(self, filename: str) -> None:
-        """
-        Save tarball of the release to requested `filename`.
-
-        Args:
-            filename: Path to the file to save archive to.
-        """
-        response = urlopen(self.tarball_url)
-        data = response.read()
-
-        with open(filename, "wb") as file:
-            file.write(data)
 
     def __str__(self) -> str:
         return (
@@ -1085,6 +1048,119 @@ class Release(OgrAbstractClass):
             f"created_at='{self.created_at}', "
             f"tarball_url='{self.tarball_url}')"
         )
+
+    @property
+    def title(self) -> str:
+        """Title of the release."""
+        raise NotImplementedError()
+
+    @property
+    def body(self) -> str:
+        """Body of the release."""
+        raise NotImplementedError()
+
+    @property
+    def git_tag(self) -> GitTag:
+        """Object that represents tag tied to the release."""
+        raise NotImplementedError()
+
+    @property
+    def tag_name(self) -> str:
+        """Tag tied to the release."""
+        raise NotImplementedError()
+
+    @property
+    def url(self) -> Optional[str]:
+        """URL of the release."""
+        raise NotImplementedError()
+
+    # TODO: Check if should really be string
+    @property
+    def created_at(self) -> datetime.datetime:
+        """Datetime of creating the release."""
+        raise NotImplementedError()
+
+    @property
+    def tarball_url(self) -> str:
+        """URL of the tarball."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def get(
+        project: Any,
+        identifier: Optional[int] = None,
+        name: Optional[str] = None,
+        tag_name: Optional[str] = None,
+    ) -> "Release":
+        """
+        Get a single release.
+
+        Args:
+            identifier: Identifier of the release.
+
+                Defaults to `None`, which means not being used.
+            name: Name of the release.
+
+                Defaults to `None`, which means not being used.
+            tag_name: Tag that the release is tied to.
+
+                Defaults to `None`, which means not being used.
+
+        Returns:
+            Object that represents release that satisfies requested condition.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_latest(project: Any) -> Optional["Release"]:
+        """
+        Returns:
+            Object that represents the latest release.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def get_list(project: Any) -> List["Release"]:
+        """
+        Returns:
+            List of the objects that represent releases.
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def create(
+        project: Any,
+        tag: str,
+        name: str,
+        message: str,
+        ref: Optional[str] = None,
+    ) -> "Release":
+        """
+        Create new release.
+
+        Args:
+            project: Project where the release is to be created.
+            tag: Tag which is the release based off.
+            name: Name of the release.
+            message: Message or description of the release.
+            ref: Git reference, mainly commit hash for the release. If provided
+                git tag is created prior to creating a release.
+
+                Defaults to `None`.
+
+        Returns:
+            Object that represents newly created release.
+        """
+        raise NotImplementedError()
+
+    def save_archive(self, filename: str) -> None:
+        """
+        Save tarball of the release to requested `filename`.
+
+        Args:
+            filename: Path to the file to save archive to.
+        """
+        raise NotImplementedError()
 
     def edit_release(self, name: str, message: str) -> None:
         """
@@ -1536,6 +1612,26 @@ class GitProject(OgrAbstractClass):
         """
         Returns:
             List of the objects that represent releases.
+        """
+        raise NotImplementedError()
+
+    def create_release(
+        self, tag: str, name: str, message: str, ref: Optional[str] = None
+    ) -> Release:
+        """
+        Create new release.
+
+        Args:
+            tag: Tag which is the release based off.
+            name: Name of the release.
+            message: Message or description of the release.
+            ref: Git reference, mainly commit hash for the release. If provided
+                git tag is created prior to creating a release.
+
+                Defaults to `None`.
+
+        Returns:
+            Object that represents newly created release.
         """
         raise NotImplementedError()
 

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from typing import List, Optional, Any
+from urllib.request import urlopen
 
 from ogr.abstract import (
     GitService,
@@ -12,6 +13,7 @@ from ogr.abstract import (
     PullRequest,
     CommitFlag,
     CommitStatus,
+    Release,
 )
 from ogr.exceptions import OgrException
 from ogr.parsing import parse_git_repo
@@ -102,3 +104,12 @@ class BaseCommitFlag(CommitFlag):
             raise ValueError("Invalid state given")
 
         return state
+
+
+class BaseRelease(Release):
+    def save_archive(self, filename: str) -> None:
+        response = urlopen(self.tarball_url)
+        data = response.read()
+
+        with open(filename, "wb") as file:
+            file.write(data)

--- a/ogr/services/github/release.py
+++ b/ogr/services/github/release.py
@@ -1,35 +1,116 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import datetime
+from typing import List, Optional
+from github import GithubException
 from github.GitRelease import GitRelease as PyGithubRelease
 
 from ogr.abstract import Release, GitTag
+from ogr.exceptions import GithubAPIException
 from ogr.services import github as ogr_github
 
 
 class GithubRelease(Release):
+    _raw_release: PyGithubRelease
     project: "ogr_github.GithubProject"
 
-    def __init__(
-        self,
-        tag_name: str,
-        url: str,
-        created_at: str,
-        tarball_url: str,
-        git_tag: GitTag,
-        project: "ogr_github.GithubProject",
-        raw_release: PyGithubRelease,
-    ) -> None:
-        super().__init__(tag_name, url, created_at, tarball_url, git_tag, project)
-        self.raw_release = raw_release
+    @staticmethod
+    def _release_id_from_name(
+        project: "ogr_github.GithubProject", name: str
+    ) -> Optional[int]:
+        releases = project.github_repo.get_releases()
+        for release in releases:
+            if release.title == name:
+                return release.id
+        return None
+
+    @staticmethod
+    def _release_id_from_tag(
+        project: "ogr_github.GithubProject", tag: str
+    ) -> Optional[int]:
+        releases = project.github_repo.get_releases()
+        for release in releases:
+            if release.tag_name == tag:
+                return release.id
+        return None
 
     @property
     def title(self):
-        return self.raw_release.title
+        return self._raw_release.title
 
     @property
     def body(self):
-        return self.raw_release.body
+        return self._raw_release.body
+
+    @property
+    def git_tag(self) -> GitTag:
+        return self.project.get_tag_from_tag_name(self.tag_name)
+
+    @property
+    def tag_name(self) -> str:
+        return self._raw_release.tag_name
+
+    @property
+    def url(self) -> Optional[str]:
+        return self._raw_release.url
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        return self._raw_release.created_at
+
+    @property
+    def tarball_url(self) -> str:
+        return self._raw_release.tarball_url
+
+    def __str__(self) -> str:
+        return "Github" + super().__str__()
+
+    @staticmethod
+    def get(
+        project: "ogr_github.GithubProject",
+        identifier: Optional[int] = None,
+        name: Optional[str] = None,
+        tag_name: Optional[str] = None,
+    ) -> "Release":
+        if tag_name:
+            identifier = GithubRelease._release_id_from_tag(project, tag_name)
+        elif name:
+            identifier = GithubRelease._release_id_from_name(project, name)
+        if identifier is None:
+            raise GithubAPIException("Release was not found.")
+        release = project.github_repo.get_release(id=identifier)
+        return GithubRelease(release, project)
+
+    @staticmethod
+    def get_latest(project: "ogr_github.GithubProject") -> Optional["Release"]:
+        try:
+            release = project.github_repo.get_latest_release()
+            return GithubRelease(release, project)
+        except GithubException as ex:
+            if ex.status == 404:
+                return None
+            raise GithubAPIException from ex
+
+    @staticmethod
+    def get_list(project: "ogr_github.GithubProject") -> List["Release"]:
+        releases = project.github_repo.get_releases()
+        return [GithubRelease(release, project) for release in releases]
+
+    @staticmethod
+    def create(
+        project: "ogr_github.GithubProject",
+        tag: str,
+        name: str,
+        message: str,
+        ref: Optional[str] = None,
+    ) -> "Release":
+        created_release = project.github_repo.create_git_release(
+            tag=tag, name=name, message=message
+        )
+        return GithubRelease(created_release, project)
+        # XXX: Why?
+        return GithubRelease.get(project, created_release.id)
 
     def edit_release(self, name: str, message: str) -> None:
         """
@@ -39,4 +120,4 @@ class GithubRelease(Release):
             name: New name of the release.
             message: New message for the release.
         """
-        self.raw_release = self.raw_release.update_release(name=name, message=message)
+        self._raw_release = self._raw_release.update_release(name=name, message=message)

--- a/ogr/services/github/release.py
+++ b/ogr/services/github/release.py
@@ -109,8 +109,6 @@ class GithubRelease(Release):
             tag=tag, name=name, message=message
         )
         return GithubRelease(created_release, project)
-        # XXX: Why?
-        return GithubRelease.get(project, created_release.id)
 
     def edit_release(self, name: str, message: str) -> None:
         """

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -384,47 +384,23 @@ class GitlabProject(BaseGitProject):
         git_tag = self.gitlab_repo.tags.get(tag_name)
         return GitTag(name=git_tag.name, commit_sha=git_tag.commit["id"])
 
+    @indirect(GitlabRelease.get_list)
     def get_releases(self) -> List[Release]:
-        if not hasattr(self.gitlab_repo, "releases"):
-            raise OperationNotSupported(
-                "This version of python-gitlab does not support release, please upgrade."
-            )
-        releases = self.gitlab_repo.releases.list(all=True)
-        return [
-            self._release_from_gitlab_object(
-                raw_release=release,
-                git_tag=self._git_tag_from_tag_name(release.tag_name),
-            )
-            for release in releases
-        ]
+        pass
 
+    @indirect(GitlabRelease.get)
     def get_release(self, identifier=None, name=None, tag_name=None) -> GitlabRelease:
-        release = self.gitlab_repo.releases.get(tag_name)
-        return self._release_from_gitlab_object(
-            raw_release=release, git_tag=self._git_tag_from_tag_name(release.tag_name)
-        )
+        pass
 
+    @indirect(GitlabRelease.create)
     def create_release(
-        self, name: str, tag_name: str, description: str, ref=None
+        self, tag: str, name: str, message: str, commit_sha: Optional[str] = None
     ) -> GitlabRelease:
-        release = self.gitlab_repo.releases.create(
-            {"name": name, "tag_name": tag_name, "description": description, "ref": ref}
-        )
-        return self._release_from_gitlab_object(
-            raw_release=release, git_tag=self._git_tag_from_tag_name(release.tag_name)
-        )
+        pass
 
+    @indirect(GitlabRelease.get_latest)
     def get_latest_release(self) -> Optional[GitlabRelease]:
-        releases = self.gitlab_repo.releases.list()
-        # list of releases sorted by released_at
-        return (
-            self._release_from_gitlab_object(
-                raw_release=releases[0],
-                git_tag=self._git_tag_from_tag_name(releases[0].tag_name),
-            )
-            if releases
-            else None
-        )
+        pass
 
     def list_labels(self):
         """
@@ -490,19 +466,6 @@ class GitlabProject(BaseGitProject):
     def _commit_comment_from_gitlab_object(raw_comment, commit) -> CommitComment:
         return CommitComment(
             sha=commit, comment=raw_comment.note, author=raw_comment.author["username"]
-        )
-
-    def _release_from_gitlab_object(
-        self, raw_release, git_tag: GitTag
-    ) -> GitlabRelease:
-        return GitlabRelease(
-            tag_name=raw_release.tag_name,
-            url=None,
-            created_at=raw_release.created_at,
-            tarball_url=raw_release.assets["sources"][1]["url"],
-            git_tag=git_tag,
-            project=self,
-            raw_release=raw_release,
         )
 
     def get_web_url(self) -> str:

--- a/ogr/services/gitlab/release.py
+++ b/ogr/services/gitlab/release.py
@@ -33,8 +33,7 @@ class GitlabRelease(Release):
 
     @property
     def url(self) -> Optional[str]:
-        # no link is provided
-        return None
+        return f"{self.project.get_web_url()}/-/releases/{self.tag_name}"
 
     @property
     def created_at(self) -> datetime.datetime:

--- a/ogr/services/gitlab/release.py
+++ b/ogr/services/gitlab/release.py
@@ -1,7 +1,10 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from typing import Optional
+from gitlab.v4.objects import ProjectRelease as _GitlabRelease
+
+import datetime
+from typing import Optional, List
 
 from ogr.abstract import Release, GitTag
 from ogr.services import gitlab as ogr_gitlab
@@ -9,28 +12,78 @@ from ogr.exceptions import OperationNotSupported
 
 
 class GitlabRelease(Release):
+    _raw_release: _GitlabRelease
     project: "ogr_gitlab.GitlabProject"
-
-    def __init__(
-        self,
-        tag_name: str,
-        url: Optional[str],
-        created_at: str,
-        tarball_url: str,
-        git_tag: GitTag,
-        project: "ogr_gitlab.GitlabProject",
-        raw_release,
-    ) -> None:
-        super().__init__(tag_name, url, created_at, tarball_url, git_tag, project)
-        self.raw_release = raw_release
 
     @property
     def title(self):
-        return self.raw_release.name
+        return self._raw_release.name
 
     @property
     def body(self):
-        return self.raw_release.description
+        return self._raw_release.description
+
+    @property
+    def git_tag(self) -> GitTag:
+        return self.project._git_tag_from_tag_name(self.tag_name)
+
+    @property
+    def tag_name(self) -> str:
+        return self._raw_release.tag_name
+
+    @property
+    def url(self) -> Optional[str]:
+        # no link is provided
+        return None
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        return self._raw_release.created_at
+
+    @property
+    def tarball_url(self) -> str:
+        return self._raw_release.assets["sources"][1]["url"]
+
+    def __str__(self) -> str:
+        return "Gitlab" + super().__str__()
+
+    @staticmethod
+    def get(
+        project: "ogr_gitlab.GitlabProject",
+        identifier: Optional[int] = None,
+        name: Optional[str] = None,
+        tag_name: Optional[str] = None,
+    ) -> "Release":
+        release = project.gitlab_repo.releases.get(tag_name)
+        return GitlabRelease(release, project)
+
+    @staticmethod
+    def get_latest(project: "ogr_gitlab.GitlabProject") -> Optional["Release"]:
+        releases = project.gitlab_repo.releases.list()
+        # list of releases sorted by released_at
+        return GitlabRelease(releases[0], project) if releases else None
+
+    @staticmethod
+    def get_list(project: "ogr_gitlab.GitlabProject") -> List["Release"]:
+        if not hasattr(project.gitlab_repo, "releases"):
+            raise OperationNotSupported(
+                "This version of python-gitlab does not support release, please upgrade."
+            )
+        releases = project.gitlab_repo.releases.list(all=True)
+        return [GitlabRelease(release, project) for release in releases]
+
+    @staticmethod
+    def create(
+        project: "ogr_gitlab.GitlabProject",
+        tag: str,
+        name: str,
+        message: str,
+        ref: Optional[str] = None,
+    ) -> "Release":
+        release = project.gitlab_repo.releases.create(
+            {"name": name, "tag_name": tag, "description": message, "ref": ref}
+        )
+        return GitlabRelease(release, project)
 
     def edit_release(self, name: str, message: str) -> None:
         raise OperationNotSupported("edit_release not supported on GitLab")

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -433,26 +433,23 @@ class PagureProject(BaseGitProject):
         response = self._call_project_api("git", "tags", params={"with_commits": True})
         return {n: GitTag(name=n, commit_sha=c) for n, c in response["tags"].items()}
 
+    @indirect(PagureRelease.get_list)
     def get_releases(self) -> List[Release]:
-        # git tag for Pagure is shown as Release in Pagure UI
-        git_tags = self.get_tags()
-        return [self._release_from_git_tag(git_tag) for git_tag in git_tags]
+        pass
 
+    @indirect(PagureRelease.get)
     def get_release(self, identifier=None, name=None, tag_name=None) -> PagureRelease:
-        raise OperationNotSupported
+        pass
 
+    @indirect(PagureRelease.get_latest)
     def get_latest_release(self) -> Optional[PagureRelease]:
-        raise OperationNotSupported
+        pass
 
-    def _release_from_git_tag(self, git_tag: GitTag) -> PagureRelease:
-        return PagureRelease(
-            tag_name=git_tag.name,
-            url="",
-            created_at="",
-            tarball_url="",
-            git_tag=git_tag,
-            project=self,
-        )
+    @indirect(PagureRelease.create)
+    def create_release(
+        self, tag: str, name: str, message: str, ref: Optional[str] = None
+    ) -> Release:
+        pass
 
     def get_forks(self) -> List["PagureProject"]:
         forks_url = self.service.get_api_url("projects")

--- a/ogr/services/pagure/release.py
+++ b/ogr/services/pagure/release.py
@@ -1,24 +1,17 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import datetime
+from typing import List, Optional
+
 from ogr.abstract import GitTag, Release
 from ogr.services import pagure as ogr_pagure
-from ogr.exceptions import OperationNotSupported
+from ogr.exceptions import OperationNotSupported, PagureAPIException
 
 
 class PagureRelease(Release):
+    _raw_release: GitTag
     project: "ogr_pagure.PagureProject"
-
-    def __init__(
-        self,
-        tag_name: str,
-        url: str,
-        created_at: str,
-        tarball_url: str,
-        git_tag: GitTag,
-        project: "ogr_pagure.PagureProject",
-    ) -> None:
-        super().__init__(tag_name, url, created_at, tarball_url, git_tag, project)
 
     @property
     def title(self):
@@ -27,6 +20,69 @@ class PagureRelease(Release):
     @property
     def body(self):
         return ""
+
+    @property
+    def git_tag(self) -> GitTag:
+        return self._raw_release
+
+    @property
+    def tag_name(self) -> str:
+        return self._raw_release.name
+
+    @property
+    def url(self) -> Optional[str]:
+        return ""
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        return None
+
+    @property
+    def tarball_url(self) -> str:
+        return ""
+
+    def __str__(self) -> str:
+        return "Pagure" + super().__str__()
+
+    @staticmethod
+    def get(
+        project: "ogr_pagure.PagureProject",
+        identifier: Optional[int] = None,
+        name: Optional[str] = None,
+        tag_name: Optional[str] = None,
+    ) -> "Release":
+        raise OperationNotSupported()
+
+    @staticmethod
+    def get_latest(project: "ogr_pagure.PagureProject") -> Optional["Release"]:
+        raise OperationNotSupported("Pagure API does not provide timestamps")
+
+    @staticmethod
+    def get_list(project: "ogr_pagure.PagureProject") -> List["Release"]:
+        # git tag for Pagure is shown as Release in Pagure UI
+        git_tags = project.get_tags()
+        return [PagureRelease(git_tag, project) for git_tag in git_tags]
+
+    @staticmethod
+    def create(
+        project: "ogr_pagure.PagureProject",
+        tag: str,
+        name: str,
+        message: str,
+        ref: Optional[str] = None,
+    ) -> "Release":
+        payload = {
+            "tagname": tag,
+            "commit_hash": ref,
+        }
+        if message:
+            payload["message"] = message
+
+        response = project._call_project_api("git", "tags", data=payload, method="POST")
+        if not response["tag_created"]:
+            raise PagureAPIException("Release has not been created")
+
+        return PagureRelease(GitTag(tag, ref), project)
 
     def edit_release(self, name: str, message: str) -> None:
         raise OperationNotSupported("edit_release not supported on Pagure")

--- a/tests/integration/gitlab/test_releases.py
+++ b/tests/integration/gitlab/test_releases.py
@@ -19,8 +19,8 @@ class Releases(GitlabTests):
         count_before = len(releases_before)
         release = self.project.create_release(
             name=f"test {increased}",
-            tag_name=increased,
-            description=f"testing release-{increased}",
+            tag=increased,
+            message=f"testing release-{increased}",
             ref="master",
         )
         count_after = len(self.project.get_releases())

--- a/tests/integration/gitlab/test_releases.py
+++ b/tests/integration/gitlab/test_releases.py
@@ -28,6 +28,10 @@ class Releases(GitlabTests):
         assert release.title == f"test {increased}"
         assert release.body == f"testing release-{increased}"
         assert count_before + 1 == count_after
+        assert (
+            release.url
+            == f"https://gitlab.com/packit-service/ogr-tests/-/releases/{increased}"
+        )
 
     def test_get_releases(self):
         try:
@@ -40,6 +44,10 @@ class Releases(GitlabTests):
         assert releases[-1].title == "test"
         assert releases[-1].tag_name == "0.1.0"
         assert releases[-1].body == "testing release"
+        assert (
+            releases[-1].url
+            == "https://gitlab.com/packit-service/ogr-tests/-/releases/0.1.0"
+        )
 
     def test_get_releases_pagination(self):
         # in time of writing tests using graphviz/graphviz (60 releases)
@@ -60,6 +68,10 @@ class Releases(GitlabTests):
         assert latest_release.title == release.title
         assert latest_release.tag_name == release.tag_name
         assert latest_release.body == release.body
+        assert (
+            latest_release.url
+            == f"https://gitlab.com/packit-service/ogr-tests/-/releases/{release.tag_name}"
+        )
 
     def test_get_latest_release_doesnt_exist(self):
         project = self.service.project_create(repo="ogr-playground")

--- a/tests/integration/pagure/test_data/test_project_token/PagureProjectTokenCommands.test_create_release.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/PagureProjectTokenCommands.test_create_release.yaml
@@ -1,0 +1,173 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://pagure.io/api/0/ogr-tests/git/tags?with_commits=True:
+      - metadata:
+          latency: 0.3335845470428467
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.release
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            tags:
+              v0: 2988640e03ddee8385a2acb827a36c8e50b1be1a
+            total_tags: 1
+          _next: null
+          elapsed: 0.3327
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '93'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-QKAiRlhXGMYfoGHpo14bhj5tx';
+              style-src 'self' 'nonce-QKAiRlhXGMYfoGHpo14bhj5tx'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Tue, 04 Jan 2022 14:17:57 GMT
+            Keep-Alive: timeout=5, max=98
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYWQyNDAyZDY2NTU2YjdhNGEzMGU1NDdlODZmMmM1NjZiNTJhYzljYyJ9.FLXolQ.4pkQ_RK8WtbZXUYf6v2wij4CKKA;
+              Expires=Fri, 04-Feb-2022 14:17:57 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://pagure.io/api/0/-/whoami:
+      - metadata:
+          latency: 0.6511719226837158
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.649696
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-SydyPwOcWQBAk5jB1HPCJuZvI';
+              style-src 'self' 'nonce-SydyPwOcWQBAk5jB1HPCJuZvI'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Tue, 04 Jan 2022 14:17:56 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYWQyNDAyZDY2NTU2YjdhNGEzMGU1NDdlODZmMmM1NjZiNTJhYzljYyJ9.FLXolA.QR75LOKRtQZjBtmuL7nmqwqOZ0A;
+              Expires=Fri, 04-Feb-2022 14:17:56 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://pagure.io/api/0/ogr-tests/git/tags:
+      - metadata:
+          latency: 0.2436363697052002
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.release
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            tag_created: true
+            tags:
+            - v0
+            total_tags: 1
+          _next: null
+          elapsed: 0.242707
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '73'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-99Bj0DG3KAS0Dd35K59GD0H05';
+              style-src 'self' 'nonce-99Bj0DG3KAS0Dd35K59GD0H05'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Tue, 04 Jan 2022 14:17:57 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYWQyNDAyZDY2NTU2YjdhNGEzMGU1NDdlODZmMmM1NjZiNTJhYzljYyJ9.FLXolQ.4pkQ_RK8WtbZXUYf6v2wij4CKKA;
+              Expires=Fri, 04-Feb-2022 14:17:57 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/pagure/test_project_token.py
+++ b/tests/integration/pagure/test_project_token.py
@@ -198,3 +198,14 @@ class PagureProjectTokenCommands(PagureTests):
 
         self.service.user.get_username()
         self.service.user.get_username()  # 2nd identical call
+
+    def test_create_release(self):
+        self.ogr_project.create_release(
+            tag="v0",
+            name="v0",
+            message="# v0\n\n• added README",
+            ref="2988640e03ddee8385a2acb827a36c8e50b1be1a",
+        )
+        assert "v0" in map(
+            lambda release: release.tag_name, self.ogr_project.get_releases()
+        )


### PR DESCRIPTION
breaking changes:
- reordered and renamed parameters for `.create_release`
  * also introduced into `GitProject`s API

Fixes #86
Fixes #112

---

RELEASE NOTES BEGIN
Release class in ogr has been reworked and `create_release` has been made part of the API for `GitProject`.
RELEASE NOTES END