### PR TITLE
fix(issues): raise exception when issues are disabled

### DIFF
--- a/ogr/services/github/issue.py
+++ b/ogr/services/github/issue.py
@@ -100,6 +100,9 @@ class GithubIssue(BaseIssue):
 
     @staticmethod
     def get(project: "ogr_github.GithubProject", issue_id: int) -> "Issue":
+        if not project.has_issues:
+            raise IssueTrackerDisabled()
+
         try:
             issue = project.github_repo.get_issue(number=issue_id)
         except github.UnknownObjectException as ex:
@@ -114,6 +117,9 @@ class GithubIssue(BaseIssue):
         assignee: Optional[str] = None,
         labels: Optional[List[str]] = None,
     ) -> List["Issue"]:
+        if not project.has_issues:
+            raise IssueTrackerDisabled()
+
         parameters: Dict[str, Union[str, List[str]]] = {
             "state": status.name,
             "sort": "updated",

--- a/ogr/services/gitlab/issue.py
+++ b/ogr/services/gitlab/issue.py
@@ -109,6 +109,9 @@ class GitlabIssue(BaseIssue):
 
     @staticmethod
     def get(project: "ogr_gitlab.GitlabProject", issue_id: int) -> "Issue":
+        if not project.has_issues:
+            raise IssueTrackerDisabled()
+
         try:
             return GitlabIssue(project.gitlab_repo.issues.get(issue_id), project)
         except gitlab.exceptions.GitlabGetError as ex:
@@ -122,6 +125,9 @@ class GitlabIssue(BaseIssue):
         assignee: Optional[str] = None,
         labels: Optional[List[str]] = None,
     ) -> List["Issue"]:
+        if not project.has_issues:
+            raise IssueTrackerDisabled()
+
         # Gitlab API has status 'opened', not 'open'
         parameters: Dict[str, Union[str, List[str], bool]] = {
             "state": status.name if status != IssueStatus.open else "opened",

--- a/ogr/services/pagure/issue.py
+++ b/ogr/services/pagure/issue.py
@@ -140,6 +140,9 @@ class PagureIssue(BaseIssue):
 
     @staticmethod
     def get(project: "ogr_pagure.PagureProject", issue_id: int) -> "Issue":
+        if not project.has_issues:
+            raise IssueTrackerDisabled()
+
         raw_issue = project._call_project_api("issue", str(issue_id))
         return PagureIssue(raw_issue, project)
 
@@ -151,6 +154,9 @@ class PagureIssue(BaseIssue):
         assignee: Optional[str] = None,
         labels: Optional[List[str]] = None,
     ) -> List["Issue"]:
