### PR TITLE
feat: implement getting contributors

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -1881,6 +1881,13 @@ class GitProject(OgrAbstractClass):
         """
         raise NotImplementedError()
 
+    def get_contributors(self) -> Set[str]:
+        """
+        Returns:
+            Set of all contributors to the given project.
+        """
+        raise NotImplementedError()
+
 
 class GitUser(OgrAbstractClass):
     """

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -527,3 +527,10 @@ class GithubProject(BaseGitProject):
             if ex.status == 404:
                 return None
             raise GithubAPIException from ex
+
+    def get_contributors(self) -> Set[str]:
+        """
+        Returns:
+            Logins of contributors to the project.
+        """
+        return set(map(lambda c: c.login, self.github_repo.get_contributors()))

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from typing import List, Optional, Dict, Set, Union
+from typing import Any, List, Optional, Dict, Set, Union
 
 import gitlab
 from gitlab.exceptions import GitlabGetError
@@ -486,3 +486,16 @@ class GitlabProject(BaseGitProject):
             if ex.response_code == 404:
                 return None
             raise GitlabAPIException from ex
+
+    def get_contributors(self) -> Set[str]:
+        """
+        Returns:
+            Unique authors of the commits in the project.
+        """
+
+        def format_contributor(contributor: Dict[str, Any]) -> str:
+            return f"{contributor['name']} <{contributor['email']}>"
+
+        return set(
+            map(format_contributor, self.gitlab_repo.repository_contributors(all=True))
+        )

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -523,3 +523,6 @@ class PagureProject(BaseGitProject):
         )["branches"]
 
         return branches.get(branch)
+
+    def get_contributors(self) -> Set[str]:
+        raise OperationNotSupported("Pagure doesn't provide list of contributors")

