### PR TITLE
Use both prod and stg Packit instance

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,4 +1,5 @@
 ---
+packit_instances: ["prod", "stg"]
 specfile_path: fedora/python-ogr.spec
 # https://packit.dev/docs/configuration/#top-level-keys
 downstream_package_name: python-ogr
@@ -26,6 +27,8 @@ jobs:
 
   - job: propose_downstream
     trigger: release
+    # Use the stage instance once it works in downstream.
+    packit_instances: ["prod"]
     metadata:
       dist_git_branches:
         - fedora-all
@@ -74,12 +77,16 @@ jobs:
   # downstream automation:
   - job: koji_build
     trigger: commit
+    # Use the stage once it works in downstream.
+    packit_instances: ["prod"]
     metadata:
       dist_git_branches:
         - fedora-all
         - epel-8
   - job: bodhi_update
     trigger: commit
+    # Use the stage instance once it works in downstream.
+    packit_instances: ["prod"]
     metadata:
       dist_git_branches:
         - fedora-stable # rawhide updates are created automatically

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,11 @@ repos:
     hooks:
       - id: pyupgrade
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.6.1
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -35,7 +35,7 @@ repos:
       - id: flake8
         args: [--max-line-length=100]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.940
+    rev: v0.942
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]


### PR DESCRIPTION
And use a production instance for downstream jobs until the stage one does not work.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
