### PR TITLE
When merging from fork the target is the fork's parent

### DIFF
--- a/ogr/services/github/pull_request.py
+++ b/ogr/services/github/pull_request.py
@@ -147,10 +147,12 @@ class GithubPullRequest(BasePullRequest):
         """
         github_repo = project.github_repo
 
+        target_project = project
         if project.is_fork and fork_username is None:
             logger.warning(f"{project.full_repo_name} is fork, ignoring fork_repo.")
             source_branch = f"{project.namespace}:{source_branch}"
             github_repo = project.parent.github_repo
+            target_project = project.parent
         elif fork_username:
             source_branch = f"{fork_username}:{source_branch}"
             if fork_username != project.namespace and project.parent is not None:
@@ -162,7 +164,7 @@ class GithubPullRequest(BasePullRequest):
             title=title, body=body, base=target_branch, head=source_branch
         )
         logger.info(f"PR {created_pr.id} created: {target_branch}<-{source_branch}")
-        return GithubPullRequest(created_pr, project)
+        return GithubPullRequest(created_pr, target_project)
 
     @staticmethod
     def __get_fork(fork_username: str, repo: _GithubRepository) -> _GithubRepository:

--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -170,9 +170,11 @@ class GitlabPullRequest(BasePullRequest):
         }
         target_id = None
 
+        target_project = project
         if project.is_fork and fork_username is None:
             # handles fork -> upstream (called on fork)
             target_id = project.parent.gitlab_repo.attributes["id"]
+            target_project = project.parent
         elif fork_username and fork_username != project.namespace:
             # handles fork -> upstream
             #   (username of fork owner specified by fork_username)
@@ -194,7 +196,7 @@ class GitlabPullRequest(BasePullRequest):
             parameters["target_project_id"] = target_id
 
         mr = repo.mergerequests.create(parameters)
-        return GitlabPullRequest(mr, project)
+        return GitlabPullRequest(mr, target_project)
 
     @staticmethod
     def __get_fork(

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -171,7 +171,7 @@ class PagurePullRequest(BasePullRequest):
         response = caller._call_project_api(
             "pull-request", "new", method="POST", data=data
         )
-        return PagurePullRequest(response, project)
+        return PagurePullRequest(response, caller)
 
     @staticmethod
     def get(project: "ogr_pagure.PagureProject", pr_id: int) -> "PullRequest":

--- a/tests/integration/github/test_pull_requests.py
+++ b/tests/integration/github/test_pull_requests.py
@@ -87,6 +87,7 @@ class PullRequests(GithubTests):
 
         assert pr_upstream_upstream.title == "test: upstream <- upstream"
         assert pr_upstream_upstream.status == PRStatus.open
+        assert not pr_upstream_upstream.target_project.is_fork
         assert pr_opened_after == pr_opened_before + 1
 
         pr_upstream_upstream.close()
@@ -117,6 +118,7 @@ class PullRequests(GithubTests):
             == "test: upstream <- fork_username:source_branch"
         )
         assert pr_upstream_forkusername.status == PRStatus.open
+        assert not pr_upstream_forkusername.target_project.is_fork
         assert pr_opened_after == pr_opened_before + 1
 
         pr_upstream_forkusername.close()
@@ -142,6 +144,7 @@ class PullRequests(GithubTests):
 
         assert pr_upstream_fork.title == "test: upstream <- fork"
         assert pr_upstream_fork.status == PRStatus.open
+        assert not pr_upstream_fork.target_project.is_fork
         assert pr_opened_after == pr_opened_before + 1
 
         pr_upstream_fork.close()
@@ -167,6 +170,7 @@ class PullRequests(GithubTests):
 
         assert opened_pr.title == "test: other_fork(master) <- fork"
         assert opened_pr.status == PRStatus.open
+        assert opened_pr.target_project.is_fork
         assert pr_opened_after == pr_opened_before + 1
 
         opened_pr.close()
@@ -191,6 +195,7 @@ class PullRequests(GithubTests):
 
         assert opened_pr.title == "test: fork(master) <- fork"
         assert opened_pr.status == PRStatus.open
+        assert opened_pr.target_project.is_fork
         assert pr_opened_after == pr_opened_before + 1
 
         opened_pr.close()

--- a/tests/integration/gitlab/test_pull_requests.py
+++ b/tests/integration/gitlab/test_pull_requests.py
@@ -286,6 +286,7 @@ class PullRequests(GitlabTests):
         )
         assert pr_upstream_upstream.title == "test PR: upstream -> upstream"
         assert pr_upstream_upstream.status == PRStatus.open
+        assert not pr_upstream_upstream.target_project.is_fork
 
         prs_after = len(self.project.get_pr_list(status=PRStatus.open))
         self.project.get_pr(pr_upstream_upstream.id).close()
@@ -306,6 +307,7 @@ class PullRequests(GitlabTests):
         )
         assert pr_upstream_forkusername.status == PRStatus.open
         assert pr_upstream_forkusername.source_project == self.project.get_fork()
+        assert not pr_upstream_forkusername.target_project.is_fork
 
         prs_after = len(self.project.get_pr_list(status=PRStatus.open))
         self.project.get_pr(pr_upstream_forkusername.id).close()
@@ -321,6 +323,7 @@ class PullRequests(GitlabTests):
         )
         assert pr_upstream_fork.title == "test PR: fork -> upstream"
         assert pr_upstream_fork.status == PRStatus.open
+        assert not pr_upstream_fork.target_project.is_fork
 
         prs_after = len(self.project.get_pr_list(status=PRStatus.open))
         self.project.get_pr(pr_upstream_fork.id).close()
@@ -345,6 +348,7 @@ class PullRequests(GitlabTests):
 
         assert opened_pr.title == "test: fork(master) <- fork"
         assert opened_pr.status == PRStatus.open
+        assert opened_pr.target_project.is_fork
         assert pr_opened_after == pr_opened_before + 1
 
         opened_pr.close()
@@ -367,6 +371,7 @@ class PullRequests(GitlabTests):
         )
         assert pr_fork_fork.title == "test PR: fork -> other_fork"
         assert pr_fork_fork.status == PRStatus.open
+        assert pr_fork_fork.target_project.is_fork
 
         prs_after = len(other_fork.get_pr_list(status=PRStatus.open))
         self.project.get_pr(pr_fork_fork.id).close()

--- a/tests/integration/pagure/test_pull_requests.py
+++ b/tests/integration/pagure/test_pull_requests.py
@@ -21,6 +21,7 @@ class PullRequests(PagureTests):
         assert pr.target_branch == "master"
         assert pr.source_branch == "master"
         assert pr.status == PRStatus.open
+        assert not pr.target_project.is_fork
 
     def test_pr_create_from_parent(self):
         pr = self.ogr_project.create_pr(


### PR DESCRIPTION
The PullRequest target project should be the parent of the forked project when merging from fork.

Fixes packit/hardly#63
