### PR TITLE
fix(github): raise specific exception from tokman

### DIFF
--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -101,3 +101,7 @@ class OgrNetworkError(OgrException):
 
 class GitForgeInternalError(OgrNetworkError):
     """Exception raised when git forge returns internal failure."""
+
+
+class GithubAppNotInstalledError(OgrException):
+    """Exception raised when GitHub App is not installed."""

--- a/ogr/services/github/auth_providers/tokman.py
+++ b/ogr/services/github/auth_providers/tokman.py
@@ -7,7 +7,7 @@ from typing import Optional
 import github
 
 from ogr.services.github.auth_providers.abstract import GithubAuthentication
-from ogr.exceptions import OgrException, OgrNetworkError
+from ogr.exceptions import GithubAppNotInstalledError, OgrException, OgrNetworkError
 
 
 class Tokman(GithubAuthentication):
@@ -32,6 +32,9 @@ class Tokman(GithubAuthentication):
         response = requests.get(f"{self._instance_url}/api/{namespace}/{repo}")
 
         if not response.ok:
+            if response.status_code == 400:
+                raise GithubAppNotInstalledError(response.text)
+
             cls = OgrNetworkError if response.status_code >= 500 else OgrException
             raise cls(
                 f"Couldn't retrieve token from Tokman: ({response.status_code}) {response.text}"


### PR DESCRIPTION
When querying tokman, we can get 400 for suspended or uninstalled GitHub
Apps, in such case raise an appropriate exception that can be handled
later on in a better way.

Signed-off-by: Matej Focko <mfocko@redhat.com>

Fixes #666

Merge before packit/packit#1566

RELEASE NOTES BEGIN
When using Tokman as GitHub authentication mechanism, ogr will now raise `GithubAppNotInstalledError` instead of failing with generic `GithubAPIException` when app providing tokens is not installed on the repository.
RELEASE NOTES END
