### PR TITLE
fix(pagure): raise for invalid URL in pagure

### DIFF
--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -100,6 +100,9 @@ class PagureService(BaseGitService):
 
     def get_project_from_url(self, url: str) -> "PagureProject":
         repo_url = parse_git_repo(potential_url=url)
+        if not repo_url:
+            raise OgrException(f"Cannot parse project url: '{url}'")
+
         if not repo_url.is_fork:
             repo_url.username = None
 


### PR DESCRIPTION
When using `PagureService.get_project_from_url` test for correctly parsed
URL before accessing its attributes (resulting in `AttributeError`).

Fixes #698

Signed-off-by: Matej Focko <mfocko@redhat.com>

RELEASE NOTES BEGIN
`ogr` now correctly raises `OgrException` when given invalid URL to `PagureService.get_project_from_url`.
RELEASE NOTES END
