### PR TITLE
Prepare release 0.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.38.1
+
+- When using Tokman as GitHub authentication mechanism, ogr will now raise GithubAppNotInstalledError instead of failing with generic GithubAPIException when app providing tokens is not installed on the repository.
+- Use the standard library instead of setuptools for getting the version on Python 3.8+,
+  or a smaller package on older Pythons.
+  This also fixes the packaging issue with missing `pkg_resources`.
+
 # 0.38.0
 
 - ogr now correctly raises `OgrException` when given invalid URL to

--- a/fedora/python-ogr.spec
+++ b/fedora/python-ogr.spec
@@ -1,7 +1,7 @@
 %global srcname ogr
 
 Name:           python-%{srcname}
-Version:        0.38.0
+Version:        0.38.1
 Release:        1%{?dist}
 Summary:        One API for multiple git forges
 
@@ -52,6 +52,9 @@ rm -rf %{srcname}.egg-info
 
 
 %changelog
+* Fri Apr 29 2022 Frantisek Lachman <flachman@redhat.com> - 0.38.1-1
+- New upstream release 0.38.1
+
 * Thu Apr 28 2022 František Nečas <fnecas@redhat.com> - 0.38.0-1
 - New upstream release 0.38.0
 


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

GitHub release content:
```
- When using Tokman as GitHub authentication mechanism, ogr will now raise GithubAppNotInstalledError instead of failing with generic GithubAPIException when app providing tokens is not installed on the repository.
- Use the standard library instead of setuptools for getting the version on Python 3.8+,
  or a smaller package on older Pythons.
  This also fixes the packaging issue with missing `pkg_resources`.
```