--- a/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_contributors.yaml
+++ b/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_contributors.yaml
@@ -1,0 +1,1033 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/ogr:
+      - metadata:
+          latency: 0.25812840461730957
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            allow_update_branch: false
+            archive_url: https://api.github.com/repos/packit/ogr/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/ogr/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/ogr/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/ogr/branches{/branch}
+            clone_url: https://github.com/packit/ogr.git
+            collaborators_url: https://api.github.com/repos/packit/ogr/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/ogr/comments{/number}
+            commits_url: https://api.github.com/repos/packit/ogr/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/ogr/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/ogr/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/ogr/contributors
+            created_at: '2018-12-13T12:33:52Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/ogr/deployments
+            description: One Git library to Rule -- one API for many git forges
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/ogr/downloads
+            events_url: https://api.github.com/repos/packit/ogr/events
+            fork: false
+            forks: 50
+            forks_count: 50
+            forks_url: https://api.github.com/repos/packit/ogr/forks
+            full_name: packit/ogr
+            git_commits_url: https://api.github.com/repos/packit/ogr/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/ogr/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/ogr/git/tags{/sha}
+            git_url: git://github.com/packit/ogr.git
+            has_downloads: true
+            has_issues: true
+            has_pages: true
+            has_projects: true
+            has_wiki: true
+            homepage: ''
+            hooks_url: https://api.github.com/repos/packit/ogr/hooks
+            html_url: https://github.com/packit/ogr
+            id: 161636700
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/packit/ogr/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/ogr/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/ogr/issues{/number}
+            keys_url: https://api.github.com/repos/packit/ogr/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/ogr/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/ogr/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/packit/ogr/merges
+            milestones_url: https://api.github.com/repos/packit/ogr/milestones{/number}
+            mirror_url: null
+            name: ogr
+            network_count: 50
+            node_id: MDEwOlJlcG9zaXRvcnkxNjE2MzY3MDA=
+            notifications_url: https://api.github.com/repos/packit/ogr/notifications{?since,all,participating}
+            open_issues: 18
+            open_issues_count: 18
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/ogr/pulls{/number}
+            pushed_at: '2022-03-29T13:44:48Z'
+            releases_url: https://api.github.com/repos/packit/ogr/releases{/id}
+            size: 13099
+            ssh_url: git@github.com:packit/ogr.git
+            stargazers_count: 37
+            stargazers_url: https://api.github.com/repos/packit/ogr/stargazers
+            statuses_url: https://api.github.com/repos/packit/ogr/statuses/{sha}
+            subscribers_count: 11
+            subscribers_url: https://api.github.com/repos/packit/ogr/subscribers
+            subscription_url: https://api.github.com/repos/packit/ogr/subscription
+            svn_url: https://github.com/packit/ogr
+            tags_url: https://api.github.com/repos/packit/ogr/tags
+            teams_url: https://api.github.com/repos/packit/ogr/teams
+            temp_clone_token: ''
+            topics:
+            - git
+            - github
+            - hacktoberfest
+            - pagure
+            - python
+            - python3
+            trees_url: https://api.github.com/repos/packit/ogr/git/trees{/sha}
+            updated_at: '2022-01-06T14:31:23Z'
+            url: https://api.github.com/repos/packit/ogr
+            visibility: public
+            watchers: 37
+            watchers_count: 37
+          _next: null
+          elapsed: 0.257425
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Wed, 30 Mar 2022 08:55:09 GMT
+            ETag: W/"e070b06de06024f0f232452d73cbea10db12f9ac9b2248072ed1c12ef0a7f586"
+            Last-Modified: Thu, 06 Jan 2022 14:31:23 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 7A33:101B8:A0F0ADE:A3B46C1:62441AED
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4996'
+            X-RateLimit-Reset: '1648630931'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '4'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/ogr/contributors:
+      - metadata:
+          latency: 0.3289792537689209
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.PaginatedList
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - avatar_url: https://avatars.githubusercontent.com/in/6924?v=4
+            contributions: 280
+            events_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/events{/privacy}
+            followers_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/followers
+            following_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/following{/other_user}
+            gists_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/apps/softwarefactory-project-zuul
+            id: 33884098
+            login: softwarefactory-project-zuul[bot]
+            node_id: MDM6Qm90MzM4ODQwOTg=
+            organizations_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/orgs
+            received_events_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/received_events
+            repos_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D/subscriptions
+            type: Bot
+            url: https://api.github.com/users/softwarefactory-project-zuul%5Bbot%5D
+          - avatar_url: https://avatars.githubusercontent.com/u/20214043?v=4
+            contributions: 257
+            events_url: https://api.github.com/users/lachmanfrantisek/events{/privacy}
+            followers_url: https://api.github.com/users/lachmanfrantisek/followers
+            following_url: https://api.github.com/users/lachmanfrantisek/following{/other_user}
+            gists_url: https://api.github.com/users/lachmanfrantisek/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/lachmanfrantisek
+            id: 20214043
+            login: lachmanfrantisek
+            node_id: MDQ6VXNlcjIwMjE0MDQz
+            organizations_url: https://api.github.com/users/lachmanfrantisek/orgs
+            received_events_url: https://api.github.com/users/lachmanfrantisek/received_events
+            repos_url: https://api.github.com/users/lachmanfrantisek/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/lachmanfrantisek/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/lachmanfrantisek/subscriptions
+            type: User
+            url: https://api.github.com/users/lachmanfrantisek
+          - avatar_url: https://avatars.githubusercontent.com/u/8149784?v=4
+            contributions: 230
+            events_url: https://api.github.com/users/mfocko/events{/privacy}
+            followers_url: https://api.github.com/users/mfocko/followers
+            following_url: https://api.github.com/users/mfocko/following{/other_user}
+            gists_url: https://api.github.com/users/mfocko/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/mfocko
+            id: 8149784
+            login: mfocko
+            node_id: MDQ6VXNlcjgxNDk3ODQ=
+            organizations_url: https://api.github.com/users/mfocko/orgs
+            received_events_url: https://api.github.com/users/mfocko/received_events
+            repos_url: https://api.github.com/users/mfocko/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mfocko/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mfocko/subscriptions
+            type: User
+            url: https://api.github.com/users/mfocko
+          - avatar_url: https://avatars.githubusercontent.com/u/288686?v=4
+            contributions: 92
+            events_url: https://api.github.com/users/jpopelka/events{/privacy}
+            followers_url: https://api.github.com/users/jpopelka/followers
+            following_url: https://api.github.com/users/jpopelka/following{/other_user}
+            gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/jpopelka
+            id: 288686
+            login: jpopelka
+            node_id: MDQ6VXNlcjI4ODY4Ng==
+            organizations_url: https://api.github.com/users/jpopelka/orgs
+            received_events_url: https://api.github.com/users/jpopelka/received_events
+            repos_url: https://api.github.com/users/jpopelka/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
+            type: User
+            url: https://api.github.com/users/jpopelka
+          - avatar_url: https://avatars.githubusercontent.com/u/1662493?v=4
+            contributions: 79
+            events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
+            followers_url: https://api.github.com/users/TomasTomecek/followers
+            following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
+            gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/TomasTomecek
+            id: 1662493
+            login: TomasTomecek
+            node_id: MDQ6VXNlcjE2NjI0OTM=
+            organizations_url: https://api.github.com/users/TomasTomecek/orgs
+            received_events_url: https://api.github.com/users/TomasTomecek/received_events
+            repos_url: https://api.github.com/users/TomasTomecek/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
+            type: User
+            url: https://api.github.com/users/TomasTomecek
+          - avatar_url: https://avatars.githubusercontent.com/u/49026743?v=4
+            contributions: 57
+            events_url: https://api.github.com/users/lbarcziova/events{/privacy}
+            followers_url: https://api.github.com/users/lbarcziova/followers
+            following_url: https://api.github.com/users/lbarcziova/following{/other_user}
+            gists_url: https://api.github.com/users/lbarcziova/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/lbarcziova
+            id: 49026743
+            login: lbarcziova
+            node_id: MDQ6VXNlcjQ5MDI2NzQz
+            organizations_url: https://api.github.com/users/lbarcziova/orgs
+            received_events_url: https://api.github.com/users/lbarcziova/received_events
+            repos_url: https://api.github.com/users/lbarcziova/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/lbarcziova/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/lbarcziova/subscriptions
+            type: User
+            url: https://api.github.com/users/lbarcziova
+          - avatar_url: https://avatars.githubusercontent.com/u/8735467?v=4
+            contributions: 39
+            events_url: https://api.github.com/users/jscotka/events{/privacy}
+            followers_url: https://api.github.com/users/jscotka/followers
+            following_url: https://api.github.com/users/jscotka/following{/other_user}
+            gists_url: https://api.github.com/users/jscotka/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/jscotka
+            id: 8735467
+            login: jscotka
+            node_id: MDQ6VXNlcjg3MzU0Njc=
+            organizations_url: https://api.github.com/users/jscotka/orgs
+            received_events_url: https://api.github.com/users/jscotka/received_events
+            repos_url: https://api.github.com/users/jscotka/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/jscotka/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/jscotka/subscriptions
+            type: User
+            url: https://api.github.com/users/jscotka
+          - avatar_url: https://avatars.githubusercontent.com/in/68672?v=4
+            contributions: 37
+            events_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/events{/privacy}
+            followers_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/followers
+            following_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/following{/other_user}
+            gists_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/apps/pre-commit-ci
+            id: 66853113
+            login: pre-commit-ci[bot]
+            node_id: MDM6Qm90NjY4NTMxMTM=
+            organizations_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/orgs
+            received_events_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/received_events
+            repos_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/pre-commit-ci%5Bbot%5D/subscriptions
+            type: Bot
+            url: https://api.github.com/users/pre-commit-ci%5Bbot%5D
+          - avatar_url: https://avatars.githubusercontent.com/u/11816497?v=4
+            contributions: 24
+            events_url: https://api.github.com/users/csomh/events{/privacy}
+            followers_url: https://api.github.com/users/csomh/followers
+            following_url: https://api.github.com/users/csomh/following{/other_user}
+            gists_url: https://api.github.com/users/csomh/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/csomh
+            id: 11816497
+            login: csomh
+            node_id: MDQ6VXNlcjExODE2NDk3
+            organizations_url: https://api.github.com/users/csomh/orgs
+            received_events_url: https://api.github.com/users/csomh/received_events
+            repos_url: https://api.github.com/users/csomh/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/csomh/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/csomh/subscriptions
+            type: User
+            url: https://api.github.com/users/csomh
+          - avatar_url: https://avatars.githubusercontent.com/u/36231209?v=4
+            contributions: 20
+            events_url: https://api.github.com/users/usercont-release-bot/events{/privacy}
+            followers_url: https://api.github.com/users/usercont-release-bot/followers
+            following_url: https://api.github.com/users/usercont-release-bot/following{/other_user}
+            gists_url: https://api.github.com/users/usercont-release-bot/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/usercont-release-bot
+            id: 36231209
+            login: usercont-release-bot
+            node_id: MDQ6VXNlcjM2MjMxMjA5
+            organizations_url: https://api.github.com/users/usercont-release-bot/orgs
+            received_events_url: https://api.github.com/users/usercont-release-bot/received_events
+            repos_url: https://api.github.com/users/usercont-release-bot/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/usercont-release-bot/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/usercont-release-bot/subscriptions
+            type: User
+            url: https://api.github.com/users/usercont-release-bot
+          - avatar_url: https://avatars.githubusercontent.com/u/7654857?v=4
+            contributions: 20
+            events_url: https://api.github.com/users/sakalosj/events{/privacy}
+            followers_url: https://api.github.com/users/sakalosj/followers
+            following_url: https://api.github.com/users/sakalosj/following{/other_user}
+            gists_url: https://api.github.com/users/sakalosj/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/sakalosj
+            id: 7654857
+            login: sakalosj
+            node_id: MDQ6VXNlcjc2NTQ4NTc=
+            organizations_url: https://api.github.com/users/sakalosj/orgs
+            received_events_url: https://api.github.com/users/sakalosj/received_events
+            repos_url: https://api.github.com/users/sakalosj/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/sakalosj/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/sakalosj/subscriptions
+            type: User
+            url: https://api.github.com/users/sakalosj
+          - avatar_url: https://avatars.githubusercontent.com/u/25414049?v=4
+            contributions: 19
+            events_url: https://api.github.com/users/marusinm/events{/privacy}
+            followers_url: https://api.github.com/users/marusinm/followers
+            following_url: https://api.github.com/users/marusinm/following{/other_user}
+            gists_url: https://api.github.com/users/marusinm/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/marusinm
+            id: 25414049
+            login: marusinm
+            node_id: MDQ6VXNlcjI1NDE0MDQ5
+            organizations_url: https://api.github.com/users/marusinm/orgs
+            received_events_url: https://api.github.com/users/marusinm/received_events
+            repos_url: https://api.github.com/users/marusinm/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/marusinm/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/marusinm/subscriptions
+            type: User
+            url: https://api.github.com/users/marusinm
+          - avatar_url: https://avatars.githubusercontent.com/u/32942101?v=4
+            contributions: 16
+            events_url: https://api.github.com/users/svenharris/events{/privacy}
+            followers_url: https://api.github.com/users/svenharris/followers
+            following_url: https://api.github.com/users/svenharris/following{/other_user}
+            gists_url: https://api.github.com/users/svenharris/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/svenharris
+            id: 32942101
+            login: svenharris
+            node_id: MDQ6VXNlcjMyOTQyMTAx
+            organizations_url: https://api.github.com/users/svenharris/orgs
+            received_events_url: https://api.github.com/users/svenharris/received_events
+            repos_url: https://api.github.com/users/svenharris/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/svenharris/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/svenharris/subscriptions
+            type: User
+            url: https://api.github.com/users/svenharris
+          - avatar_url: https://avatars.githubusercontent.com/u/70757578?v=4
+            contributions: 14
+            events_url: https://api.github.com/users/nikromen/events{/privacy}
+            followers_url: https://api.github.com/users/nikromen/followers
+            following_url: https://api.github.com/users/nikromen/following{/other_user}
+            gists_url: https://api.github.com/users/nikromen/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/nikromen
+            id: 70757578
+            login: nikromen
+            node_id: MDQ6VXNlcjcwNzU3NTc4
+            organizations_url: https://api.github.com/users/nikromen/orgs
+            received_events_url: https://api.github.com/users/nikromen/received_events
+            repos_url: https://api.github.com/users/nikromen/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/nikromen/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/nikromen/subscriptions
+            type: User
+            url: https://api.github.com/users/nikromen
+          - avatar_url: https://avatars.githubusercontent.com/u/31201372?v=4
+            contributions: 14
+            events_url: https://api.github.com/users/dhodovsk/events{/privacy}
+            followers_url: https://api.github.com/users/dhodovsk/followers
+            following_url: https://api.github.com/users/dhodovsk/following{/other_user}
+            gists_url: https://api.github.com/users/dhodovsk/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/dhodovsk
+            id: 31201372
+            login: dhodovsk
+            node_id: MDQ6VXNlcjMxMjAxMzcy
+            organizations_url: https://api.github.com/users/dhodovsk/orgs
+            received_events_url: https://api.github.com/users/dhodovsk/received_events
+            repos_url: https://api.github.com/users/dhodovsk/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/dhodovsk/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/dhodovsk/subscriptions
+            type: User
+            url: https://api.github.com/users/dhodovsk
+          - avatar_url: https://avatars.githubusercontent.com/u/28452337?v=4
+            contributions: 11
+            events_url: https://api.github.com/users/FrNecas/events{/privacy}
+            followers_url: https://api.github.com/users/FrNecas/followers
+            following_url: https://api.github.com/users/FrNecas/following{/other_user}
+            gists_url: https://api.github.com/users/FrNecas/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/FrNecas
+            id: 28452337
+            login: FrNecas
+            node_id: MDQ6VXNlcjI4NDUyMzM3
+            organizations_url: https://api.github.com/users/FrNecas/orgs
+            received_events_url: https://api.github.com/users/FrNecas/received_events
+            repos_url: https://api.github.com/users/FrNecas/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/FrNecas/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/FrNecas/subscriptions
+            type: User
+            url: https://api.github.com/users/FrNecas
+          - avatar_url: https://avatars.githubusercontent.com/u/3416672?v=4
+            contributions: 9
+            events_url: https://api.github.com/users/phracek/events{/privacy}
+            followers_url: https://api.github.com/users/phracek/followers
+            following_url: https://api.github.com/users/phracek/following{/other_user}
+            gists_url: https://api.github.com/users/phracek/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/phracek
+            id: 3416672
+            login: phracek
+            node_id: MDQ6VXNlcjM0MTY2NzI=
+            organizations_url: https://api.github.com/users/phracek/orgs
+            received_events_url: https://api.github.com/users/phracek/received_events
+            repos_url: https://api.github.com/users/phracek/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/phracek/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/phracek/subscriptions
+            type: User
+            url: https://api.github.com/users/phracek
+          - avatar_url: https://avatars.githubusercontent.com/u/22324802?v=4
+            contributions: 8
+            events_url: https://api.github.com/users/shreyaspapi/events{/privacy}
+            followers_url: https://api.github.com/users/shreyaspapi/followers
+            following_url: https://api.github.com/users/shreyaspapi/following{/other_user}
+            gists_url: https://api.github.com/users/shreyaspapi/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/shreyaspapi
+            id: 22324802
+            login: shreyaspapi
+            node_id: MDQ6VXNlcjIyMzI0ODAy
+            organizations_url: https://api.github.com/users/shreyaspapi/orgs
+            received_events_url: https://api.github.com/users/shreyaspapi/received_events
+            repos_url: https://api.github.com/users/shreyaspapi/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/shreyaspapi/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/shreyaspapi/subscriptions
+            type: User
+            url: https://api.github.com/users/shreyaspapi
+          - avatar_url: https://avatars.githubusercontent.com/u/26160778?v=4
+            contributions: 8
+            events_url: https://api.github.com/users/rpitonak/events{/privacy}
+            followers_url: https://api.github.com/users/rpitonak/followers
+            following_url: https://api.github.com/users/rpitonak/following{/other_user}
+            gists_url: https://api.github.com/users/rpitonak/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/rpitonak
+            id: 26160778
+            login: rpitonak
+            node_id: MDQ6VXNlcjI2MTYwNzc4
+            organizations_url: https://api.github.com/users/rpitonak/orgs
+            received_events_url: https://api.github.com/users/rpitonak/received_events
+            repos_url: https://api.github.com/users/rpitonak/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/rpitonak/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/rpitonak/subscriptions
+            type: User
+            url: https://api.github.com/users/rpitonak
+          - avatar_url: https://avatars.githubusercontent.com/u/20273495?v=4
+            contributions: 5
+            events_url: https://api.github.com/users/bcrocker15/events{/privacy}
+            followers_url: https://api.github.com/users/bcrocker15/followers
+            following_url: https://api.github.com/users/bcrocker15/following{/other_user}
+            gists_url: https://api.github.com/users/bcrocker15/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/bcrocker15
+            id: 20273495
+            login: bcrocker15
+            node_id: MDQ6VXNlcjIwMjczNDk1
+            organizations_url: https://api.github.com/users/bcrocker15/orgs
+            received_events_url: https://api.github.com/users/bcrocker15/received_events
+            repos_url: https://api.github.com/users/bcrocker15/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/bcrocker15/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/bcrocker15/subscriptions
+            type: User
+            url: https://api.github.com/users/bcrocker15
+          - avatar_url: https://avatars.githubusercontent.com/u/8876312?v=4
+            contributions: 3
+            events_url: https://api.github.com/users/mmuzila/events{/privacy}
+            followers_url: https://api.github.com/users/mmuzila/followers
+            following_url: https://api.github.com/users/mmuzila/following{/other_user}
+            gists_url: https://api.github.com/users/mmuzila/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/mmuzila
+            id: 8876312
+            login: mmuzila
+            node_id: MDQ6VXNlcjg4NzYzMTI=
+            organizations_url: https://api.github.com/users/mmuzila/orgs
+            received_events_url: https://api.github.com/users/mmuzila/received_events
+            repos_url: https://api.github.com/users/mmuzila/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/mmuzila/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/mmuzila/subscriptions
+            type: User
+            url: https://api.github.com/users/mmuzila
+          - avatar_url: https://avatars.githubusercontent.com/u/434063?v=4
+            contributions: 3
+            events_url: https://api.github.com/users/birdcar/events{/privacy}
+            followers_url: https://api.github.com/users/birdcar/followers
+            following_url: https://api.github.com/users/birdcar/following{/other_user}
+            gists_url: https://api.github.com/users/birdcar/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/birdcar
+            id: 434063
+            login: birdcar
+            node_id: MDQ6VXNlcjQzNDA2Mw==
+            organizations_url: https://api.github.com/users/birdcar/orgs
+            received_events_url: https://api.github.com/users/birdcar/received_events
+            repos_url: https://api.github.com/users/birdcar/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/birdcar/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/birdcar/subscriptions
+            type: User
+            url: https://api.github.com/users/birdcar
+          - avatar_url: https://avatars.githubusercontent.com/u/7237866?v=4
+            contributions: 2
+            events_url: https://api.github.com/users/cverna/events{/privacy}
+            followers_url: https://api.github.com/users/cverna/followers
+            following_url: https://api.github.com/users/cverna/following{/other_user}
+            gists_url: https://api.github.com/users/cverna/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/cverna
+            id: 7237866
+            login: cverna
+            node_id: MDQ6VXNlcjcyMzc4NjY=
+            organizations_url: https://api.github.com/users/cverna/orgs
+            received_events_url: https://api.github.com/users/cverna/received_events
+            repos_url: https://api.github.com/users/cverna/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/cverna/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/cverna/subscriptions
+            type: User
+            url: https://api.github.com/users/cverna
+          - avatar_url: https://avatars.githubusercontent.com/u/17784034?v=4
+            contributions: 2
+            events_url: https://api.github.com/users/pawelkopka/events{/privacy}
+            followers_url: https://api.github.com/users/pawelkopka/followers
+            following_url: https://api.github.com/users/pawelkopka/following{/other_user}
+            gists_url: https://api.github.com/users/pawelkopka/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/pawelkopka
+            id: 17784034
+            login: pawelkopka
+            node_id: MDQ6VXNlcjE3Nzg0MDM0
+            organizations_url: https://api.github.com/users/pawelkopka/orgs
+            received_events_url: https://api.github.com/users/pawelkopka/received_events
+            repos_url: https://api.github.com/users/pawelkopka/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/pawelkopka/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/pawelkopka/subscriptions
+            type: User
+            url: https://api.github.com/users/pawelkopka
+          - avatar_url: https://avatars.githubusercontent.com/u/38399871?v=4
+            contributions: 2
+            events_url: https://api.github.com/users/yzhang2907/events{/privacy}
+            followers_url: https://api.github.com/users/yzhang2907/followers
+            following_url: https://api.github.com/users/yzhang2907/following{/other_user}
+            gists_url: https://api.github.com/users/yzhang2907/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/yzhang2907
+            id: 38399871
+            login: yzhang2907
+            node_id: MDQ6VXNlcjM4Mzk5ODcx
+            organizations_url: https://api.github.com/users/yzhang2907/orgs
+            received_events_url: https://api.github.com/users/yzhang2907/received_events
+            repos_url: https://api.github.com/users/yzhang2907/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/yzhang2907/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/yzhang2907/subscriptions
+            type: User
+            url: https://api.github.com/users/yzhang2907
+          - avatar_url: https://avatars.githubusercontent.com/u/4530030?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/dustymabe/events{/privacy}
+            followers_url: https://api.github.com/users/dustymabe/followers
+            following_url: https://api.github.com/users/dustymabe/following{/other_user}
+            gists_url: https://api.github.com/users/dustymabe/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/dustymabe
+            id: 4530030
+            login: dustymabe
+            node_id: MDQ6VXNlcjQ1MzAwMzA=
+            organizations_url: https://api.github.com/users/dustymabe/orgs
+            received_events_url: https://api.github.com/users/dustymabe/received_events
+            repos_url: https://api.github.com/users/dustymabe/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/dustymabe/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/dustymabe/subscriptions
+            type: User
+            url: https://api.github.com/users/dustymabe
+          - avatar_url: https://avatars.githubusercontent.com/u/84583?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/morucci/events{/privacy}
+            followers_url: https://api.github.com/users/morucci/followers
+            following_url: https://api.github.com/users/morucci/following{/other_user}
+            gists_url: https://api.github.com/users/morucci/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/morucci
+            id: 84583
+            login: morucci
+            node_id: MDQ6VXNlcjg0NTgz
+            organizations_url: https://api.github.com/users/morucci/orgs
+            received_events_url: https://api.github.com/users/morucci/received_events
+            repos_url: https://api.github.com/users/morucci/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/morucci/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/morucci/subscriptions
+            type: User
+            url: https://api.github.com/users/morucci
+          - avatar_url: https://avatars.githubusercontent.com/u/35947115?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/path2himanshu/events{/privacy}
+            followers_url: https://api.github.com/users/path2himanshu/followers
+            following_url: https://api.github.com/users/path2himanshu/following{/other_user}
+            gists_url: https://api.github.com/users/path2himanshu/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/path2himanshu
+            id: 35947115
+            login: path2himanshu
+            node_id: MDQ6VXNlcjM1OTQ3MTE1
+            organizations_url: https://api.github.com/users/path2himanshu/orgs
+            received_events_url: https://api.github.com/users/path2himanshu/received_events
+            repos_url: https://api.github.com/users/path2himanshu/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/path2himanshu/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/path2himanshu/subscriptions
+            type: User
+            url: https://api.github.com/users/path2himanshu
+          - avatar_url: https://avatars.githubusercontent.com/u/35431035?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/Hojang2/events{/privacy}
+            followers_url: https://api.github.com/users/Hojang2/followers
+            following_url: https://api.github.com/users/Hojang2/following{/other_user}
+            gists_url: https://api.github.com/users/Hojang2/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/Hojang2
+            id: 35431035
+            login: Hojang2
+            node_id: MDQ6VXNlcjM1NDMxMDM1
+            organizations_url: https://api.github.com/users/Hojang2/orgs
+            received_events_url: https://api.github.com/users/Hojang2/received_events
+            repos_url: https://api.github.com/users/Hojang2/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/Hojang2/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/Hojang2/subscriptions
+            type: User
+            url: https://api.github.com/users/Hojang2
+          - avatar_url: https://avatars.githubusercontent.com/u/17623061?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/KPostOffice/events{/privacy}
+            followers_url: https://api.github.com/users/KPostOffice/followers
+            following_url: https://api.github.com/users/KPostOffice/following{/other_user}
+            gists_url: https://api.github.com/users/KPostOffice/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/KPostOffice
+            id: 17623061
+            login: KPostOffice
+            node_id: MDQ6VXNlcjE3NjIzMDYx
+            organizations_url: https://api.github.com/users/KPostOffice/orgs
+            received_events_url: https://api.github.com/users/KPostOffice/received_events
+            repos_url: https://api.github.com/users/KPostOffice/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/KPostOffice/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/KPostOffice/subscriptions
+            type: User
+            url: https://api.github.com/users/KPostOffice
+          _next: null
+          elapsed: 0.327845
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Wed, 30 Mar 2022 08:55:10 GMT
+            ETag: W/"6b4010cf8b19abeecb6179ce57d428e8ee861fffef681108850ee0270ec808d0"
+            Last-Modified: Thu, 06 Jan 2022 14:31:23 GMT
+            Link: <https://api.github.com/repositories/161636700/contributors?page=2>;
+              rel="next", <https://api.github.com/repositories/161636700/contributors?page=2>;
+              rel="last"
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 7A33:101B8:A0F0B69:A3B475A:62441AEE
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4995'
+            X-RateLimit-Reset: '1648630931'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '5'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repositories/161636700/contributors?page=2:
+      - metadata:
+          latency: 0.17561960220336914
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.PaginatedList
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - avatar_url: https://avatars.githubusercontent.com/u/6732513?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/LilySu/events{/privacy}
+            followers_url: https://api.github.com/users/LilySu/followers
+            following_url: https://api.github.com/users/LilySu/following{/other_user}
+            gists_url: https://api.github.com/users/LilySu/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/LilySu
+            id: 6732513
+            login: LilySu
+            node_id: MDQ6VXNlcjY3MzI1MTM=
+            organizations_url: https://api.github.com/users/LilySu/orgs
+            received_events_url: https://api.github.com/users/LilySu/received_events
+            repos_url: https://api.github.com/users/LilySu/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/LilySu/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/LilySu/subscriptions
+            type: User
+            url: https://api.github.com/users/LilySu
+          - avatar_url: https://avatars.githubusercontent.com/u/2678400?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/majamassarini/events{/privacy}
+            followers_url: https://api.github.com/users/majamassarini/followers
+            following_url: https://api.github.com/users/majamassarini/following{/other_user}
+            gists_url: https://api.github.com/users/majamassarini/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/majamassarini
+            id: 2678400
+            login: majamassarini
+            node_id: MDQ6VXNlcjI2Nzg0MDA=
+            organizations_url: https://api.github.com/users/majamassarini/orgs
+            received_events_url: https://api.github.com/users/majamassarini/received_events
+            repos_url: https://api.github.com/users/majamassarini/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/majamassarini/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/majamassarini/subscriptions
+            type: User
+            url: https://api.github.com/users/majamassarini
+          - avatar_url: https://avatars.githubusercontent.com/u/3617836?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/Roming22/events{/privacy}
+            followers_url: https://api.github.com/users/Roming22/followers
+            following_url: https://api.github.com/users/Roming22/following{/other_user}
+            gists_url: https://api.github.com/users/Roming22/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/Roming22
+            id: 3617836
+            login: Roming22
+            node_id: MDQ6VXNlcjM2MTc4MzY=
+            organizations_url: https://api.github.com/users/Roming22/orgs
+            received_events_url: https://api.github.com/users/Roming22/received_events
+            repos_url: https://api.github.com/users/Roming22/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/Roming22/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/Roming22/subscriptions
+            type: User
+            url: https://api.github.com/users/Roming22
+          - avatar_url: https://avatars.githubusercontent.com/u/19755484?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/RomaneGreen/events{/privacy}
+            followers_url: https://api.github.com/users/RomaneGreen/followers
+            following_url: https://api.github.com/users/RomaneGreen/following{/other_user}
+            gists_url: https://api.github.com/users/RomaneGreen/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/RomaneGreen
+            id: 19755484
+            login: RomaneGreen
+            node_id: MDQ6VXNlcjE5NzU1NDg0
+            organizations_url: https://api.github.com/users/RomaneGreen/orgs
+            received_events_url: https://api.github.com/users/RomaneGreen/received_events
+            repos_url: https://api.github.com/users/RomaneGreen/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/RomaneGreen/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/RomaneGreen/subscriptions
+            type: User
+            url: https://api.github.com/users/RomaneGreen
+          - avatar_url: https://avatars.githubusercontent.com/u/18401396?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/abkosar/events{/privacy}
+            followers_url: https://api.github.com/users/abkosar/followers
+            following_url: https://api.github.com/users/abkosar/following{/other_user}
+            gists_url: https://api.github.com/users/abkosar/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/abkosar
+            id: 18401396
+            login: abkosar
+            node_id: MDQ6VXNlcjE4NDAxMzk2
+            organizations_url: https://api.github.com/users/abkosar/orgs
+            received_events_url: https://api.github.com/users/abkosar/received_events
+            repos_url: https://api.github.com/users/abkosar/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/abkosar/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/abkosar/subscriptions
+            type: User
+            url: https://api.github.com/users/abkosar
+          - avatar_url: https://avatars.githubusercontent.com/u/9396452?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/saisankargochhayat/events{/privacy}
+            followers_url: https://api.github.com/users/saisankargochhayat/followers
+            following_url: https://api.github.com/users/saisankargochhayat/following{/other_user}
+            gists_url: https://api.github.com/users/saisankargochhayat/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/saisankargochhayat
+            id: 9396452
+            login: saisankargochhayat
+            node_id: MDQ6VXNlcjkzOTY0NTI=
+            organizations_url: https://api.github.com/users/saisankargochhayat/orgs
+            received_events_url: https://api.github.com/users/saisankargochhayat/received_events
+            repos_url: https://api.github.com/users/saisankargochhayat/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/saisankargochhayat/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/saisankargochhayat/subscriptions
+            type: User
+            url: https://api.github.com/users/saisankargochhayat
+          - avatar_url: https://avatars.githubusercontent.com/u/21237576?v=4
+            contributions: 1
+            events_url: https://api.github.com/users/TomasJani/events{/privacy}
+            followers_url: https://api.github.com/users/TomasJani/followers
+            following_url: https://api.github.com/users/TomasJani/following{/other_user}
+            gists_url: https://api.github.com/users/TomasJani/gists{/gist_id}
+            gravatar_id: ''
+            html_url: https://github.com/TomasJani
+            id: 21237576
+            login: TomasJani
+            node_id: MDQ6VXNlcjIxMjM3NTc2
+            organizations_url: https://api.github.com/users/TomasJani/orgs
+            received_events_url: https://api.github.com/users/TomasJani/received_events
+            repos_url: https://api.github.com/users/TomasJani/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/TomasJani/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/TomasJani/subscriptions
+            type: User
+            url: https://api.github.com/users/TomasJani
+          _next: null
+          elapsed: 0.175044
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Wed, 30 Mar 2022 08:55:10 GMT
+            ETag: W/"9a78f041d30ad0be7cf31c5e9ca2cbbb38647fb51ff5f9453937dd7f1e65d557"
+            Last-Modified: Thu, 06 Jan 2022 14:31:23 GMT
+            Link: <https://api.github.com/repositories/161636700/contributors?page=1>;
+              rel="prev", <https://api.github.com/repositories/161636700/contributors?page=1>;
+              rel="first"
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 7A33:101B8:A0F0C5E:A3B483B:62441AEE
+            X-OAuth-Scopes: admin:enterprise, admin:gpg_key, admin:org, admin:org_hook,
+              admin:public_key, admin:repo_hook, delete:packages, delete_repo, gist,
+              notifications, repo, user, workflow, write:discussion, write:packages
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4994'
+            X-RateLimit-Reset: '1648630931'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '6'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/github/test_generic_commands.py
+++ b/tests/integration/github/test_generic_commands.py
@@ -261,3 +261,8 @@ class GenericCommands(GithubTests):
 
         assert project.has_issues
         assert not project.get_fork().has_issues, "Forks don't have issues by default"
