### PR TITLE
Use upstream for creating issues about downstream Packit failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,6 +4,8 @@ specfile_path: fedora/python-ogr.spec
 # https://packit.dev/docs/configuration/#top-level-keys
 downstream_package_name: python-ogr
 upstream_project_url: https://github.com/packit/ogr
+issue_repository: https://github.com/packit/ogr
+
 # we are setting this so we can use packit from ogr's dist-git
 # packit can't know what's the upstream name when running from distgit
 upstream_package_name: ogr


### PR DESCRIPTION
Use upstream for creating issues about downstream Packit failures

See https://packit.dev/docs/configuration/#issue_repository
