### PR TITLE
Improve parsing of service class from URL

### DIFF
--- a/ogr/factory.py
+++ b/ogr/factory.py
@@ -130,8 +130,9 @@ def get_service_class_or_none(
     if service_mapping_update:
         mapping.update(service_mapping_update)
 
+    parsed_url = parse_git_repo(url)
     for service, service_kls in mapping.items():
-        if service in url:
+        if service in parsed_url.hostname:
             return service_kls
 
     return None

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -38,6 +38,22 @@ from ogr.services.pagure import PagureProject
         ("https://pagure.something.com/ogr", None, PagureService),
         ("https://gitlab.com/someone/project", None, GitlabService),
         ("https://gitlab.abcd.def/someone/project", None, GitlabService),
+        (
+            "https://src.fedoraproject.org/rpms/golang-gitlab-flimzy-testy",
+            None,
+            PagureService,
+        ),
+        (
+            "https://src.stg.fedoraproject.org/rpms/golang-gitlab-flimzy-testy",
+            None,
+            PagureService,
+        ),
+        ("https://src.fedoraproject.org/rpms/python-gitlab", None, PagureService),
+        (
+            "https://src.fedoraproject.org/rpms/golang-gitlab-yawning-utls",
+            None,
+            PagureService,
+        ),
     ],
 )
 def test_get_service_class(url, mapping, result):


### PR DESCRIPTION
Instead of trying to find substring that could indicate usage of specific
git forge, parse the URL first and then look for the indication in parsed
«hostname». That way we avoid situations when parts of service names, e.g.
gitlab or pagure, could be included in the URL and matched with the service
even though they are not part of the hostname.

Fixes #663

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [ ] Consider reorganizing the code in the factory methods to parse the URL only once from the callers of affected function.

RELEASE NOTES BEGIN
Factory method for acquiring project or service class from URL has been improved by checking just the hostname for determining the service.
RELEASE NOTES END