### PR TITLE
Deprecation warning with Github Retry kwarg

### DIFF
--- a/ogr/services/github/service.py
+++ b/ogr/services/github/service.py
@@ -65,7 +65,7 @@ class GithubService(BaseGitService):
                 total=int(max_retries),
                 read=0,
                 # Retry mechanism active for these HTTP methods:
-                method_whitelist=["DELETE", "GET", "PATCH", "POST", "PUT"],
+                allowed_methods=["DELETE", "GET", "PATCH", "POST", "PUT"],
                 # Only retry on following HTTP status codes
                 status_forcelist=[500, 503, 403, 401],
                 raise_on_status=False,


### PR DESCRIPTION
We were getting a warning during our pytest tests:
```
DeprecationWarning: Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0. Use 'allowed_methods' instead
    self._max_retries = Retry(
```
Changelog here: https://github.com/urllib3/urllib3/blob/9571a9860437f4ce2ebb04803a90625db5ba52ee/CHANGES.rst#1260-2020-11-10

This should hopefully resolve it, not sure if there are any tests that need to be updated regarding this.