### PR TITLE
Drop runtime dependency on setuptools

### DIFF
--- a/ogr/__init__.py
+++ b/ogr/__init__.py
@@ -5,8 +5,6 @@
 Module providing one api for multiple git services (github/gitlab/pagure)
 """
 
-from pkg_resources import get_distribution, DistributionNotFound
-
 from ogr.factory import (
     get_project,
     get_service_class,
@@ -18,8 +16,14 @@ from ogr.services.gitlab import GitlabService
 from ogr.services.pagure import PagureService
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError, distribution
+except ImportError:
+    from importlib_metadata import PackageNotFoundError  # type: ignore
+    from importlib_metadata import distribution  # type: ignore
+
+try:
+    __version__ = distribution(__name__).version
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     PyYAML
     requests
     urllib3
-    setuptools
+    importlib-metadata;python_version<"3.8"
 python_requires = >=3.6
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
The `setuptools` package is a huge overkill to get self-version.

Use the standard library instead on Python 3.8+,
or a smaller package on older Pythons.

Credits go to Miro Hrončok:
https://github.com/packit/specfile/commit/7ab965a161c14b841c200d3779d7163edd314372

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

Replaces: #709


RELEASE NOTES BEGIN
Use the standard library instead of `setuptools` for getting the version on Python 3.8+,
or a smaller package on older Pythons.
RELEASE NOTES END