+
+    def test_get_contributors(self):
+        owners = self.ogr_project.get_owners()
+        contributors = self.ogr_project.get_contributors()
+        assert len(owners) < len(contributors)

--- a/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_contributors.yaml
+++ b/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_contributors.yaml
@@ -1,0 +1,1009 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/2396494/members/all:
+      - metadata:
+          latency: 0.3989067077636719
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - access_level: 50
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/916250/avatar.png
+            created_at: '2016-12-28T14:35:44.527Z'
+            expires_at: null
+            id: 916250
+            membership_state: active
+            name: digitalLumberjack
+            state: active
+            username: digitalLumberjack
+            web_url: https://gitlab.com/digitalLumberjack
+          - access_level: 30
+            avatar_url: https://secure.gravatar.com/avatar/439e73cfa33edd27a03289c6d88adc18?s=80&d=identicon
+            created_at: '2016-12-29T10:13:04.129Z'
+            expires_at: null
+            id: 63817
+            membership_state: active
+            name: MikaXII
+            state: active
+            username: MikaXII
+            web_url: https://gitlab.com/MikaXII
+          - access_level: 30
+            avatar_url: https://secure.gravatar.com/avatar/f80d482a96e95691a7ede9021c7e147d?s=80&d=identicon
+            created_at: '2016-12-29T10:19:56.516Z'
+            expires_at: null
+            id: 917350
+            membership_state: active
+            name: reivaax
+            state: active
+            username: reivaax
+            web_url: https://gitlab.com/reivaax
+          - access_level: 30
+            avatar_url: https://secure.gravatar.com/avatar/cbaa750a684cb14fb147789075b11df8?s=80&d=identicon
+            created_at: '2017-03-02T10:31:09.007Z'
+            expires_at: null
+            id: 1155479
+            membership_state: active
+            name: Yann MORERE
+            state: active
+            username: ian57
+            web_url: https://gitlab.com/ian57
+          - access_level: 30
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/628253/avatar.png
+            created_at: '2017-05-18T07:01:45.556Z'
+            expires_at: null
+            id: 628253
+            membership_state: active
+            name: Supernature2k
+            state: active
+            username: Supernature2k
+            web_url: https://gitlab.com/Supernature2k
+          - access_level: 30
+            avatar_url: https://secure.gravatar.com/avatar/43bd0a75f93c2d04e2693ff4687626d5?s=80&d=identicon
+            created_at: '2017-06-13T08:56:29.163Z'
+            expires_at: null
+            id: 1393089
+            membership_state: active
+            name: Jean-Baptiste Demonte
+            state: active
+            username: jbdemonte
+            web_url: https://gitlab.com/jbdemonte
+          - access_level: 30
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/1087848/avatar.png
+            created_at: '2017-08-09T16:49:56.847Z'
+            expires_at: null
+            id: 1087848
+            membership_state: active
+            name: paradadf
+            state: active
+            username: paradadf
+            web_url: https://gitlab.com/paradadf
+          - access_level: 30
+            avatar_url: https://secure.gravatar.com/avatar/003e96e123af54ef6b7e43d995262119?s=80&d=identicon
+            created_at: '2017-09-28T13:56:14.489Z'
+            expires_at: null
+            id: 1645471
+            membership_state: active
+            name: Robsdedude
+            state: active
+            username: robsdedude
+            web_url: https://gitlab.com/robsdedude
+          - access_level: 30
+            avatar_url: https://secure.gravatar.com/avatar/14c7aaf57a2f027de2c17901267045fb?s=80&d=identicon
+            created_at: '2017-11-01T17:33:27.739Z'
+            expires_at: null
+            id: 1691868
+            membership_state: active
+            name: Fabrice
+            state: active
+            username: Fab2Ris
+            web_url: https://gitlab.com/Fab2Ris
+          - access_level: 40
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/480704/avatar.png
+            created_at: '2017-12-11T20:25:48.645Z'
+            expires_at: null
+            id: 480704
+            membership_state: active
+            name: OyyoDams
+            state: active
+            username: OyyoDams
+            web_url: https://gitlab.com/OyyoDams
+          - access_level: 30
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/1747944/avatar.png
+            created_at: '2018-02-03T20:23:42.025Z'
+            expires_at: null
+            id: 1747944
+            membership_state: active
+            name: LMerckx
+            state: active
+            username: lmerckx
+            web_url: https://gitlab.com/lmerckx
+          - access_level: 50
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2327677/avatar.png
+            created_at: '2018-08-06T07:55:41.018Z'
+            expires_at: null
+            id: 2327677
+            membership_state: active
+            name: Bkg2k
+            state: active
+            username: Bkg2k
+            web_url: https://gitlab.com/Bkg2k
+          - access_level: 30
+            avatar_url: https://secure.gravatar.com/avatar/dbd03eb7341372231c3fea524cea443c?s=80&d=identicon
+            created_at: '2019-03-03T14:33:44.094Z'
+            expires_at: null
+            id: 2559481
+            membership_state: active
+            name: Michael Baudino
+            state: active
+            username: michaelbaudino
+            web_url: https://gitlab.com/michaelbaudino
+          - access_level: 30
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2699477/avatar.png
+            created_at: '2019-05-13T09:27:39.105Z'
+            expires_at: null
+            id: 2699477
+            membership_state: active
+            name: strodown
+            state: active
+            username: strodown
+            web_url: https://gitlab.com/strodown
+          - access_level: 40
+            avatar_url: https://secure.gravatar.com/avatar/212b057a2aa2fa02c24807b433a8f075?s=80&d=identicon
+            created_at: '2020-07-11T08:48:14.742Z'
+            expires_at: null
+            id: 1922419
+            membership_state: active
+            name: David Barbion
+            state: active
+            username: davidb2111_
+            web_url: https://gitlab.com/davidb2111_
+          - access_level: 20
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/727783/avatar.png
+            created_at: '2020-10-12T07:24:33.806Z'
+            expires_at: null
+            id: 727783
+            membership_state: active
+            name: Nicolas TESSIER
+            state: active
+            username: Asthonishia
+            web_url: https://gitlab.com/Asthonishia
+          - access_level: 20
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/1183570/avatar.png
+            created_at: '2020-10-12T07:24:33.875Z'
+            expires_at: null
+            id: 1183570
+            membership_state: active
+            name: Redblueflame
+            state: active
+            username: redblueflame
+            web_url: https://gitlab.com/redblueflame
+          - access_level: 10
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/1870668/avatar.png
+            created_at: '2020-10-12T07:24:33.921Z'
+            expires_at: null
+            id: 1870668
+            membership_state: active
+            name: Jerome Boulinguez
+            state: active
+            username: MarbleMad
+            web_url: https://gitlab.com/MarbleMad
+          - access_level: 10
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2610343/avatar.png
+            created_at: '2020-10-12T07:24:33.965Z'
+            expires_at: null
+            id: 2610343
+            membership_state: active
+            name: lionsquall
+            state: active
+            username: lionsquall
+            web_url: https://gitlab.com/lionsquall
+          - access_level: 10
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/3418145/avatar.png
+            created_at: '2020-10-12T07:24:34.055Z'
+            expires_at: null
+            id: 3418145
+            membership_state: active
+            name: Maksthorr
+            state: active
+            username: maksthorr
+            web_url: https://gitlab.com/maksthorr
+          _next: null
+          elapsed: 0.392385
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6f3f9ff8ea59f9d6-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Wed, 30 Mar 2022 08:55:11 GMT
+            Etag: W/"241088c40baead39df4c306a415a0930"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-23-lb-gprd
+            GitLab-SV: localhost
+            Link: <https://gitlab.com/api/v4/projects/2396494/members/all?id=2396494&page=2&per_page=20>;
+              rel="next", <https://gitlab.com/api/v4/projects/2396494/members/all?id=2396494&page=1&per_page=20>;
+              rel="first", <https://gitlab.com/api/v4/projects/2396494/members/all?id=2396494&page=2&per_page=20>;
+              rel="last"
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '9'
+            RateLimit-Remaining: '1991'
+            RateLimit-Reset: '1648630571'
+            RateLimit-ResetTime: Wed, 30 Mar 2022 08:56:11 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=iEWYPp6RCKJGjI0W4T2bf7VHKitaHb5aEpiSdu8eyBtn5sav8OGwK6KtFZ7O3hvJwI6N5%2BIfvIN2yCbDA2pBufc6vLX6gEQarw76A%2FkDk%2FjmwT6lh4OhrqA8a5I%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Next-Page: '2'
+            X-Page: '1'
+            X-Per-Page: '20'
+            X-Prev-Page: ''
+            X-Request-Id: 01FZD0JDZQGH22XZT3AKCWE54D
+            X-Runtime: '0.193128'
+            X-Total: '30'
+            X-Total-Pages: '2'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/2396494/members/all?id=2396494&page=2&per_page=20:
+      - metadata:
+          latency: 0.43704795837402344
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - access_level: 10
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/3516214/avatar.png
+            created_at: '2020-10-12T07:24:34.101Z'
+            expires_at: null
+            id: 3516214
+            membership_state: active
+            name: mYSt
+            state: active
+            username: samuel.eminet
+            web_url: https://gitlab.com/samuel.eminet
+          - access_level: 20
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/3935712/avatar.png
+            created_at: '2020-10-12T07:24:34.141Z'
+            expires_at: null
+            id: 3935712
+            membership_state: active
+            name: OlivierDroid92
+            state: active
+            username: OlivierDroid92
+            web_url: https://gitlab.com/OlivierDroid92
+          - access_level: 20
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/4091093/avatar.png
+            created_at: '2020-10-12T07:24:34.175Z'
+            expires_at: null
+            id: 4091093
+            membership_state: active
+            name: Chriskt78
+            state: active
+            username: Chriskt78
+            web_url: https://gitlab.com/Chriskt78
+          - access_level: 10
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/5200974/avatar.png
+            created_at: '2020-10-12T07:24:34.214Z'
+            expires_at: null
+            id: 5200974
+            membership_state: active
+            name: Patrick Breil
+            state: active
+            username: ArcadePatMan
+            web_url: https://gitlab.com/ArcadePatMan
+          - access_level: 10
+            avatar_url: https://secure.gravatar.com/avatar/a75464de30b3c9bf4e586b44ce697a01?s=80&d=identicon
+            created_at: '2020-10-12T07:24:34.260Z'
+            expires_at: null
+            id: 5743391
+            membership_state: active
+            name: rastaware
+            state: active
+            username: rastaware
+            web_url: https://gitlab.com/rastaware
+          - access_level: 10
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/5743396/avatar.png
+            created_at: '2020-10-12T07:24:34.308Z'
+            expires_at: null
+            id: 5743396
+            membership_state: active
+            name: Archangel54
+            state: active
+            username: Archangel54
+            web_url: https://gitlab.com/Archangel54
+          - access_level: 10
+            avatar_url: https://secure.gravatar.com/avatar/9ff930333cf07ab78830560598bdc434?s=80&d=identicon
+            created_at: '2020-10-12T07:24:34.491Z'
+            expires_at: null
+            id: 5743972
+            membership_state: active
+            name: Scavy74
+            state: active
+            username: Scavy74
+            web_url: https://gitlab.com/Scavy74
+          - access_level: 30
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/4908464/avatar.png
+            created_at: '2021-02-09T10:21:48.647Z'
+            expires_at: null
+            id: 4908464
+            membership_state: active
+            name: gugue
+            state: active
+            username: gugueU
+            web_url: https://gitlab.com/gugueU
+          - access_level: 30
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/7444101/avatar.png
+            created_at: '2021-03-21T14:30:49.800Z'
+            expires_at: null
+            id: 7444101
+            membership_state: active
+            name: Akkeoss
+            state: active
+            username: Akkeoss
+            web_url: https://gitlab.com/Akkeoss
+          - access_level: 30
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/7794377/avatar.png
+            created_at: '2021-08-17T09:55:32.232Z'
+            expires_at: null
+            id: 7794377
+            membership_state: active
+            name: Pit64
+            state: active
+            username: Pit64
+            web_url: https://gitlab.com/Pit64
+          _next: null
+          elapsed: 0.436233
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6f3f9ffb4e99f9d6-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Wed, 30 Mar 2022 08:55:12 GMT
+            Etag: W/"d8483cebcaac105e56b938bb51511c75"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-03-lb-gprd
+            GitLab-SV: localhost
+            Link: <https://gitlab.com/api/v4/projects/2396494/members/all?id=2396494&page=1&per_page=20>;
+              rel="prev", <https://gitlab.com/api/v4/projects/2396494/members/all?id=2396494&page=1&per_page=20>;
+              rel="first", <https://gitlab.com/api/v4/projects/2396494/members/all?id=2396494&page=2&per_page=20>;
+              rel="last"
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '10'
+            RateLimit-Remaining: '1990'
+            RateLimit-Reset: '1648630572'
+            RateLimit-ResetTime: Wed, 30 Mar 2022 08:56:12 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=wRUx9ZDEU3SGgE23P8LiJo%2BP6lc1y2oW6oAYeOEEy1Jx%2FxYkxmqCioH0n2oabrHtTai6ac3hSlaMg7J7Q0SfflHVThygbLXwE5d6z8%2FhR4Gzf6FcoD97KwWxYfs%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Next-Page: ''
+            X-Page: '2'
+            X-Per-Page: '20'
+            X-Prev-Page: '1'
+            X-Request-Id: 01FZD0JEBQDTCMRNQQ6M7FY2KK
+            X-Runtime: '0.165626'
+            X-Total: '30'
+            X-Total-Pages: '2'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/2396494/repository/contributors:
+      - metadata:
+          latency: 0.656252384185791
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.cli
+          - gitlab.exceptions
+          - gitlab.v4.objects.repositories
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - additions: 0
+            commits: 1
+            deletions: 0
+            email: guillaume.savignan@viavoo.com
+            name: guillaume S
+          - additions: 0
+            commits: 1
+            deletions: 0
+            email: kalap.tran@gmail.com
+            name: Christophe Tran
+          - additions: 0
+            commits: 1
+            deletions: 0
+            email: osvathrobi@gmail.com
+            name: Osvath Boros Robert
+          - additions: 0
+            commits: 1
+            deletions: 0
+            email: rogez.renaud@bbox.fr
+            name: rogez
+          - additions: 0
+            commits: 1
+            deletions: 0
+            email: numsys@free.fr
+            name: Fred
+          - additions: 0
+            commits: 1
+            deletions: 0
+            email: rafael.c_@hotmail.com
+            name: Zing
+          - additions: 0
+            commits: 2
+            deletions: 0
+            email: sberthelot54@gmail.com
+            name: "St\xE9phane Berthelot"
+          - additions: 0
+            commits: 2
+            deletions: 0
+            email: darcelf@gmail.com
+            name: Chips-fr
+          - additions: 0
+            commits: 2
+            deletions: 0
+            email: sswarrior@yahoo.com
+            name: RaZeR0k
+          - additions: 0
+            commits: 2
+            deletions: 0
+            email: 2.71828183e0+git@gmail.com
+            name: 1e1
+          - additions: 0
+            commits: 4
+            deletions: 0
+            email: wolfgang-wallner@gmx.at
+            name: Wolfgang Wallner
+          - additions: 0
+            commits: 5
+            deletions: 0
+            email: 3935712-OlivierDroid92@users.noreply.gitlab.com
+            name: OlivierDroid92
+          - additions: 0
+            commits: 6
+            deletions: 0
+            email: 7444101-Akkeoss@users.noreply.gitlab.com
+            name: Akkeoss
+          - additions: 0
+            commits: 7
+            deletions: 0
+            email: bozolesv2@gmail.com
+            name: Bozo the geek
+          - additions: 0
+            commits: 7
+            deletions: 0
+            email: laurent-merckx@skynet.be
+            name: Laurent Merckx
+          - additions: 0
+            commits: 7
+            deletions: 0
+            email: oyyodams@recalbox.com
+            name: OyyoDams
+          - additions: 0
+            commits: 10
+            deletions: 0
+            email: dj_xizor@hotmail.com
+            name: Supernature2k
+          - additions: 0
+            commits: 15
+            deletions: 0
+            email: michael.baudino@alpine-lab.com
+            name: Michael Baudino
+          - additions: 0
+            commits: 22
+            deletions: 0
+            email: cpasjuste@gmail.com
+            name: cpasjuste
+          - additions: 0
+            commits: 23
+            deletions: 0
+            email: akkeoss@laposte.net
+            name: Akkeoss
+          _next: null
+          elapsed: 0.655562
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6f3f9ffe1b89f9d6-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Wed, 30 Mar 2022 08:55:12 GMT
+            Etag: W/"8011e68b652d4a140388f2be18149965"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-18-lb-gprd
+            GitLab-SV: localhost
+            Link: <https://gitlab.com/api/v4/projects/2396494/repository/contributors?id=2396494&order_by=commits&page=2&per_page=20&sort=asc>;
+              rel="next", <https://gitlab.com/api/v4/projects/2396494/repository/contributors?id=2396494&order_by=commits&page=1&per_page=20&sort=asc>;
+              rel="first", <https://gitlab.com/api/v4/projects/2396494/repository/contributors?id=2396494&order_by=commits&page=2&per_page=20&sort=asc>;
+              rel="last"
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '11'
+            RateLimit-Remaining: '1989'
+            RateLimit-Reset: '1648630572'
+            RateLimit-ResetTime: Wed, 30 Mar 2022 08:56:12 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=tESqHrvFeW0AunUoHjPwe2XmdvtieizdVgAD3V89G9gclLRTeiVcAjCRa9Z4xiwq7LUCY0x2fF4Eot3dUIutZnl7cVu3p0His5oLbseWvS3%2BjTLbOVUM4YMo8%2Fg%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Next-Page: '2'
+            X-Page: '1'
+            X-Per-Page: '20'
+            X-Prev-Page: ''
+            X-Request-Id: 01FZD0JF0NPA75N0Y1D3MRBR1K
+            X-Runtime: '0.260746'
+            X-Total: '30'
+            X-Total-Pages: '2'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/2396494/repository/contributors?id=2396494&order_by=commits&page=2&per_page=20&sort=asc:
+      - metadata:
+          latency: 0.4758288860321045
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.cli
+          - gitlab.exceptions
+          - gitlab.v4.objects.repositories
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - additions: 0
+            commits: 24
+            deletions: 0
+            email: paradad@outlook.com
+            name: paradadf
+          - additions: 0
+            commits: 28
+            deletions: 0
+            email: strodown@gmail.com
+            name: Strodown
+          - additions: 0
+            commits: 41
+            deletions: 0
+            email: webmaster@zelda-series.net
+            name: Pitchoune
+          - additions: 0
+            commits: 50
+            deletions: 0
+            email: akeos@laposte.net
+            name: Akkeoss
+          - additions: 0
+            commits: 60
+            deletions: 0
+            email: yrigaud@icloud.com
+            name: Pit64
+          - additions: 0
+            commits: 77
+            deletions: 0
+            email: gugue_u@hotmail.com
+            name: gugueU
+          - additions: 0
+            commits: 98
+            deletions: 0
+            email: yann.morere@gmail.com
+            name: Yann MORERE
+          - additions: 0
+            commits: 288
+            deletions: 0
+            email: digitallumberjack@gmail.com
+            name: digitalLumberjack
+          - additions: 0
+            commits: 421
+            deletions: 0
+            email: davidb@230ruedubac.fr
+            name: David Barbion
+          - additions: 0
+            commits: 793
+            deletions: 0
+            email: bkg2k9@gmail.com
+            name: Bkg2k
+          _next: null
+          elapsed: 0.475276
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6f3fa0024ac1f9d6-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Wed, 30 Mar 2022 08:55:13 GMT
+            Etag: W/"c0d889b7603941218347669c215c92cb"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-26-lb-gprd
+            GitLab-SV: localhost
+            Link: <https://gitlab.com/api/v4/projects/2396494/repository/contributors?id=2396494&order_by=commits&page=1&per_page=20&sort=asc>;
+              rel="prev", <https://gitlab.com/api/v4/projects/2396494/repository/contributors?id=2396494&order_by=commits&page=1&per_page=20&sort=asc>;
+              rel="first", <https://gitlab.com/api/v4/projects/2396494/repository/contributors?id=2396494&order_by=commits&page=2&per_page=20&sort=asc>;
+              rel="last"
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '11'
+            RateLimit-Remaining: '1989'
+            RateLimit-Reset: '1648630573'
+            RateLimit-ResetTime: Wed, 30 Mar 2022 08:56:13 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Jz1mL1TaXyxNk5QZjTLpOilsQwbNz532eXc6p1K8R2y4D2bKylOK8UaIIGWR7SQ4eQwsrh9oEN9HZ8UOrdPauyafAKFopAtabCeEB0sxlhcHiZ108aDdW6TwgZk%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Next-Page: ''
+            X-Page: '2'
+            X-Per-Page: '20'
+            X-Prev-Page: '1'
+            X-Request-Id: 01FZD0JFEMGAHKDZDM6G5C8TQ6
+            X-Runtime: '0.296246'
+            X-Total: '30'
+            X-Total-Pages: '2'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/recalbox%2Frecalbox:
+      - metadata:
+          latency: 0.4643678665161133
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              events: https://gitlab.com/api/v4/projects/2396494/events
+              issues: https://gitlab.com/api/v4/projects/2396494/issues
+              labels: https://gitlab.com/api/v4/projects/2396494/labels
+              members: https://gitlab.com/api/v4/projects/2396494/members
+              merge_requests: https://gitlab.com/api/v4/projects/2396494/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/2396494/repository/branches
+              self: https://gitlab.com/api/v4/projects/2396494
+            allow_merge_on_skipped_pipeline: true
+            analytics_access_level: enabled
+            approvals_before_merge: 1
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: false
+            avatar_url: https://gitlab.com/uploads/-/system/project/avatar/2396494/recalbox-controller-only.png
+            build_coverage_regex: ''
+            build_timeout: 43200
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: ''
+            ci_default_git_depth: null
+            ci_forward_deployment_enabled: false
+            ci_job_token_scope_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/recalbox/recalbox
+            created_at: '2017-01-29T09:26:40.944Z'
+            creator_id: 916250
+            default_branch: master
+            description: The recalbox os. Retrogaming open source operating system
+              for Raspberry Pi, Odroid and PC.
+            emails_disabled: false
+            empty_repo: false
+            external_authorization_classification_label: ''
+            forking_access_level: enabled
+            forks_count: 161
+            http_url_to_repo: https://gitlab.com/recalbox/recalbox.git
+            id: 2396494
+            import_status: none
+            issues_access_level: enabled
+            issues_enabled: true
+            issues_template: ''
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2022-03-30T08:23:33.204Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            merge_commit_template: ''
+            merge_method: ff
+            merge_pipelines_enabled: false
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            merge_requests_template: "**Thank you for your contribution!**\r\n\r\n\
+              Please make sure your Merge Request is ready to be merged:\r\n- [ ]\
+              \ if the Merge Request is about a new feature, an improvement or an\
+              \ important bugfix, amend **RELEASE-NOTES.md** \r\n- [ ] you respected\
+              \ [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)\r\
+              \n- [ ] you updated [the wiki](https://wiki.recalbox.com) Please it\
+              \ is important :pray: !\r\n\r\nThe results of the build can give you\
+              \ clues about what is missing in your Merge Request.\r\n\r\n\r\nChanges\
+              \ :\r\n- Describe your changes\r\n\r\nRelated to :\r\n- Link to related\
+              \ Merge Requests or Issues\r\n"
+            merge_trains_enabled: false
+            mirror: false
+            name: recalbox
+            name_with_namespace: recalbox / recalbox
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/1099461/recalbox.png
+              full_path: recalbox
+              id: 1099461
+              kind: group
+              name: recalbox
+              parent_id: null
+              path: recalbox
+              web_url: https://gitlab.com/groups/recalbox
+            only_allow_merge_if_all_discussions_are_resolved: true
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 272
+            operations_access_level: enabled
+            packages_enabled: false
+            pages_access_level: disabled
+            path: recalbox
+            path_with_namespace: recalbox/recalbox
+            permissions:
+              group_access: null
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: false
+            readme_url: https://gitlab.com/recalbox/recalbox/-/blob/master/README.md
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_access_level: enabled
+            requirements_enabled: true
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runner_token_expiration_interval: null
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: false
+            service_desk_enabled: null
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: disabled
+            snippets_enabled: false
+            squash_commit_template: ''
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:recalbox/recalbox.git
+            star_count: 563
+            suggestion_commit_message: ''
+            tag_list: []
+            topics: []
+            visibility: public
+            web_url: https://gitlab.com/recalbox/recalbox
+            wiki_access_level: private
+            wiki_enabled: false
+          _next: null
+          elapsed: 0.463675
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6f3f9ff5cbc6f9d6-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Wed, 30 Mar 2022 08:55:11 GMT
+            Etag: W/"5945645a2cd77ed5b4db69df51ed7ba4"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-01-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '8'
+            RateLimit-Remaining: '1992'
+            RateLimit-Reset: '1648630571'
+            RateLimit-ResetTime: Wed, 30 Mar 2022 08:56:11 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=QxKLxIO9J%2Bismb8T0gYIJ8w7FC3BphpjGnuhBo%2BgWAB13im0yHM7vqOL%2BxRkNOYvbflILz85WXTi1XYpjX2pv6EoIc8Qt9FgzQ4cmkV7YfvqdvdPhk0vgd67RyY%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FZD0JDP1VMPMXVWFVZVCKNS8
+            X-Runtime: '0.081039'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.3247640132904053
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.v4.objects.users
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+            bio: CS student @ FI MUNI (also tutoring), working in Red Hat. Fan of
+              open-source, Haskell, functional programming, containers and Linux.
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 2
+            commit_email: matej.focko@outlook.com
+            confirmed_at: '2020-07-24T20:00:33.764Z'
+            created_at: '2016-01-15T21:12:31.705Z'
+            current_sign_in_at: '2022-03-28T15:17:32.347Z'
+            email: matej.focko@outlook.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            followers: 0
+            following: 0
+            id: 375555
+            identities:
+            - extern_uid: mfocko
+              provider: group_saml
+              saml_provider_id: 2868
+            - extern_uid: 46bd3cb0-73a0-11ea-8e0e-0a58ac142609
+              provider: group_saml
+              saml_provider_id: 1769
+            - extern_uid: '8149784'
+              provider: github
+              saml_provider_id: null
+            - extern_uid: '90177795'
+              provider: twitter
+              saml_provider_id: null
+            - extern_uid: '104088596414930556092'
+              provider: google_oauth2
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2022-03-30'
+            last_sign_in_at: '2022-03-23T16:27:42.903Z'
+            linkedin: mfocko
+            local_time: 10:55 AM
+            location: Brno, Czechia
+            name: Matej Focko
+            organization: Red Hat
+            private_profile: false
+            projects_limit: 100000
+            pronouns: ''
+            public_email: ''
+            shared_runners_minutes_limit: 2000
+            skype: ''
+            state: active
+            theme_id: 11
+            twitter: MatejFocko
+            two_factor_enabled: true
+            username: mfocko
+            web_url: https://gitlab.com/mfocko
+            website_url: https://me.mfocko.xyz
+            work_information: Red Hat
+          _next: null
+          elapsed: 0.324118
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-RAY: 6f3f9ff418a4f9d6-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Wed, 30 Mar 2022 08:55:10 GMT
+            Etag: W/"b19d942448c1ca6ad8203ee120632e0b"
+            Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+            GitLab-LB: fe-20-lb-gprd
+            GitLab-SV: localhost
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            RateLimit-Limit: '2000'
+            RateLimit-Observed: '7'
+            RateLimit-Remaining: '1993'
+            RateLimit-Reset: '1648630570'
+            RateLimit-ResetTime: Wed, 30 Mar 2022 08:56:10 GMT
+            Referrer-Policy: strict-origin-when-cross-origin
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=dh3Da54G92yMZCPaV8wt0Y7uZ4XIXuAtflrCpkP%2Fe3dacvsmbVyC5A9TmwUZxYeaCXaiA3Ze3g%2Bn7w9pNDwiQfNO3Qr8wuJR%2Bf5WGeR9SPCZtkBoUTlZFhkF%2BtE%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: SAMEORIGIN
+            X-Request-Id: 01FZD0JD8H0A6MBAG08PFJBZXQ
+            X-Runtime: '0.043910'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_generic_commands.py
+++ b/tests/integration/gitlab/test_generic_commands.py
@@ -239,3 +239,9 @@ class GenericCommands(GitlabTests):
         assert not self.service.get_project(
             namespace="redhat/centos-stream/rpms", repo="firefox"
         ).has_issues
+
+    def test_get_contributors(self):
+        project = self.service.get_project(namespace="recalbox", repo="recalbox")
+        owners = project.get_owners()
+        contributors = project.get_contributors()
+        assert len(owners) < len(contributors)


### PR DESCRIPTION
Implement methods for acquiring contributors to the GitProject.

Signed-off-by: Matej Focko <mfocko@redhat.com>

RELEASE NOTES BEGIN
We have implemented `get_contributors` function in ogr that can be used for getting contributors to the project on GitHub (set of logins) and GitLab (set of authors).
RELEASE NOTES END
