### PR TITLE
Create Bodhi updates for branched development version as well

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -89,5 +89,6 @@ jobs:
     packit_instances: ["prod"]
     metadata:
       dist_git_branches:
-        - fedora-stable # rawhide updates are created automatically
+        - fedora-latest # branched version, rawhide updates are created automatically
+        - fedora-stable
         - epel-8


### PR DESCRIPTION
Rawhide updates are created automatically,
but not for not-released branched versions.

We can use `fedora-latest` alias which is the latest non-rawhide branch.
It is not an issue if `fedora-latest` is covered also by `fedora-stable`,
Packit converts all the values to a set
so we don't need to worry about duplicates.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
