### PR TITLE
Update classifiers to mark support for Python 3.9 and 3.10

### DIFF
--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Optional, Union
 
 import requests
+import urllib3
 
 from ogr.exceptions import (
     PagureAPIException,
@@ -36,7 +37,7 @@ class PagureService(BaseGitService):
         instance_url: str = "https://src.fedoraproject.org",
         read_only: bool = False,
         insecure: bool = False,
-        max_retries: Union[int, requests.packages.urllib3.util.Retry] = 5,
+        max_retries: Union[int, urllib3.util.Retry] = 5,
         **kwargs,
     ) -> None:
         super().__init__()

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,12 +36,14 @@ keywords =
 [options]
 packages = find:
 install_requires =
+    cryptography
     Deprecated
     GitPython
     PyGithub
-    PyYAML
-    cryptography
     python-gitlab
+    PyYAML
+    requests
+    urllib3
 python_requires = >=3.6
 include_package_data = True
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development
     Topic :: Utilities
 keywords =


### PR DESCRIPTION
So that this is also correctly displayed on PyPI.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

---

n/a