+        if not project.has_issues:
+            raise IssueTrackerDisabled()
+
         payload: Dict[str, Union[str, List[str], int]] = {
             "status": status.name.capitalize(),
             "page": 1,

--- a/tests/integration/github/test_issues.py
+++ b/tests/integration/github/test_issues.py
@@ -19,9 +19,8 @@ class Issues(GithubTests):
     description = "This is a description"
 
     def test_issue_list(self):
-        issue_list = self.ogr_fork.get_issue_list()
-        assert isinstance(issue_list, list)
-        assert not issue_list
+        with self.assertRaises(IssueTrackerDisabled):
+            issue_list = self.ogr_fork.get_issue_list()
 
         issue_list_all = self.ogr_project.get_issue_list(status=IssueStatus.all)
         assert issue_list_all

--- a/tests/integration/pagure/test_data/test_issues/Issues.test_get_comment.yaml
+++ b/tests/integration/pagure/test_data/test_issues/Issues.test_get_comment.yaml
@@ -87,6 +87,95 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      - metadata:
+          latency: 0.25437498092651367
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            assignee: null
+            blocks: []
+            close_status: null
+            closed_at: null
+            closed_by: null
+            comments:
+            - comment: example issue comment
+              date_created: '1632485834'
+              edited_on: null
+              editor: null
+              id: 753462
+              notification: false
+              parent: null
+              reactions: {}
+              user:
+                full_url: https://pagure.io/user/nikromen
+                fullname: Jiri Kyjovsky
+                name: nikromen
+                url_path: user/nikromen
+            content: issue
+            custom_fields: []
+            date_created: '1632485822'
+            depends: []
+            full_url: https://pagure.io/my-playground/issue/1
+            id: 1
+            last_updated: '1632485834'
+            milestone: null
+            priority: null
+            private: false
+            related_prs: []
+            status: Open
+            tags: []
+            title: ogr test issue
+            user:
+              full_url: https://pagure.io/user/nikromen
+              fullname: Jiri Kyjovsky
+              name: nikromen
+              url_path: user/nikromen
+          _next: null
+          elapsed: 0.25415
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '1067'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-WHSf4yHcZhbNNFYCTCf0Zk1rm';
+              style-src 'self' 'nonce-WHSf4yHcZhbNNFYCTCf0Zk1rm'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Fri, 22 Apr 2022 09:32:56 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZTQyZmE1YTdiYTMxNDFlMThjN2VmNWI2YzcxY2I2N2Q5YTk2NjgyYyJ9.FUQHyQ.hHqxpB067SAf_zblSpQDhEq9_MM;
+              Expires=Mon, 23-May-2022 09:32:57 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
       https://pagure.io/api/0/my-playground/issue/1/comment/753462:
       - metadata:
           latency: 0.23948907852172852
@@ -138,6 +227,79 @@ requests.sessions:
               Python/3.6
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMzc5OTYxOGVmYjhjYzEyYjE1NjMwMjFhNDQ0ZDcyMGQzMmMxY2ZlMiJ9.FC9ZjA.v0yYlcwqXRpi5uWYeVufLeJf3Qo;
               Expires=Mon, 25-Oct-2021 12:43:56 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://pagure.io/api/0/my-playground/options:
+      - metadata:
+          latency: 0.49100685119628906
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.490791
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY';
+              style-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Fri, 22 Apr 2022 09:32:56 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZTQyZmE1YTdiYTMxNDFlMThjN2VmNWI2YzcxY2I2N2Q5YTk2NjgyYyJ9.FUQHyA.qxnkC258umKVWGdR4ixj7eorCuk;
+              Expires=Mon, 23-May-2022 09:32:56 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_issues/Issues.test_issue_assignees.yaml
+++ b/tests/integration/pagure/test_data/test_issues/Issues.test_issue_assignees.yaml
@@ -5,6 +5,223 @@ _requre:
 requests.sessions:
   send:
     GET:
+      https://pagure.io/api/0/fork/kpostlet/testing/hello-112111/options:
+      - metadata:
+          latency: 0.49100685119628906
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.490791
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY';
+              style-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Fri, 22 Apr 2022 09:32:56 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZTQyZmE1YTdiYTMxNDFlMThjN2VmNWI2YzcxY2I2N2Q5YTk2NjgyYyJ9.FUQHyA.qxnkC258umKVWGdR4ixj7eorCuk;
+              Expires=Mon, 23-May-2022 09:32:56 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.49100685119628906
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.490791
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY';
+              style-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Fri, 22 Apr 2022 09:32:56 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZTQyZmE1YTdiYTMxNDFlMThjN2VmNWI2YzcxY2I2N2Q5YTk2NjgyYyJ9.FUQHyA.qxnkC258umKVWGdR4ixj7eorCuk;
+              Expires=Mon, 23-May-2022 09:32:56 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.49100685119628906
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.490791
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY';
+              style-src 'self' 'nonce-K7vZDgdUDAbi8r4tZmbUnL2KY'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Fri, 22 Apr 2022 09:32:56 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZTQyZmE1YTdiYTMxNDFlMThjN2VmNWI2YzcxY2I2N2Q5YTk2NjgyYyJ9.FUQHyA.qxnkC258umKVWGdR4ixj7eorCuk;
+              Expires=Mon, 23-May-2022 09:32:56 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
       https://pagure.io/api/0/fork/kpostlet/testing/hello-112111/issue/4:
       - metadata:
           latency: 0.4468674659729004

--- a/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list.yaml
+++ b/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list.yaml
@@ -283,6 +283,311 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      - metadata:
+          latency: 0.33968400955200195
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            args:
+              assignee: null
+              author: null
+              milestones: []
+              no_stones: null
+              order: null
+              priority: null
+              since: null
+              status: All
+              tags: []
+            issues:
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments: []
+              content: Example of Issue description
+              custom_fields: []
+              date_created: '1596113996'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/8
+              id: 8
+              last_updated: '1596113996'
+              milestone: null
+              priority: null
+              private: true
+              related_prs: []
+              status: Open
+              tags: []
+              title: This is an issue
+              user:
+                full_url: https://pagure.io/user/spapinwar
+                fullname: Shreyas Papinwar
+                name: spapinwar
+                url_path: user/spapinwar
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments: []
+              content: Example of Issue description
+              custom_fields: []
+              date_created: '1596111329'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/7
+              id: 7
+              last_updated: '1596111329'
+              milestone: null
+              priority: null
+              private: true
+              related_prs: []
+              status: Open
+              tags: []
+              title: This is an issue
+              user:
+                full_url: https://pagure.io/user/spapinwar
+                fullname: Shreyas Papinwar
+                name: spapinwar
+                url_path: user/spapinwar
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: test
+                date_created: '1570615519'
+                edited_on: '1574278899'
+                editor:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+                id: 603532
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: tests
+                date_created: '1570615521'
+                edited_on: null
+                editor: null
+                id: 603533
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: let's test regex
+                date_created: '1570615541'
+                edited_on: null
+                editor: null
+                id: 603534
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: regex test let's
+                date_created: '1570615551'
+                edited_on: null
+                editor: null
+                id: 603535
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              content: Issue for testing filtering comments
+              custom_fields: []
+              date_created: '1570615513'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/3
+              id: 3
+              last_updated: '1598357220'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags: []
+              title: Testing regex
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            - assignee:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+              blocks: []
+              close_status: null
+              closed_at: '1570615462'
+              closed_by:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+              comments:
+              - comment: '**Metadata Update from @mfocko**:
+
+                  - Issue status updated to: Closed (was: Open)'
+                date_created: '1570615463'
+                edited_on: null
+                editor: null
+                id: 603531
+                notification: true
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: '**Metadata Update from @mfocko**:
+
+                  - Issue assigned to mfocko'
+                date_created: '1579269774'
+                edited_on: null
+                editor: null
+                id: 621416
+                notification: true
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              content: Test closed issue
+              custom_fields: []
+              date_created: '1570615458'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/2
+              id: 2
+              last_updated: '1579269774'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Closed
+              tags: []
+              title: Test 1
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: '**Metadata Update from @cverna**:
+
+                  - Issue tagged with: test_label'
+                date_created: '1582728498'
+                edited_on: null
+                editor: null
+                id: 628903
+                notification: true
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/cverna
+                  fullname: Clement Verna
+                  name: cverna
+                  url_path: user/cverna
+              content: Testing issue
+              custom_fields: []
+              date_created: '1570615432'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/1
+              id: 1
+              last_updated: '1582728498'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags:
+              - test_label
+              title: Testing issue
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            pagination:
+              first: https://pagure.io/api/0/ogr-tests/issues?per_page=100&status=All&page=1
+              last: https://pagure.io/api/0/ogr-tests/issues?per_page=100&status=All&page=1
+              next: null
+              page: 1
+              pages: 1
+              per_page: 100
+              prev: null
+            total_issues: 5
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '8389'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=96
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYzVkYmI2OGFhMDg2MzI5MWZmNDU1Zjg3ZjNmMGFkOTQyYjIyNWYyMSJ9.FUQHzA.hxXFmIBrF6Y77cF3tsMMfUgxR8Q;
+              Expires=Mon, 23-May-2022 09:33:00 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
       https://pagure.io/api/0/ogr-tests/issues?status=Open&page=1&per_page=100:
       - metadata:
           latency: 0.4063444137573242
@@ -504,6 +809,391 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      - metadata:
+          latency: 0.3033876419067383
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            args:
+              assignee: null
+              author: null
+              milestones: []
+              no_stones: null
+              order: null
+              priority: null
+              since: null
+              status: Open
+              tags: []
+            issues:
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments: []
+              content: Example of Issue description
+              custom_fields: []
+              date_created: '1596113996'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/8
+              id: 8
+              last_updated: '1596113996'
+              milestone: null
+              priority: null
+              private: true
+              related_prs: []
+              status: Open
+              tags: []
+              title: This is an issue
+              user:
+                full_url: https://pagure.io/user/spapinwar
+                fullname: Shreyas Papinwar
+                name: spapinwar
+                url_path: user/spapinwar
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments: []
+              content: Example of Issue description
+              custom_fields: []
+              date_created: '1596111329'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/7
+              id: 7
+              last_updated: '1596111329'
+              milestone: null
+              priority: null
+              private: true
+              related_prs: []
+              status: Open
+              tags: []
+              title: This is an issue
+              user:
+                full_url: https://pagure.io/user/spapinwar
+                fullname: Shreyas Papinwar
+                name: spapinwar
+                url_path: user/spapinwar
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: test
+                date_created: '1570615519'
+                edited_on: '1574278899'
+                editor:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+                id: 603532
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: tests
+                date_created: '1570615521'
+                edited_on: null
+                editor: null
+                id: 603533
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: let's test regex
+                date_created: '1570615541'
+                edited_on: null
+                editor: null
+                id: 603534
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: regex test let's
+                date_created: '1570615551'
+                edited_on: null
+                editor: null
+                id: 603535
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              content: Issue for testing filtering comments
+              custom_fields: []
+              date_created: '1570615513'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/3
+              id: 3
+              last_updated: '1598357220'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags: []
+              title: Testing regex
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            - assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: '**Metadata Update from @cverna**:
+
+                  - Issue tagged with: test_label'
+                date_created: '1582728498'
+                edited_on: null
+                editor: null
+                id: 628903
+                notification: true
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/cverna
+                  fullname: Clement Verna
+                  name: cverna
+                  url_path: user/cverna
+              content: Testing issue
+              custom_fields: []
+              date_created: '1570615432'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/1
+              id: 1
+              last_updated: '1582728498'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags:
+              - test_label
+              title: Testing issue
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            pagination:
+              first: https://pagure.io/api/0/ogr-tests/issues?per_page=100&status=Open&page=1
+              last: https://pagure.io/api/0/ogr-tests/issues?per_page=100&status=Open&page=1
+              next: null
+              page: 1
+              pages: 1
+              per_page: 100
+              prev: null
+            total_issues: 4
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '6260'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=98
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYzVkYmI2OGFhMDg2MzI5MWZmNDU1Zjg3ZjNmMGFkOTQyYjIyNWYyMSJ9.FUQHyw.bCJkp0i6wC9c4yL87OQdP6gXFc8;
+              Expires=Mon, 23-May-2022 09:32:59 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.24509263038635254
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYzVkYmI2OGFhMDg2MzI5MWZmNDU1Zjg3ZjNmMGFkOTQyYjIyNWYyMSJ9.FUQHyw.bCJkp0i6wC9c4yL87OQdP6gXFc8;
+              Expires=Mon, 23-May-2022 09:32:59 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.245194673538208
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=97
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYzVkYmI2OGFhMDg2MzI5MWZmNDU1Zjg3ZjNmMGFkOTQyYjIyNWYyMSJ9.FUQHyw.bCJkp0i6wC9c4yL87OQdP6gXFc8;
+              Expires=Mon, 23-May-2022 09:32:59 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -542,6 +1232,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTURoaE9XWmtZalk1TkRjM09XVXpaRFJoT0RsbE9EVXhPV1V4T0RKbU4yWmlNemt5TW1GbFpnPT0ifX0.Eikbcg.gs_Q2MuSBO-8JWnuU7c6UoJ1YPY;
               Expires=Sun, 27-Sep-2020 10:24:50 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4584176540374756
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYzVkYmI2OGFhMDg2MzI5MWZmNDU1Zjg3ZjNmMGFkOTQyYjIyNWYyMSJ9.FUQHyg.S343sc085K09w4pZDb7e_BO_RgY;
+              Expires=Mon, 23-May-2022 09:32:58 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_assignee.yaml
+++ b/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_assignee.yaml
@@ -125,6 +125,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.26599812507629395
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZDBhNDRiNjlkMTQxN2ZiZDhlZTIxYzc4MmUxMTRiYmI3NmRjOTJiYSJ9.FUQHzA.LrGpyUXSo3yCLo6aCDGLY1eiRS4;
+              Expires=Mon, 23-May-2022 09:33:00 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -163,6 +235,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTkRsak5HUmtZbUkxTnpNeFptRmhZVFF3WkRKaVpURTJZVEkyTWpCaE1USXpOVGhoWkRWbE53PT0ifX0.Eikbcw.7f-uDYyBy3frl9ujur9tcMPgVR0;
               Expires=Sun, 27-Sep-2020 10:24:51 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.46901369094848633
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZDBhNDRiNjlkMTQxN2ZiZDhlZTIxYzc4MmUxMTRiYmI3NmRjOTJiYSJ9.FUQHzA.LrGpyUXSo3yCLo6aCDGLY1eiRS4;
+              Expires=Mon, 23-May-2022 09:33:00 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_author.yaml
+++ b/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_author.yaml
@@ -237,6 +237,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.23883938789367676
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzRiYTMxOTg3NDA5ZDdjYzE2MWY4Zjk3YmJmYWIzOWViMjZlMmI5OCJ9.FUQHzQ._2UgVOWY5SwfgSY6fEKXxlSIVYg;
+              Expires=Mon, 23-May-2022 09:33:01 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -275,6 +347,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTjJRNE56Rm1Oek13WXpjMk16TmpOR1JtTnpNNU5HRmxNalkwTVRVMk5tUTRNVE16TURCbE1BPT0ifX0.EikbdQ.fdtkqDSvtWT5rABGfz_al4HOXXQ;
               Expires=Sun, 27-Sep-2020 10:24:53 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4570345878601074
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzRiYTMxOTg3NDA5ZDdjYzE2MWY4Zjk3YmJmYWIzOWViMjZlMmI5OCJ9.FUQHzQ._2UgVOWY5SwfgSY6fEKXxlSIVYg;
+              Expires=Mon, 23-May-2022 09:33:01 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_labels.yaml
+++ b/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_labels.yaml
@@ -107,6 +107,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.22018122673034668
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiOGFmMTBhOWFkZWMxZjUxZTc0ZTZjMDY0MTBjMjUyMmMxYjk3NmI4MyJ9.FUQHzg.wrLX_BVzgqreF6xux-cP0itkHds;
+              Expires=Mon, 23-May-2022 09:33:02 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -145,6 +217,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTmpnd1ltUTNaRFU0TURKbE1HRXlObU14WVdJeE4yTmtOMkZpTnpWbE1HRTNOREF3TW1Fek9BPT0ifX0.Eikbdg.z82ni-P6AIC3-jO2xKIN9x19CWY;
               Expires=Sun, 27-Sep-2020 10:24:54 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.439483642578125
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiOGFmMTBhOWFkZWMxZjUxZTc0ZTZjMDY0MTBjMjUyMmMxYjk3NmI4MyJ9.FUQHzg.wrLX_BVzgqreF6xux-cP0itkHds;
+              Expires=Mon, 23-May-2022 09:33:02 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_nonexisting_author.yaml
+++ b/tests/integration/pagure/test_data/test_issues/tests.integration.pagure.test_issues.Issues.test_issue_list_nonexisting_author.yaml
@@ -68,6 +68,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.21048760414123535
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmM0MjliMDM0ODYyYmNlN2E1NzhhMzBmNmQzNTY4NTA2YjQyMGQ5MSJ9.FUQH0A.Onfl9L1EByjPGr-ljruvsXyy_fk;
+              Expires=Mon, 23-May-2022 09:33:04 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -106,6 +178,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWlRFd09EUTVNV05pWXprM1pUVTJOamsxWldSak1USXdOREF4Tm1JMFpEUTJObUZpTTJWbFl3PT0ifX0.Eikbdw.UpbDHkykWNGl8hkXZBpL26yd6-c;
               Expires=Sun, 27-Sep-2020 10:24:55 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.48395490646362305
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_issues
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmM0MjliMDM0ODYyYmNlN2E1NzhhMzBmNmQzNTY4NTA2YjQyMGQ5MSJ9.FUQHzw.bpncQ8acEglIJBU39HKvi6H1QCM;
+              Expires=Mon, 23-May-2022 09:33:03 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments.yaml
@@ -125,6 +125,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.20630764961242676
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYjdmMjRjNTdkZjkzODc5ODI2NTE2MTM1NDg0M2QyN2M0MzQzNjRhMCJ9.FUQH9g.W_g3jjNFlfACKA5CnyQsrUBdREU;
+              Expires=Mon, 23-May-2022 09:33:42 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -162,6 +234,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTkRobU1USXdPRGd5WkRReVl6UXlaV1ptTXpGaFptWTROMlJoWlRGbVpXWXdZbUUzTkRFek13PT0ifX0.EiaQVw.l3rG9cX6BwcLKivHbKCdEtDpMOU;
               Expires=Fri, 25-Sep-2020 12:06:47 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4486508369445801
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYjdmMjRjNTdkZjkzODc5ODI2NTE2MTM1NDg0M2QyN2M0MzQzNjRhMCJ9.FUQH9g.W_g3jjNFlfACKA5CnyQsrUBdREU;
+              Expires=Mon, 23-May-2022 09:33:42 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_author.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_author.yaml
@@ -125,6 +125,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.2242896556854248
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMzc3ZTc1YjkxOGI5YTNlY2VjY2Q2YjBmNzU0YmYyNzE1ZDI0OTUzZiJ9.FUQH9w.R57Jiwa9cAXu_RrXs_9YlCCec4w;
+              Expires=Mon, 23-May-2022 09:33:43 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -162,6 +234,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTmpoalpUSTJaRFJsWkRRMU16UTNPVE0xWlRrd09HRTROREkzTlRsbU9URTNNelpqTlRNME5BPT0ifX0.EiaQWA.qovQ_wEoqV6NrixZR4qKSLwHGbM;
               Expires=Fri, 25-Sep-2020 12:06:48 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4694650173187256
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMzc3ZTc1YjkxOGI5YTNlY2VjY2Q2YjBmNzU0YmYyNzE1ZDI0OTUzZiJ9.FUQH9w.R57Jiwa9cAXu_RrXs_9YlCCec4w;
+              Expires=Mon, 23-May-2022 09:33:43 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_author_regex.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_author_regex.yaml
@@ -125,6 +125,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.2138209342956543
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMjM1ZWE5Y2Q4NTEzY2ZhNGMyYzg3ZmQ3Y2I5MWE3ODFmNDUzZmE0OSJ9.FUQH-A.1CyP-u0azVewjAux_yAYTGSp_UE;
+              Expires=Mon, 23-May-2022 09:33:44 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -162,6 +234,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTWpVeU9XVXlNbUZqTm1VMllXUmhNR1ptTVdFMk1ETTNORFJoT1RjeE1UVTBOVEprTldZeU5BPT0ifX0.EiaQWg.Rsz9GbZApWMvkEde4EleQSy21b4;
               Expires=Fri, 25-Sep-2020 12:06:50 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.46073126792907715
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMjM1ZWE5Y2Q4NTEzY2ZhNGMyYzg3ZmQ3Y2I5MWE3ODFmNDUzZmE0OSJ9.FUQH-A.1CyP-u0azVewjAux_yAYTGSp_UE;
+              Expires=Mon, 23-May-2022 09:33:44 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_regex.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_regex.yaml
@@ -125,6 +125,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.27692413330078125
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZTBlMmM0YjIwODA0OWVhYzJjNDAwNDdhZmE4OGM5ZWQyOGM3Y2Q5NCJ9.FUQH-Q.sCZ_pIrVmrCgPf_RXmEI46xC6J8;
+              Expires=Mon, 23-May-2022 09:33:45 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -162,6 +234,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTmpFMVptSmpaREZsTVRsak5UWTBaRGd4WlRCaFkySXpZVE5oTkdRNFlUWm1NMlJsTVRJMU1BPT0ifX0.EiaQWw.vUyRLqlmq9vTdbB9ABI-GBAiPJA;
               Expires=Fri, 25-Sep-2020 12:06:51 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4456315040588379
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZTBlMmM0YjIwODA0OWVhYzJjNDAwNDdhZmE4OGM5ZWQyOGM3Y2Q5NCJ9.FUQH-Q.sCZ_pIrVmrCgPf_RXmEI46xC6J8;
+              Expires=Mon, 23-May-2022 09:33:45 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_regex_reversed.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_regex_reversed.yaml
@@ -125,6 +125,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.19196748733520508
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMzdhMDVlYTg5ZTBhZjBhN2VjNjIxYzZkYTAzYzUxMGNhMDU1MjZkYiJ9.FUQH-g.ip7fI7xuC7zzy1OAt55_ztGTMmg;
+              Expires=Mon, 23-May-2022 09:33:46 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -162,6 +234,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTjJabE9XVTFNakpoWldJNFlqWXhOVGMzTVdZMllUTTBOekEzWldZM05EZGlObVl5TXpOaU53PT0ifX0.EiaQXA.8VGS3HOtYU2-WcBOceF3dQp-ops;
               Expires=Fri, 25-Sep-2020 12:06:52 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4647972583770752
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMzdhMDVlYTg5ZTBhZjBhN2VjNjIxYzZkYTAzYzUxMGNhMDU1MjZkYiJ9.FUQH-g.ip7fI7xuC7zzy1OAt55_ztGTMmg;
+              Expires=Mon, 23-May-2022 09:33:46 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_reversed.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_comments_reversed.yaml
@@ -125,6 +125,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.2337629795074463
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZWYxMjUzM2VlMWE5ZTRiN2NmZDMxMDVlYjUyMTg4OTU2YTM0MDdiZSJ9.FUQH-w.tFjghw4FXnDQOE1PQ25CX29ic64;
+              Expires=Mon, 23-May-2022 09:33:47 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -162,6 +234,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTmpabE5UaGhNbVl4TjJNME9EY3hOelkyT0dOak1UQTJNVE5oTkRNMFl6YzNObUZtWXpFMlpnPT0ifX0.EiaQXQ.JxerY9z7RCcoATLhuB3KXzXYK0o;
               Expires=Fri, 25-Sep-2020 12:06:53 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.44587230682373047
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZWYxMjUzM2VlMWE5ZTRiN2NmZDMxMDVlYjUyMTg4OTU2YTM0MDdiZSJ9.FUQH-w.tFjghw4FXnDQOE1PQ25CX29ic64;
+              Expires=Mon, 23-May-2022 09:33:47 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_info.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_info.yaml
@@ -108,6 +108,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.22684264183044434
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiOWUzZTUzZWI3NTgzYzk0MzBmZjM5YTNjMzg1ZjczNzdhZDEwMWRhYSJ9.FUQH_A.kzedciBLT2vg74m0I2i0aylWeLc;
+              Expires=Mon, 23-May-2022 09:33:48 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -145,6 +217,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiWlRkak9XVmxaREF4WWpJMlpqWmpNMk13TVRZNVltWmtZek13T0dFM01USTBZelpqTVROa09BPT0ifX0.EiaQXg.LOKN4Z6vsh56imSbBn7fhFcMf-g;
               Expires=Fri, 25-Sep-2020 12:06:54 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.46694374084472656
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiOWUzZTUzZWI3NTgzYzk0MzBmZjM5YTNjMzg1ZjczNzdhZDEwMWRhYSJ9.FUQH_A.kzedciBLT2vg74m0I2i0aylWeLc;
+              Expires=Mon, 23-May-2022 09:33:48 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_permissions.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_permissions.yaml
@@ -155,6 +155,180 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      - metadata:
+          latency: 0.2090013027191162
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_groups:
+              admin: []
+              collaborator: []
+              commit: []
+              ticket: []
+            access_users:
+              admin:
+              - jscotka
+              - lbarczio
+              - mfocko
+              - nikromen
+              collaborator: []
+              commit: []
+              owner:
+              - lachmanfrantisek
+              ticket: []
+            close_status: []
+            custom_keys: []
+            date_created: '1570568389'
+            date_modified: '1638271116'
+            description: Testing repository for python-ogr package.
+            full_url: https://pagure.io/ogr-tests
+            fullname: ogr-tests
+            id: 6826
+            milestones: {}
+            name: ogr-tests
+            namespace: null
+            parent: null
+            priorities: {}
+            tags: []
+            url_path: ogr-tests
+            user:
+              full_url: https://pagure.io/user/lachmanfrantisek
+              fullname: "Franti\u0161ek Lachman"
+              name: lachmanfrantisek
+              url_path: user/lachmanfrantisek
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '946'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMjY3Njc1ZDRkZjUyZGViYjUwZTNmNDYyMTYzNWY5NjY3OTdmNmNiZiJ9.FUQH_Q.4tVhCRfTwFs9Gi2_PEOZq-KP_fk;
+              Expires=Mon, 23-May-2022 09:33:49 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.237396240234375
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.services.base
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_groups:
+              admin: []
+              collaborator: []
+              commit: []
+              ticket: []
+            access_users:
+              admin:
+              - jscotka
+              - lbarczio
+              - mfocko
+              - nikromen
+              collaborator: []
+              commit: []
+              owner:
+              - lachmanfrantisek
+              ticket: []
+            close_status: []
+            custom_keys: []
+            date_created: '1570568389'
+            date_modified: '1638271116'
+            description: Testing repository for python-ogr package.
+            full_url: https://pagure.io/ogr-tests
+            fullname: ogr-tests
+            id: 6826
+            milestones: {}
+            name: ogr-tests
+            namespace: null
+            parent: null
+            priorities: {}
+            tags: []
+            url_path: ogr-tests
+            user:
+              full_url: https://pagure.io/user/lachmanfrantisek
+              fullname: "Franti\u0161ek Lachman"
+              name: lachmanfrantisek
+              url_path: user/lachmanfrantisek
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '946'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=96
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMjY3Njc1ZDRkZjUyZGViYjUwZTNmNDYyMTYzNWY5NjY3OTdmNmNiZiJ9.FUQH_g.jH-MNKkzvE8xa7ZTe0Z4GeQIFcU;
+              Expires=Mon, 23-May-2022 09:33:50 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
       https://pagure.io/api/0/ogr-tests/issue/2:
       - metadata:
           latency: 0.2963848114013672
@@ -258,6 +432,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.19512224197387695
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=98
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMjY3Njc1ZDRkZjUyZGViYjUwZTNmNDYyMTYzNWY5NjY3OTdmNmNiZiJ9.FUQH_Q.4tVhCRfTwFs9Gi2_PEOZq-KP_fk;
+              Expires=Mon, 23-May-2022 09:33:49 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -295,6 +541,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTm1aak5UazFaRFV6WkRRME16UTRNalUxTnpCaE1XTmxObVl6WWpaa01XUXhNR0ppTVRNNFl3PT0ifX0.EiaQXw.cZSETmQpheBxUz3Gdu88-Rhwt7s;
               Expires=Fri, 25-Sep-2020 12:06:55 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.5356144905090332
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMjY3Njc1ZDRkZjUyZGViYjUwZTNmNDYyMTYzNWY5NjY3OTdmNmNiZiJ9.FUQH_Q.4tVhCRfTwFs9Gi2_PEOZq-KP_fk;
+              Expires=Mon, 23-May-2022 09:33:49 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_update_description.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_update_description.yaml
@@ -122,6 +122,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.21282362937927246
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMGIxMWQ4NDg2OTZkNWJlMjAwNzY1Mjc0M2QyZGFkMjFiZjg0ZTNhOSJ9.FUQH_g.vb9wPDIDnI8IUEbX6AeNmxEAe98;
+              Expires=Mon, 23-May-2022 09:33:50 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -159,6 +231,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTlRNMVpUaGtOVGsxTVRWbVkyVXlZakppTjJVMU1tWXlaR0ptWVRobU0yTXhNMlJsWm1SaU9RPT0ifX0.EiaQYQ.935USbxv7uIjMPdxJjTZ-liDiIU;
               Expires=Fri, 25-Sep-2020 12:06:57 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.44315242767333984
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMGIxMWQ4NDg2OTZkNWJlMjAwNzY1Mjc0M2QyZGFkMjFiZjg0ZTNhOSJ9.FUQH_g.vb9wPDIDnI8IUEbX6AeNmxEAe98;
+              Expires=Mon, 23-May-2022 09:33:50 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -394,6 +516,270 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTlRNMVpUaGtOVGsxTVRWbVkyVXlZakppTjJVMU1tWXlaR0ptWVRobU0yTXhNMlJsWm1SaU9RPT0ifX0.EiaQYg.e5ZOb7FiVrTOg4uzj-Me3u65mjE;
               Expires=Fri, 25-Sep-2020 12:06:58 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4144308567047119
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            issue:
+              assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: test
+                date_created: '1570615519'
+                edited_on: '1574278899'
+                editor:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+                id: 603532
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: tests
+                date_created: '1570615521'
+                edited_on: null
+                editor: null
+                id: 603533
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: let's test regex
+                date_created: '1570615541'
+                edited_on: null
+                editor: null
+                id: 603534
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: regex test let's
+                date_created: '1570615551'
+                edited_on: null
+                editor: null
+                id: 603535
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              content: testing description
+              custom_fields: []
+              date_created: '1570615513'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/3
+              id: 3
+              last_updated: '1650620031'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags: []
+              title: Testing regex
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            message: Issue edited
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '2668'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=97
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMGIxMWQ4NDg2OTZkNWJlMjAwNzY1Mjc0M2QyZGFkMjFiZjg0ZTNhOSJ9.FUQH_w.m7WOOQchNOGOtooFiBl1mp20eRc;
+              Expires=Mon, 23-May-2022 09:33:51 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.40750718116760254
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            issue:
+              assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: test
+                date_created: '1570615519'
+                edited_on: '1574278899'
+                editor:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+                id: 603532
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: tests
+                date_created: '1570615521'
+                edited_on: null
+                editor: null
+                id: 603533
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: let's test regex
+                date_created: '1570615541'
+                edited_on: null
+                editor: null
+                id: 603534
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: regex test let's
+                date_created: '1570615551'
+                edited_on: null
+                editor: null
+                id: 603535
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              content: Issue for testing filtering comments
+              custom_fields: []
+              date_created: '1570615513'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/3
+              id: 3
+              last_updated: '1650620031'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags: []
+              title: Testing regex
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            message: Issue edited
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '2685'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=96
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiMGIxMWQ4NDg2OTZkNWJlMjAwNzY1Mjc0M2QyZGFkMjFiZjg0ZTNhOSJ9.FUQH_w.m7WOOQchNOGOtooFiBl1mp20eRc;
+              Expires=Mon, 23-May-2022 09:33:51 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/

--- a/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_update_title.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/tests.integration.pagure.test_project_token.PagureProjectTokenCommands.test_issue_update_title.yaml
@@ -122,6 +122,78 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      https://pagure.io/api/0/ogr-tests/options:
+      - metadata:
+          latency: 0.24489736557006836
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            settings:
+              Enforce_signed-off_commits_in_pull-request: false
+              Minimum_score_to_merge_pull-request: -1
+              Only_assignee_can_merge_pull-request: false
+              Web-hooks: null
+              always_merge: false
+              disable_non_fast-forward_merges: false
+              fedmsg_notifications: true
+              issue_tracker: true
+              issue_tracker_read_only: false
+              issues_default_to_private: false
+              mqtt_notifications: true
+              notify_on_commit_flag: false
+              notify_on_pull-request_flag: false
+              open_metadata_access_to_all: false
+              project_documentation: false
+              pull_request_access_only: false
+              pull_requests: true
+              stomp_notifications: true
+            status: ok
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '736'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=99
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZGZhYzY4NWFhNzAwYWU5Yzk4ODdlMTc3NDMwNmQ0NDA0NmUxYjZhZiJ9.FUQIAA.T5owWJZWspmAG_0TFAo4t0vLZaY;
+              Expires=Mon, 23-May-2022 09:33:52 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
@@ -159,6 +231,56 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTmpCa1ptWTVPREJpWXpFM01tSXlZVFl6WWpBMU1tWTJaamsxT1dSaVlUUTNZalJpWldFM09RPT0ifX0.EiaQYw.F-aq7xAnkeP5_50VMqPy9aSAmxk;
               Expires=Fri, 25-Sep-2020 12:06:59 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.5024807453155518
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - tests.integration.pagure.base
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            username: mfocko
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=100
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZGZhYzY4NWFhNzAwYWU5Yzk4ODdlMTc3NDMwNmQ0NDA0NmUxYjZhZiJ9.FUQIAA.T5owWJZWspmAG_0TFAo4t0vLZaY;
+              Expires=Mon, 23-May-2022 09:33:52 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -394,6 +516,270 @@ requests.sessions:
               Python/2.7.5
             Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmIjp7IiBiIjoiTmpCa1ptWTVPREJpWXpFM01tSXlZVFl6WWpBMU1tWTJaamsxT1dSaVlUUTNZalJpWldFM09RPT0ifX0.EiaQZQ.dUwyJjfTzbvJiGBeZwzBlAkWRl8;
               Expires=Fri, 25-Sep-2020 12:07:01 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 1.4790472984313965
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            issue:
+              assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: test
+                date_created: '1570615519'
+                edited_on: '1574278899'
+                editor:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+                id: 603532
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: tests
+                date_created: '1570615521'
+                edited_on: null
+                editor: null
+                id: 603533
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: let's test regex
+                date_created: '1570615541'
+                edited_on: null
+                editor: null
+                id: 603534
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: regex test let's
+                date_created: '1570615551'
+                edited_on: null
+                editor: null
+                id: 603535
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              content: Issue for testing filtering comments
+              custom_fields: []
+              date_created: '1570615513'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/3
+              id: 3
+              last_updated: '1650620033'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags: []
+              title: testing title
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            message: Issue edited
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '2685'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=97
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZGZhYzY4NWFhNzAwYWU5Yzk4ODdlMTc3NDMwNmQ0NDA0NmUxYjZhZiJ9.FUQIAg.0Beiy-FN-JM_a2TCP0Lgua7wxUM;
+              Expires=Mon, 23-May-2022 09:33:54 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.4068419933319092
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_project_token
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.issue
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            issue:
+              assignee: null
+              blocks: []
+              close_status: null
+              closed_at: null
+              closed_by: null
+              comments:
+              - comment: test
+                date_created: '1570615519'
+                edited_on: '1574278899'
+                editor:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+                id: 603532
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: tests
+                date_created: '1570615521'
+                edited_on: null
+                editor: null
+                id: 603533
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: let's test regex
+                date_created: '1570615541'
+                edited_on: null
+                editor: null
+                id: 603534
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              - comment: regex test let's
+                date_created: '1570615551'
+                edited_on: null
+                editor: null
+                id: 603535
+                notification: false
+                parent: null
+                reactions: {}
+                user:
+                  full_url: https://pagure.io/user/mfocko
+                  fullname: Matej Focko
+                  name: mfocko
+                  url_path: user/mfocko
+              content: Issue for testing filtering comments
+              custom_fields: []
+              date_created: '1570615513'
+              depends: []
+              full_url: https://pagure.io/ogr-tests/issue/3
+              id: 3
+              last_updated: '1650620034'
+              milestone: null
+              priority: null
+              private: false
+              related_prs: []
+              status: Open
+              tags: []
+              title: Testing regex
+              user:
+                full_url: https://pagure.io/user/mfocko
+                fullname: Matej Focko
+                name: mfocko
+                url_path: user/mfocko
+            message: Issue edited
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '2685'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Keep-Alive: timeout=5, max=96
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZGZhYzY4NWFhNzAwYWU5Yzk4ODdlMTc3NDMwNmQ0NDA0NmUxYjZhZiJ9.FUQIAw.l8WoR-Zq7Ig15S0-RXuNSCiwszA;
+              Expires=Mon, 23-May-2022 09:33:55 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/


### PR DESCRIPTION
Raise ‹IssueTrackerDisabled› in all functions that directly touch the
issues of the project, not just the ‹.create› function.

Reproduced in packit/packit-service#1463
Fixes #702

Signed-off-by: Matej Focko <mfocko@redhat.com>

RELEASE NOTES BEGIN
We have fixed a bug in ogr that caused `IssueTrackerDisabled` being raised only when trying to create an issue on git project with disabled issue tracker. Now it is also raised when getting a specific issue or an issue list.
RELEASE NOTES END
