### PR TITLE
Implement closed by property for Pagure PR

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -20,6 +20,7 @@ In case you find any error, please [create a new issue](https://github.com/packi
 | `body` (get/set) |  ✔/✔   |  ✔/✔   |  ✔/✘   |
 | `add_reaction`   |   ✔    |   ✔    |   ✘    |
 | `get_reactions`  |   ✔    |   ✔    |   ✘    |
+| `closed_by`      |   ✘    |   ✘    |   ✔    |
 
 ## Issue
 

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -675,6 +675,11 @@ class PullRequest(OgrAbstractClass):
         """Web URL to the list of commits in the pull request."""
         raise NotImplementedError()
 
+    @property
+    def closed_by(self) -> Optional[str]:
+        """Login of the account that closed the pull request."""
+        raise NotImplementedError
+
     def __str__(self) -> str:
         description = (
             f"{self.description[:10]}..." if self.description is not None else "None"

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -125,6 +125,11 @@ class PagurePullRequest(BasePullRequest):
 
         return self._source_project
 
+    @property
+    def closed_by(self) -> Optional[str]:
+        closed_by = self._raw_pr["closed_by"]
+        return closed_by["name"] if closed_by else None
+
     def __str__(self) -> str:
         return "Pagure" + super().__str__()
 

--- a/tests/integration/pagure/test_pull_requests.py
+++ b/tests/integration/pagure/test_pull_requests.py
@@ -36,6 +36,7 @@ class PullRequests(PagureTests):
         assert pr.target_branch == "master"
         assert pr.source_branch == "master"
         assert pr.status == PRStatus.open
+        assert pr.closed_by is None
 
     def test_pr_list(self):
         pr_list_default = self.ogr_project.get_pr_list()
@@ -59,6 +60,7 @@ class PullRequests(PagureTests):
             == "https://pagure.io/ogr-tests/pull-request/5#request_diff"
         )
         assert pr_info.head_commit == "517121273b142293807606dbd7a2e0f514b21cc8"
+        assert pr_info.closed_by == "mfocko"
 
     def test_set_pr_flag(self):
         # https://pagure.io/ogr-tests/pull-request/6


### PR DESCRIPTION

RELEASE NOTES BEGIN
We have implemented the `closed_by` property for the Pagure pull request for getting the login of the account that closed the pull request.
RELEASE NOTES END
