### PR TITLE
feat(forks): allow forking to specific namespace

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -1733,9 +1733,15 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
-    def fork_create(self) -> "GitProject":
+    def fork_create(self, namespace: Optional[str] = None) -> "GitProject":
         """
         Fork this project using the authenticated user.
+
+        Args:
+            namespace: Namespace where the project should be forked.
+
+                Defaults to `None`, which means forking to the namespace of
+                currently authenticated user.
 
         Returns:
             Fork of the current project.

--- a/ogr/read_only.py
+++ b/ogr/read_only.py
@@ -233,7 +233,9 @@ class GitProjectReadOnly:
         )
 
     @classmethod
-    def fork_create(cls, original_object: Any) -> "GitProject":
+    def fork_create(
+        cls, original_object: Any, namespace: Optional[str] = None
+    ) -> "GitProject":
         return original_object
 
     @classmethod

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -386,11 +386,14 @@ class GithubProject(BaseGitProject):
         return {"git": self.github_repo.clone_url, "ssh": self.github_repo.ssh_url}
 
     @if_readonly(return_function=GitProjectReadOnly.fork_create)
-    def fork_create(self) -> "GithubProject":
-        gh_user = self.github_instance.get_user()
-        fork = self.service.get_project_from_github_repository(
-            gh_user.create_fork(self.github_repo)
+    def fork_create(self, namespace: Optional[str] = None) -> "GithubProject":
+        fork_repo = (
+            self.github_repo.create_fork(organization=namespace)
+            if namespace
+            else self.github_repo.create_fork()
         )
+
+        fork = self.service.get_project_from_github_repository(fork_repo)
         logger.debug(f"Forked to {fork.namespace}/{fork.repo}")
         return fork
 

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -302,9 +302,13 @@ class GitlabProject(BaseGitProject):
             "ssh": self.gitlab_repo.attributes["ssh_url_to_repo"],
         }
 
-    def fork_create(self) -> "GitlabProject":
+    def fork_create(self, namespace: Optional[str] = None) -> "GitlabProject":
+        data = {}
+        if namespace:
+            data["namespace_path"] = namespace
+
         try:
-            fork = self.gitlab_repo.forks.create({})
+            fork = self.gitlab_repo.forks.create(data=data)
         except gitlab.GitlabCreateError as ex:
             logger.error(f"Repo {self.gitlab_repo} cannot be forked")
             raise GitlabAPIException(

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -266,7 +266,12 @@ class PagureProject(BaseGitProject):
         pass
 
     @if_readonly(return_function=GitProjectReadOnly.fork_create)
-    def fork_create(self) -> "PagureProject":
+    def fork_create(self, namespace: Optional[str] = None) -> "PagureProject":
+        if namespace is not None:
+            raise OperationNotSupported(
+                "Pagure does not support forking to namespaces."
+            )
+
         request_url = self.service.get_api_url("fork")
         self.service.call_api(
             url=request_url,

--- a/tests/integration/github/test_data/test_forks/Forks.test_create_fork_with_namespace.yaml
+++ b/tests/integration/github/test_data/test_forks/Forks.test_create_fork_with_namespace.yaml
@@ -1,0 +1,747 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/ogr-tests-mfocko/GithubProject(namespace=%22packit%22,%20repo=%22hello-world%22):
+      - metadata:
+          latency: 0.22756433486938477
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_forks
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            documentation_url: https://docs.github.com/rest/reference/repos#get-a-repository
+            message: Not Found
+          _next: null
+          elapsed: 0.226925
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Thu, 17 Mar 2022 10:27:26 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept-Encoding, Accept, X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C5A4:E07E:4200B6E:42F9122:62330D0E
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4998'
+            X-RateLimit-Reset: '1647516446'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '2'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: Not Found
+          status_code: 404
+      https://api.github.com:443/repos/packit/hello-world:
+      - metadata:
+          latency: 0.27149224281311035
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_forks
+          - ogr.abstract
+          - ogr.read_only
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            allow_update_branch: false
+            archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+            clone_url: https://github.com/packit/hello-world.git
+            collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+            created_at: '2019-05-02T18:54:46Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+            events_url: https://api.github.com/repos/packit/hello-world/events
+            fork: false
+            forks: 20
+            forks_count: 20
+            forks_url: https://api.github.com/repos/packit/hello-world/forks
+            full_name: packit/hello-world
+            git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+            git_url: git://github.com/packit/hello-world.git
+            has_downloads: true
+            has_issues: true
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+            html_url: https://github.com/packit/hello-world
+            id: 184635124
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/packit/hello-world/merges
+            milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 20
+            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+            notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+            open_issues: 66
+            open_issues_count: 66
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+            pushed_at: '2022-03-17T05:18:09Z'
+            releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+            size: 47
+            ssh_url: git@github.com:packit/hello-world.git
+            stargazers_count: 4
+            stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+            subscribers_count: 8
+            subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+            svn_url: https://github.com/packit/hello-world
+            tags_url: https://api.github.com/repos/packit/hello-world/tags
+            teams_url: https://api.github.com/repos/packit/hello-world/teams
+            temp_clone_token: ''
+            topics: []
+            trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+            updated_at: '2022-02-04T14:06:18Z'
+            url: https://api.github.com/repos/packit/hello-world
+            visibility: public
+            watchers: 4
+            watchers_count: 4
+          _next: null
+          elapsed: 0.27083
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Thu, 17 Mar 2022 10:27:26 GMT
+            ETag: W/"5e60df2f06af45e04b0bc3aedbef6c705c9e17f9872a034eae60ec485f46b256"
+            Last-Modified: Fri, 04 Feb 2022 14:06:18 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C5A6:E07B:CC72FA:D73E2E:62330D0E
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4997'
+            X-RateLimit-Reset: '1647516446'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '3'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/user:
+      - metadata:
+          latency: 0.267899751663208
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_forks
+          - ogr.abstract
+          - ogr.services.github.user
+          - github.AuthenticatedUser
+          - github.GithubObject
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://avatars.githubusercontent.com/u/8149784?v=4
+            bio: CS student @ FI MUNI (also tutoring), working in Red Hat. Fan of
+              open-source, Haskell, functional programming, containers and Linux.
+            blog: https://me.mfocko.xyz
+            collaborators: 0
+            company: Red Hat
+            created_at: '2014-07-13T12:54:55Z'
+            disk_usage: 27502
+            email: null
+            events_url: https://api.github.com/users/mfocko/events{/privacy}
+            followers: 14
+            followers_url: https://api.github.com/users/mfocko/followers
+            following: 76
+            following_url: https://api.github.com/users/mfocko/following{/other_user}
+            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+            gravatar_id: ''
+            hireable: true
+            html_url: https://github.com/mfocko
+            id: 8149784
+            location: Brno, Czech Republic
+            login: mfocko
+            name: Matej Focko
+            node_id: MDQ6VXNlcjgxNDk3ODQ=
+            organizations_url: https://api.github.com/users/mfocko/orgs
+            owned_private_repos: 4
+            plan:
+              collaborators: 0
+              name: pro
+              private_repos: 9999
+              space: 976562499
+            private_gists: 5
+            public_gists: 4
+            public_repos: 45
+            received_events_url: https://api.github.com/users/mfocko/received_events
+            repos_url: https://api.github.com/users/mfocko/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+            total_private_repos: 4
+            twitter_username: MatejFocko
+            two_factor_authentication: true
+            type: User
+            updated_at: '2022-03-10T12:37:45Z'
+            url: https://api.github.com/users/mfocko
+          _next: null
+          elapsed: 0.267403
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Thu, 17 Mar 2022 10:27:26 GMT
+            ETag: W/"c4f29526e034ad22afb6cf00a7486b36974be46fa6b6b332e80a80f0947cf0c3"
+            Last-Modified: Thu, 10 Mar 2022 12:37:45 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C5A2:222B:1A2F392:1ACE7A3:62330D0D
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4999'
+            X-RateLimit-Reset: '1647516446'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '1'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://api.github.com:443/repos/packit/hello-world/forks:
+      - metadata:
+          latency: 1.1624956130981445
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_forks
+          - ogr.abstract
+          - ogr.read_only
+          - ogr.services.github.project
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_forking: true
+            archive_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/branches{/branch}
+            clone_url: https://github.com/ogr-tests-mfocko/hello-world.git
+            collaborators_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/contributors
+            created_at: '2022-03-17T10:27:26Z'
+            default_branch: main
+            deployments_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/downloads
+            events_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/events
+            fork: true
+            forks: 0
+            forks_count: 0
+            forks_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/forks
+            full_name: ogr-tests-mfocko/hello-world
+            git_commits_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/git/tags{/sha}
+            git_url: git://github.com/ogr-tests-mfocko/hello-world.git
+            has_downloads: true
+            has_issues: false
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/hooks
+            html_url: https://github.com/ogr-tests-mfocko/hello-world
+            id: 470946107
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/labels{/name}
+            language: null
+            languages_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/merges
+            milestones_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 21
+            node_id: R_kgDOHBIROw
+            notifications_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/notifications{?since,all,participating}
+            open_issues: 0
+            open_issues_count: 0
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/101801583?v=4
+              events_url: https://api.github.com/users/ogr-tests-mfocko/events{/privacy}
+              followers_url: https://api.github.com/users/ogr-tests-mfocko/followers
+              following_url: https://api.github.com/users/ogr-tests-mfocko/following{/other_user}
+              gists_url: https://api.github.com/users/ogr-tests-mfocko/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/ogr-tests-mfocko
+              id: 101801583
+              login: ogr-tests-mfocko
+              node_id: O_kgDOBhFebw
+              organizations_url: https://api.github.com/users/ogr-tests-mfocko/orgs
+              received_events_url: https://api.github.com/users/ogr-tests-mfocko/received_events
+              repos_url: https://api.github.com/users/ogr-tests-mfocko/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/ogr-tests-mfocko/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/ogr-tests-mfocko/subscriptions
+              type: Organization
+              url: https://api.github.com/users/ogr-tests-mfocko
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/101801583?v=4
+              events_url: https://api.github.com/users/ogr-tests-mfocko/events{/privacy}
+              followers_url: https://api.github.com/users/ogr-tests-mfocko/followers
+              following_url: https://api.github.com/users/ogr-tests-mfocko/following{/other_user}
+              gists_url: https://api.github.com/users/ogr-tests-mfocko/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/ogr-tests-mfocko
+              id: 101801583
+              login: ogr-tests-mfocko
+              node_id: O_kgDOBhFebw
+              organizations_url: https://api.github.com/users/ogr-tests-mfocko/orgs
+              received_events_url: https://api.github.com/users/ogr-tests-mfocko/received_events
+              repos_url: https://api.github.com/users/ogr-tests-mfocko/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/ogr-tests-mfocko/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/ogr-tests-mfocko/subscriptions
+              type: Organization
+              url: https://api.github.com/users/ogr-tests-mfocko
+            parent:
+              allow_forking: true
+              archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+              archived: false
+              assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+              blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+              branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+              clone_url: https://github.com/packit/hello-world.git
+              collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+              comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+              commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+              compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+              contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+              contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+              created_at: '2019-05-02T18:54:46Z'
+              default_branch: main
+              deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+              description: The most progresive command-line tool in the world.
+              disabled: false
+              downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+              events_url: https://api.github.com/repos/packit/hello-world/events
+              fork: false
+              forks: 21
+              forks_count: 21
+              forks_url: https://api.github.com/repos/packit/hello-world/forks
+              full_name: packit/hello-world
+              git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+              git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+              git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+              git_url: git://github.com/packit/hello-world.git
+              has_downloads: true
+              has_issues: true
+              has_pages: false
+              has_projects: true
+              has_wiki: true
+              homepage: null
+              hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+              html_url: https://github.com/packit/hello-world
+              id: 184635124
+              is_template: false
+              issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+              issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+              issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+              keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+              labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+              language: Python
+              languages_url: https://api.github.com/repos/packit/hello-world/languages
+              license:
+                key: mit
+                name: MIT License
+                node_id: MDc6TGljZW5zZTEz
+                spdx_id: MIT
+                url: https://api.github.com/licenses/mit
+              merges_url: https://api.github.com/repos/packit/hello-world/merges
+              milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+              mirror_url: null
+              name: hello-world
+              node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+              notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+              open_issues: 66
+              open_issues_count: 66
+              owner:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+              private: false
+              pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+              pushed_at: '2022-03-17T05:18:09Z'
+              releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+              size: 47
+              ssh_url: git@github.com:packit/hello-world.git
+              stargazers_count: 4
+              stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+              statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+              subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+              subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+              svn_url: https://github.com/packit/hello-world
+              tags_url: https://api.github.com/repos/packit/hello-world/tags
+              teams_url: https://api.github.com/repos/packit/hello-world/teams
+              topics: []
+              trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+              updated_at: '2022-02-04T14:06:18Z'
+              url: https://api.github.com/repos/packit/hello-world
+              visibility: public
+              watchers: 4
+              watchers_count: 4
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/pulls{/number}
+            pushed_at: '2022-03-17T05:18:09Z'
+            releases_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/releases{/id}
+            size: 47
+            source:
+              allow_forking: true
+              archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+              archived: false
+              assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+              blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+              branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+              clone_url: https://github.com/packit/hello-world.git
+              collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+              comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+              commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+              compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+              contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+              contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+              created_at: '2019-05-02T18:54:46Z'
+              default_branch: main
+              deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+              description: The most progresive command-line tool in the world.
+              disabled: false
+              downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+              events_url: https://api.github.com/repos/packit/hello-world/events
+              fork: false
+              forks: 21
+              forks_count: 21
+              forks_url: https://api.github.com/repos/packit/hello-world/forks
+              full_name: packit/hello-world
+              git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+              git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+              git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+              git_url: git://github.com/packit/hello-world.git
+              has_downloads: true
+              has_issues: true
+              has_pages: false
+              has_projects: true
+              has_wiki: true
+              homepage: null
+              hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+              html_url: https://github.com/packit/hello-world
+              id: 184635124
+              is_template: false
+              issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+              issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+              issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+              keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+              labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+              language: Python
+              languages_url: https://api.github.com/repos/packit/hello-world/languages
+              license:
+                key: mit
+                name: MIT License
+                node_id: MDc6TGljZW5zZTEz
+                spdx_id: MIT
+                url: https://api.github.com/licenses/mit
+              merges_url: https://api.github.com/repos/packit/hello-world/merges
+              milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+              mirror_url: null
+              name: hello-world
+              node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+              notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+              open_issues: 66
+              open_issues_count: 66
+              owner:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+              private: false
+              pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+              pushed_at: '2022-03-17T05:18:09Z'
+              releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+              size: 47
+              ssh_url: git@github.com:packit/hello-world.git
+              stargazers_count: 4
+              stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+              statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+              subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+              subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+              svn_url: https://github.com/packit/hello-world
+              tags_url: https://api.github.com/repos/packit/hello-world/tags
+              teams_url: https://api.github.com/repos/packit/hello-world/teams
+              topics: []
+              trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+              updated_at: '2022-02-04T14:06:18Z'
+              url: https://api.github.com/repos/packit/hello-world
+              visibility: public
+              watchers: 4
+              watchers_count: 4
+            ssh_url: git@github.com:ogr-tests-mfocko/hello-world.git
+            stargazers_count: 0
+            stargazers_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/statuses/{sha}
+            subscribers_count: 0
+            subscribers_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/subscription
+            svn_url: https://github.com/ogr-tests-mfocko/hello-world
+            tags_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/tags
+            teams_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/teams
+            topics: []
+            trees_url: https://api.github.com/repos/ogr-tests-mfocko/hello-world/git/trees{/sha}
+            updated_at: '2022-02-04T14:06:18Z'
+            url: https://api.github.com/repos/ogr-tests-mfocko/hello-world
+            visibility: public
+            watchers: 0
+            watchers_count: 0
+          _next: null
+          elapsed: 1.135627
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Content-Length: '16642'
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Thu, 17 Mar 2022 10:27:27 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Vary: Accept-Encoding, Accept, X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: C5A6:E07B:CC731D:D73E4C:62330D0E
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4996'
+            X-RateLimit-Reset: '1647516446'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '4'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: Accepted
+          status_code: 202

--- a/tests/integration/github/test_forks.py
+++ b/tests/integration/github/test_forks.py
@@ -63,3 +63,18 @@ class Forks(GithubTests):
 
         new_forks = self.not_forked_project.service.user.get_forks()
         assert len(old_forks) == len(new_forks) - 1
+
+    def test_create_fork_with_namespace(self):
+        """
+        When regenerating create a testing namespace:
+        ogr-tests-‹your login on the git forge›
+        """
+        namespace = f"ogr-tests-{self.service.user.get_username()}"
+        expected_fork = self.service.get_project(
+            namespace=namespace, repo=self.hello_world_project
+        )
+        assert not expected_fork.exists(), "Fork should not exist before regenerating"
+
+        fork = self.hello_world_project.fork_create(namespace=namespace)
+        assert fork.exists()
+        assert fork.is_fork

--- a/tests/integration/gitlab/test_data/test_forks/Forks.test_create_fork_with_namespace.yaml
+++ b/tests/integration/gitlab/test_data/test_forks/Forks.test_create_fork_with_namespace.yaml
@@ -1,0 +1,735 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/ogr-tests-mfocko%2Fogr-tests:
+      - metadata:
+          latency: 0.22911834716796875
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_forks
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: 404 Project Not Found
+          _next: null
+          elapsed: 0.228734
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6ed507617cf6413e-PRG
+            Cache-Control: no-cache
+            Connection: keep-alive
+            Content-Length: '35'
+            Content-Type: application/json
+            Date: Thu, 17 Mar 2022 10:26:11 GMT
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-05-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '2'
+            RateLimit-Remaining: '1998'
+            RateLimit-Reset: '1647512830'
+            RateLimit-ResetTime: Thu, 17 Mar 2022 10:27:10 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=ycvrMSHSuIQw9wYfnOypIsGI0gVQc3z%2BDJEtILyHE5QUONBpj38Pv7%2BOOb%2BuP32W5DyxiVFx7UpewMXi2hfr6ewK3AskWjykokNpK7LA9jehA6SJy2yxUnIvYv4%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FYBPKPAE883543WNVDXSF3TP
+            X-Runtime: '0.034449'
+          raw: !!binary ""
+          reason: Not Found
+          status_code: 404
+      - metadata:
+          latency: 0.3568401336669922
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_forks
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/34568757/events
+              issues: https://gitlab.com/api/v4/projects/34568757/issues
+              labels: https://gitlab.com/api/v4/projects/34568757/labels
+              members: https://gitlab.com/api/v4/projects/34568757/members
+              merge_requests: https://gitlab.com/api/v4/projects/34568757/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/34568757/repository/branches
+              self: https://gitlab.com/api/v4/projects/34568757
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: true
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 1d
+              enabled: false
+              keep_n: 10
+              name_regex: .*
+              name_regex_keep: null
+              next_run_at: '2022-03-18T10:26:11.670Z'
+              older_than: 90d
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/ogr-tests-mfocko/ogr-tests
+            created_at: '2022-03-17T10:26:11.642Z'
+            creator_id: 375555
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forked_from_project:
+              avatar_url: null
+              created_at: '2019-09-10T10:28:09.946Z'
+              default_branch: master
+              description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+              forks_count: 8
+              http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+              id: 14233409
+              last_activity_at: '2022-01-05T18:40:31.301Z'
+              name: ogr-tests
+              name_with_namespace: packit-service / ogr-tests
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+                full_path: packit-service
+                id: 6032704
+                kind: group
+                name: packit-service
+                parent_id: null
+                path: packit-service
+                web_url: https://gitlab.com/groups/packit-service
+              path: ogr-tests
+              path_with_namespace: packit-service/ogr-tests
+              readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+              ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+              star_count: 0
+              tag_list: []
+              topics: []
+              web_url: https://gitlab.com/packit-service/ogr-tests
+            forking_access_level: enabled
+            forks_count: 0
+            http_url_to_repo: https://gitlab.com/ogr-tests-mfocko/ogr-tests.git
+            id: 34568757
+            import_error: null
+            import_status: finished
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2022-03-17T10:26:11.642Z'
+            lfs_enabled: true
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            mr_default_target_self: false
+            name: ogr-tests
+            name_with_namespace: ogr-tests-mfocko / ogr-tests
+            namespace:
+              avatar_url: null
+              full_path: ogr-tests-mfocko
+              id: 27132103
+              kind: group
+              name: ogr-tests-mfocko
+              parent_id: null
+              path: ogr-tests-mfocko
+              web_url: https://gitlab.com/groups/ogr-tests-mfocko
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 0
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: ogr-tests-mfocko/ogr-tests
+            permissions:
+              group_access:
+                access_level: 50
+                notification_level: 3
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: null
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runner_token_expiration_interval: null
+            runners_token: GR1348941ixEx-jDD3dDfcn2jE1Fx
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+ogr-tests-mfocko-ogr-tests-34568757-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:ogr-tests-mfocko/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: private
+            web_url: https://gitlab.com/ogr-tests-mfocko/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.356029
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6ed50769a931413e-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Thu, 17 Mar 2022 10:26:12 GMT
+            Etag: W/"06cee28312d0e48ac568d3289441a1f7"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-27-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '5'
+            RateLimit-Remaining: '1995'
+            RateLimit-Reset: '1647512832'
+            RateLimit-ResetTime: Thu, 17 Mar 2022 10:27:12 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=128BcHvCl3mj68nJp3q46lQm63IY2wHgzCAm4%2BPzj0p%2BClh32thU%2FYliQIQ%2FQnfeaUY8%2F%2BS6ecN1pXH6KE7zpsHpIS966rKaElJChh1QUpY4NLeErYqreXU6vZc%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FYBPKQKRWZ9CC6GAR6WXQBAE
+            X-Runtime: '0.158396'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.3028240203857422
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_forks
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            approvals_before_merge: 0
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            emails_disabled: null
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 7
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_error: null
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: null
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2022-01-05T18:40:31.301Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: null
+            merge_trains_enabled: false
+            mirror: false
+            name: ogr-tests
+            name_with_namespace: packit-service / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: packit-service
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 71
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access:
+                access_level: 50
+                notification_level: 3
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_access_level: enabled
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runner_token_expiration_interval: null
+            runners_token: GR1348941sWEgsQKmwrxmdNipZmMH
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.302058
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6ed5076308d4413e-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Thu, 17 Mar 2022 10:26:11 GMT
+            Etag: W/"77501ca0f58d42c783245df6bd6cb867"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-14-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '3'
+            RateLimit-Remaining: '1997'
+            RateLimit-Reset: '1647512831'
+            RateLimit-ResetTime: Thu, 17 Mar 2022 10:27:11 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=QUx1Aay7bcN8WJVAy1k1LbIqOEhWT8K2YCph1Sya1BdC1CgIII7H%2Fi4ebhhcQUvqHtxcTfnchOUS3%2FHc2DFx9zjhjrq63Rug4aoPGiJl2828Jmtdwk9RjYHUHz8%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FYBPKPJ2P347WN4837SSHTJB
+            X-Runtime: '0.130113'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.5997002124786377
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_forks
+          - ogr.abstract
+          - ogr.services.gitlab.user
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.v4.objects.users
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+            bio: CS student @ FI MUNI (also tutoring), working in Red Hat. Fan of
+              open-source, Haskell, functional programming, containers and Linux.
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 2
+            commit_email: matej.focko@outlook.com
+            confirmed_at: '2020-07-24T20:00:33.764Z'
+            created_at: '2016-01-15T21:12:31.705Z'
+            current_sign_in_at: '2022-03-06T19:31:48.370Z'
+            email: matej.focko@outlook.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            followers: 0
+            following: 0
+            id: 375555
+            identities:
+            - extern_uid: mfocko
+              provider: group_saml
+              saml_provider_id: 2868
+            - extern_uid: 46bd3cb0-73a0-11ea-8e0e-0a58ac142609
+              provider: group_saml
+              saml_provider_id: 1769
+            - extern_uid: '8149784'
+              provider: github
+              saml_provider_id: null
+            - extern_uid: '90177795'
+              provider: twitter
+              saml_provider_id: null
+            - extern_uid: '104088596414930556092'
+              provider: google_oauth2
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2022-03-17'
+            last_sign_in_at: '2022-03-05T11:22:27.310Z'
+            linkedin: mfocko
+            local_time: 11:26 AM
+            location: Brno, Czechia
+            name: Matej Focko
+            organization: Red Hat
+            private_profile: false
+            projects_limit: 100000
+            pronouns: ''
+            public_email: ''
+            shared_runners_minutes_limit: 2000
+            skype: ''
+            state: active
+            theme_id: 11
+            twitter: MatejFocko
+            two_factor_enabled: true
+            username: mfocko
+            web_url: https://gitlab.com/mfocko
+            website_url: https://me.mfocko.xyz
+            work_information: Red Hat
+          _next: null
+          elapsed: 0.599015
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6ed5075e2d12413e-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Thu, 17 Mar 2022 10:26:10 GMT
+            Etag: W/"1024046aed1426587b8ea40706ca0b6d"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-02-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '1'
+            RateLimit-Remaining: '1999'
+            RateLimit-Reset: '1647512830'
+            RateLimit-ResetTime: Thu, 17 Mar 2022 10:27:10 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=LFDi%2B5wsuj5gmfgUvJ%2BLra2UOoPIDm12NxS57EIIOCAjanKU93feVlztnAwKXOX6y%2F9vvSbNI1UXcRrHFoYz%2BBN3hbL02qP09yHZghoLRq3a%2F%2B6Qak4kYYeDS3E%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FYBPKP0V7QRHKN6FK5EMPCYK
+            X-Runtime: '0.085363'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://gitlab.com/api/v4/projects/14233409/fork:
+      - metadata:
+          latency: 0.7377490997314453
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_forks
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/34568757/events
+              issues: https://gitlab.com/api/v4/projects/34568757/issues
+              labels: https://gitlab.com/api/v4/projects/34568757/labels
+              members: https://gitlab.com/api/v4/projects/34568757/members
+              merge_requests: https://gitlab.com/api/v4/projects/34568757/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/34568757/repository/branches
+              self: https://gitlab.com/api/v4/projects/34568757
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_coverage_regex: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: true
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 1d
+              enabled: false
+              keep_n: 10
+              name_regex: .*
+              name_regex_keep: null
+              next_run_at: '2022-03-18T10:26:11.670Z'
+              older_than: 90d
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/ogr-tests-mfocko/ogr-tests
+            created_at: '2022-03-17T10:26:11.642Z'
+            creator_id: 375555
+            default_branch: main
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            emails_disabled: null
+            empty_repo: true
+            external_authorization_classification_label: ''
+            forked_from_project:
+              avatar_url: null
+              created_at: '2019-09-10T10:28:09.946Z'
+              default_branch: master
+              description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+              forks_count: 8
+              http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+              id: 14233409
+              last_activity_at: '2022-01-05T18:40:31.301Z'
+              name: ogr-tests
+              name_with_namespace: packit-service / ogr-tests
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+                full_path: packit-service
+                id: 6032704
+                kind: group
+                name: packit-service
+                parent_id: null
+                path: packit-service
+                web_url: https://gitlab.com/groups/packit-service
+              path: ogr-tests
+              path_with_namespace: packit-service/ogr-tests
+              readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+              ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+              star_count: 0
+              tag_list: []
+              topics: []
+              web_url: https://gitlab.com/packit-service/ogr-tests
+            forking_access_level: enabled
+            forks_count: 0
+            http_url_to_repo: https://gitlab.com/ogr-tests-mfocko/ogr-tests.git
+            id: 34568757
+            import_error: null
+            import_status: scheduled
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2022-03-17T10:26:11.642Z'
+            lfs_enabled: true
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            mr_default_target_self: false
+            name: ogr-tests
+            name_with_namespace: ogr-tests-mfocko / ogr-tests
+            namespace:
+              avatar_url: null
+              full_path: ogr-tests-mfocko
+              id: 27132103
+              kind: group
+              name: ogr-tests-mfocko
+              parent_id: null
+              path: ogr-tests-mfocko
+              web_url: https://gitlab.com/groups/ogr-tests-mfocko
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 0
+            operations_access_level: enabled
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: ogr-tests-mfocko/ogr-tests
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: null
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: true
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runner_token_expiration_interval: null
+            runners_token: GR1348941ixEx-jDD3dDfcn2jE1Fx
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+ogr-tests-mfocko-ogr-tests-34568757-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:ogr-tests-mfocko/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            visibility: private
+            web_url: https://gitlab.com/ogr-tests-mfocko/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.737134
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6ed507650e12413e-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Type: application/json
+            Date: Thu, 17 Mar 2022 10:26:12 GMT
+            Etag: W/"bd01254566eefd71449bffecc9f440e3"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-27-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '4'
+            RateLimit-Remaining: '1996'
+            RateLimit-Reset: '1647512832'
+            RateLimit-ResetTime: Thu, 17 Mar 2022 10:27:12 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=VzgQis7Z6BYMFLzeoSanIMlMiuoFJVSQymr5kvVRo9L5SgzJQ9qbfcmEgAV97kBd3V1iUsu%2BG%2BQCIn8RVqiL8XoRI1Hj3kpwZi3GTVH6my2RdAG5VmjV988Ce5A%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FYBPKPW00B2YD4WEZ2GN4HJC
+            X-Runtime: '0.559444'
+          raw: !!binary ""
+          reason: Created
+          status_code: 201

--- a/tests/integration/gitlab/test_forks.py
+++ b/tests/integration/gitlab/test_forks.py
@@ -37,3 +37,18 @@ class Forks(GitlabTests):
         assert self.project.get_fork()
         assert self.project.is_forked()
         assert new_fork.is_fork
+
+    def test_create_fork_with_namespace(self):
+        """
+        When regenerating create a testing namespace:
+        ogr-tests-‹your login on the git forge›
+        """
+        namespace = f"ogr-tests-{self.service.user.get_username()}"
+        expected_fork = self.service.get_project(
+            namespace=namespace, repo=self.project.repo
+        )
+        assert not expected_fork.exists(), "Fork should not exist before regenerating"
+
+        fork = self.project.fork_create(namespace=namespace)
+        assert fork.exists()
+        assert fork.is_fork

--- a/tests/integration/pagure/test_data/test_forks/Forks.test_create_fork_with_namespace.yaml
+++ b/tests/integration/pagure/test_data/test_forks/Forks.test_create_fork_with_namespace.yaml
@@ -1,0 +1,59 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    POST:
+      https://pagure.io/api/0/-/whoami:
+      - metadata:
+          latency: 0.6148264408111572
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_forks
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.614113
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-qeK3fOUYLA2AdeO4QYBdbeMfF';
+              style-src 'self' 'nonce-qeK3fOUYLA2AdeO4QYBdbeMfF'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Tue, 15 Mar 2022 19:46:21 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZjI0OGU5YmQxNjhlZjFiYTMyMmU1ZTExODUyM2Q1YmVmMWQyNzk2YSJ9.FRJ-jQ.owEzU8TIP3y_Amrs2FsUIDZqPu0;
+              Expires=Fri, 15-Apr-2022 19:46:21 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/pagure/test_forks.py
+++ b/tests/integration/pagure/test_forks.py
@@ -4,7 +4,7 @@
 from requre.online_replacing import record_requests_for_all_methods
 
 from tests.integration.pagure.base import PagureTests
-from ogr.exceptions import PagureAPIException
+from ogr.exceptions import OperationNotSupported, PagureAPIException
 
 
 @record_requests_for_all_methods()
@@ -67,3 +67,7 @@ class Forks(PagureTests):
 
         new_forks = self.ogr_project.service.user.get_forks()
         assert len(old_forks) == len(new_forks) - 1
+
+    def test_create_fork_with_namespace(self):
+        with self.assertRaises(OperationNotSupported):
+            self.ogr_project.fork_create(namespace="some_random_namespace")


### PR DESCRIPTION
Allow users to fork repositories to specific namespace or organization
rather than their user namespace.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] tests

Fixes #631

RELEASE NOTES BEGIN
We have added a new optional parameter `namespace` to `fork_create` method on git projects, which allows you to fork project into a specific namespace. (Forking to namespaces is not allowed on Pagure.)
RELEASE NOTES END