### PR TITLE
Add setuptools to requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     PyYAML
     requests
     urllib3
+    setuptools
 python_requires = >=3.6
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
We use `pkg_resources` in `ogr/__init__.py` so it needs to be installed
with the package.

Context: https://bodhi.fedoraproject.org/updates/FEDORA-2022-20fd24ab3c
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

RELEASE NOTES BEGIN
The packaging issue with missing `pkg_resources` is fixed by requiring `setuptools` as `install_requires` dependency.
RELEASE NOTES END
