### PR TITLE
Enforce strict Optional typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: v0.961
     hooks:
       - id: mypy
-        args: [--no-strict-optional, --ignore-missing-imports]
+        args: [--ignore-missing-imports]
         additional_dependencies:
           [types-pkg_resources, types-requests, types-Deprecated]
   - repo: https://github.com/packit/pre-commit-hooks

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ check:
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 pytest --verbose --showlocals $(TEST_TARGET)
 
 check-in-container:
-	podman run --rm -it -v $(CURDIR):/src:Z -w /src --env TEST_TARGET $(OGR_IMAGE) make -e GITHUB_TOKEN=$(GITHUB_TOKEN) GITLAB_TOKEN=$(GITLAB_TOKEN) check
+	podman run --rm -it -v $(CURDIR):/src:Z -w /src --env TEST_TARGET $(OGR_IMAGE) \
+		make -e GITHUB_TOKEN=$(GITHUB_TOKEN) GITLAB_TOKEN=$(GITLAB_TOKEN) \
+			    PAGURE_TOKEN=$(PAGURE_TOKEN) PAGURE_OGR_TEST_TOKEN=$(PAGURE_OGR_TEST_TOKEN) check
 
 shell:
 	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(OGR_IMAGE) bash

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -217,7 +217,7 @@ class Comment(OgrAbstractClass):
         self._body = new_body
 
     @property
-    def id(self) -> int:
+    def id(self) -> Optional[int]:
         return self._id
 
     @property
@@ -226,12 +226,12 @@ class Comment(OgrAbstractClass):
         return self._author
 
     @property
-    def created(self) -> datetime.datetime:
+    def created(self) -> Optional[datetime.datetime]:
         """Datetime of creation of the comment."""
         return self._created
 
     @property
-    def edited(self) -> datetime.datetime:
+    def edited(self) -> Optional[datetime.datetime]:
         """Datetime of last edit of the comment."""
         return self._edited
 
@@ -256,7 +256,7 @@ class Comment(OgrAbstractClass):
 
 class IssueComment(Comment):
     @property
-    def issue(self) -> "Issue":
+    def issue(self) -> Optional["Issue"]:
         """Issue of issue comment."""
         return self._parent
 
@@ -266,7 +266,7 @@ class IssueComment(Comment):
 
 class PRComment(Comment):
     @property
-    def pull_request(self) -> "PullRequest":
+    def pull_request(self) -> Optional["PullRequest"]:
         """Pull request of pull request comment."""
         return self._parent
 
@@ -642,12 +642,12 @@ class PullRequest(OgrAbstractClass):
         raise NotImplementedError()
 
     @property
-    def target_branch_head_commit(self) -> str:
+    def target_branch_head_commit(self) -> Optional[str]:
         """Commit hash of the HEAD commit of the target branch."""
         raise NotImplementedError()
 
     @property
-    def merge_commit_sha(self) -> str:
+    def merge_commit_sha(self) -> Optional[str]:
         """
         Commit hash of the merge commit of the pull request.
 
@@ -1009,12 +1009,12 @@ class CommitFlag(OgrAbstractClass):
         raise NotImplementedError()
 
     @property
-    def created(self) -> datetime.datetime:
+    def created(self) -> Optional[datetime.datetime]:
         """Datetime of creating the commit status."""
         raise NotImplementedError()
 
     @property
-    def edited(self) -> datetime.datetime:
+    def edited(self) -> Optional[datetime.datetime]:
         """Datetime of editing the commit status."""
         raise NotImplementedError()
 
@@ -1230,7 +1230,7 @@ class GitService(OgrAbstractClass):
         instance_url (str): URL of the git forge instance.
     """
 
-    instance_url: Optional[str] = None
+    instance_url: str
 
     def __init__(self, **_: Any) -> None:
         pass
@@ -1326,7 +1326,9 @@ class GitService(OgrAbstractClass):
 
 
 class GitProject(OgrAbstractClass):
-    def __init__(self, repo: str, service: GitService, namespace: str) -> None:
+    def __init__(
+        self, repo: str, service: GitService, namespace: Optional[str]
+    ) -> None:
         """
         Args:
             repo: Name of the project.
@@ -1335,7 +1337,7 @@ class GitProject(OgrAbstractClass):
 
                 - GitHub: username or org name.
                 - GitLab: username or org name.
-                - Pagure: namespace (e.g. `"rpms"`).
+                - Pagure: namespace (e.g. `"rpms"`). May be none.
 
                   In case of forks: `"fork/{username}/{namespace}"`.
         """
@@ -1916,7 +1918,7 @@ class GitUser(OgrAbstractClass):
         """
         raise NotImplementedError()
 
-    def get_email(self) -> str:
+    def get_email(self) -> Optional[str]:
         """
         Returns:
             Email of the user.

--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -1009,7 +1009,7 @@ class CommitFlag(OgrAbstractClass):
         raise NotImplementedError()
 
     @property
-    def created(self) -> Optional[datetime.datetime]:
+    def created(self) -> datetime.datetime:
         """Datetime of creating the commit status."""
         raise NotImplementedError()
 
@@ -1112,7 +1112,11 @@ class Release(OgrAbstractClass):
 
     @property
     def git_tag(self) -> GitTag:
-        """Object that represents tag tied to the release."""
+        """Object that represents tag tied to the release.
+
+        Raises:
+            OgrException, if the tag is not found.
+        """
         raise NotImplementedError()
 
     @property
@@ -1337,7 +1341,7 @@ class GitProject(OgrAbstractClass):
 
                 - GitHub: username or org name.
                 - GitLab: username or org name.
-                - Pagure: namespace (e.g. `"rpms"`). May be none.
+                - Pagure: namespace (e.g. `"rpms"`). May be `None`, i.e. no namespace present.
 
                   In case of forks: `"fork/{username}/{namespace}"`.
         """

--- a/ogr/factory.py
+++ b/ogr/factory.py
@@ -80,6 +80,11 @@ def get_project(
 
     Returns:
         `GitProject` using the matching implementation.
+
+    Raises:
+        OgrException, if the url failed to be parsed or no matching
+            project type was found.
+
     """
     mapping = service_mapping_update.copy() if service_mapping_update else {}
     custom_instances = custom_instances or []
@@ -88,6 +93,8 @@ def get_project(
 
     kls = get_service_class(url=url, service_mapping_update=mapping)
     parsed_repo_url = parse_git_repo(url)
+    if not parsed_repo_url:
+        raise OgrException(f"Failed to parse url '{url}', invalid format.")
 
     service = None
     if custom_instances:
@@ -131,8 +138,11 @@ def get_service_class_or_none(
         mapping.update(service_mapping_update)
 
     parsed_url = parse_git_repo(url)
+    if not parsed_url:
+        return None
+
     for service, service_kls in mapping.items():
-        if service in parsed_url.hostname:
+        if parsed_url.hostname and service in parsed_url.hostname:
             return service_kls
 
     return None

--- a/ogr/parsing.py
+++ b/ogr/parsing.py
@@ -10,7 +10,7 @@ class RepoUrl:
     Class that represents repo URL.
 
     Attributes:
-        repo (str): Name of the repository.
+        repo (Optional[str]): Name of the repository. Can be None if parsing is being done.
         namespace (Optional[str]): Namespace of the repository, if has any.
         username (Optional[str]): Username of the repository owner, if can be
             specified.
@@ -22,7 +22,7 @@ class RepoUrl:
 
     def __init__(
         self,
-        repo: str,
+        repo: Optional[str],
         namespace: Optional[str] = None,
         username: Optional[str] = None,
         is_fork: bool = False,

--- a/ogr/parsing.py
+++ b/ogr/parsing.py
@@ -10,14 +10,14 @@ class RepoUrl:
     Class that represents repo URL.
 
     Attributes:
-        repo (Optional[str]): Name of the repository. Can be None if parsing is being done.
-        namespace (Optional[str]): Namespace of the repository, if has any.
-        username (Optional[str]): Username of the repository owner, if can be
+        repo: Name of the repository. Can be `None` if parsing is being done.
+        namespace: Namespace of the repository, if has any.
+        username: Username of the repository owner, if can be
             specified.
-        is_fork (bool): Flag denoting if repository is a fork, if can be
+        is_fork: Flag denoting if repository is a fork, if can be
             specified (Pagure).
-        hostname (Optional[str]): Hostname of host of the repository.
-        scheme (Optional[str]): Protocol used to access repository.
+        hostname: Hostname of host of the repository.
+        scheme: Protocol used to access repository.
     """
 
     def __init__(

--- a/ogr/services/base.py
+++ b/ogr/services/base.py
@@ -49,7 +49,7 @@ class BaseGitProject(GitProject):
 
 class BasePullRequest(PullRequest):
     @property
-    def target_branch_head_commit(self) -> str:
+    def target_branch_head_commit(self) -> Optional[str]:
         return self.target_project.get_sha_from_branch(self.target_branch)
 
     def get_comments(

--- a/ogr/services/github/auth_providers/abstract.py
+++ b/ogr/services/github/auth_providers/abstract.py
@@ -11,7 +11,7 @@ class GithubAuthentication:
     Represents a token manager for authentication via GitHub App.
     """
 
-    def get_token(self, namespace: str, repo: str) -> str:
+    def get_token(self, namespace: str, repo: str) -> Optional[str]:
         """
         Get a GitHub token for requested repository.
 
@@ -20,7 +20,8 @@ class GithubAuthentication:
             repo: Name of the repository.
 
         Returns:
-            A token that can be used in PyGithub instance for authentication.
+            A token that can be used in PyGithub instance for authentication if it
+            can be obtained, None otherwise.
         """
         raise NotImplementedError()
 

--- a/ogr/services/github/auth_providers/github_app.py
+++ b/ogr/services/github/auth_providers/github_app.py
@@ -11,7 +11,9 @@ from ogr.exceptions import OgrException
 
 
 class GithubApp(GithubAuthentication):
-    def __init__(self, id: str, private_key: str, private_key_path: str) -> None:
+    def __init__(
+        self, id: str, private_key: Optional[str], private_key_path: Optional[str]
+    ) -> None:
         self.id = id
         self._private_key = private_key
         self._private_key_path = private_key_path
@@ -45,7 +47,7 @@ class GithubApp(GithubAuthentication):
         return f"GithubApp({censored_id}{censored_private_key}{private_key_path})"
 
     @property
-    def private_key(self) -> str:
+    def private_key(self) -> Optional[str]:
         if self._private_key:
             return self._private_key
 
@@ -71,7 +73,7 @@ class GithubApp(GithubAuthentication):
             self._integration = github.GithubIntegration(self.id, self.private_key)
         return self._integration
 
-    def get_token(self, namespace: str, repo: str) -> str:
+    def get_token(self, namespace: str, repo: str) -> Optional[str]:
         if not self.private_key:
             return None
 

--- a/ogr/services/github/auth_providers/token.py
+++ b/ogr/services/github/auth_providers/token.py
@@ -10,7 +10,9 @@ from ogr.services.github.auth_providers.abstract import GithubAuthentication
 
 
 class TokenAuthentication(GithubAuthentication):
-    def __init__(self, token: str, max_retries: Union[int, Retry] = 0, **_) -> None:
+    def __init__(
+        self, token: Optional[str], max_retries: Union[int, Retry] = 0, **_
+    ) -> None:
         self._token = token
         self._pygithub_instance = github.Github(login_or_token=token, retry=max_retries)
 
@@ -29,11 +31,11 @@ class TokenAuthentication(GithubAuthentication):
     def pygithub_instance(self) -> github.Github:
         return self._pygithub_instance
 
-    def get_token(self, namespace: str, repo: str) -> str:
+    def get_token(self, namespace: str, repo: str) -> Optional[str]:
         return self._token
 
     @staticmethod
     def try_create(
-        token: str = None, max_retries: Union[int, Retry] = 0, **_
+        token: Optional[str] = None, max_retries: Union[int, Retry] = 0, **_
     ) -> Optional["TokenAuthentication"]:
         return TokenAuthentication(token, max_retries=max_retries)

--- a/ogr/services/github/flag.py
+++ b/ogr/services/github/flag.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import datetime
-from typing import List
+from typing import List, Optional
 
 from github import UnknownObjectException
 
@@ -64,9 +64,13 @@ class GithubCommitFlag(BaseCommitFlag):
         return GithubCommitFlag(project=project, raw_commit_flag=status, commit=commit)
 
     @property
-    def created(self) -> datetime.datetime:
-        return self._raw_commit_flag.created_at
+    def created(self) -> Optional[datetime.datetime]:
+        if self._raw_commit_flag:
+            return self._raw_commit_flag.created_at
+        return None
 
     @property
-    def edited(self) -> datetime.datetime:
-        return self._raw_commit_flag.updated_at
+    def edited(self) -> Optional[datetime.datetime]:
+        if self._raw_commit_flag:
+            return self._raw_commit_flag.updated_at
+        return None

--- a/ogr/services/github/flag.py
+++ b/ogr/services/github/flag.py
@@ -9,6 +9,7 @@ from github import UnknownObjectException
 from ogr.abstract import CommitFlag, CommitStatus
 from ogr.services import github as ogr_github
 from ogr.services.base import BaseCommitFlag
+from ogr.exceptions import OgrException
 
 
 class GithubCommitFlag(BaseCommitFlag):
@@ -64,10 +65,10 @@ class GithubCommitFlag(BaseCommitFlag):
         return GithubCommitFlag(project=project, raw_commit_flag=status, commit=commit)
 
     @property
-    def created(self) -> Optional[datetime.datetime]:
-        if self._raw_commit_flag:
-            return self._raw_commit_flag.created_at
-        return None
+    def created(self) -> datetime.datetime:
+        if not self._raw_commit_flag:
+            raise OgrException("Raw commit flag not set, this should not happen.")
+        return self._raw_commit_flag.created_at
 
     @property
     def edited(self) -> Optional[datetime.datetime]:

--- a/ogr/services/github/issue.py
+++ b/ogr/services/github/issue.py
@@ -86,7 +86,7 @@ class GithubIssue(BaseIssue):
         body: str,
         private: Optional[bool] = None,
         labels: Optional[List[str]] = None,
-        assignees: Optional[list] = None,
+        assignees: Optional[List[str]] = None,
     ) -> "Issue":
         if private:
             raise OperationNotSupported("Private issues are not supported by Github")

--- a/ogr/services/github/release.py
+++ b/ogr/services/github/release.py
@@ -7,7 +7,7 @@ from github import GithubException
 from github.GitRelease import GitRelease as PyGithubRelease
 
 from ogr.abstract import Release, GitTag
-from ogr.exceptions import GithubAPIException
+from ogr.exceptions import GithubAPIException, OgrException
 from ogr.services import github as ogr_github
 
 
@@ -45,7 +45,10 @@ class GithubRelease(Release):
 
     @property
     def git_tag(self) -> GitTag:
-        return self.project.get_tag_from_tag_name(self.tag_name)
+        tag = self.project.get_tag_from_tag_name(self.tag_name)
+        if not tag:
+            raise OgrException(f"No tag with name '{self.tag_name}' found.")
+        return tag
 
     @property
     def tag_name(self) -> str:

--- a/ogr/services/github/service.py
+++ b/ogr/services/github/service.py
@@ -183,7 +183,9 @@ class GithubService(BaseGitService):
         )
 
     def get_pygithub_instance(self, namespace: str, repo: str) -> PyGithubInstance:
-        token = self.authentication.get_token(namespace, repo)
+        token = None
+        if self.authentication:
+            token = self.authentication.get_token(namespace, repo)
         return PyGithubInstance(login_or_token=token, retry=self._max_retries)
 
     def list_projects(

--- a/ogr/services/gitlab/flag.py
+++ b/ogr/services/gitlab/flag.py
@@ -3,12 +3,12 @@
 
 import logging
 import datetime
-from typing import List, Optional
+from typing import List
 
 import gitlab
 
 from ogr.abstract import CommitFlag, CommitStatus
-from ogr.exceptions import GitlabAPIException, OperationNotSupported
+from ogr.exceptions import GitlabAPIException, OperationNotSupported, OgrException
 from ogr.services import gitlab as ogr_gitlab
 from ogr.services.base import BaseCommitFlag
 
@@ -93,13 +93,12 @@ class GitlabCommitFlag(BaseCommitFlag):
         return GitlabCommitFlag(raw_commit_flag=raw_status, project=project)
 
     @property
-    def created(self) -> Optional[datetime.datetime]:
-        return (
-            datetime.datetime.strptime(
-                self._raw_commit_flag.created_at, "%Y-%m-%dT%H:%M:%S.%fZ"
-            )
-            if self._raw_commit_flag
-            else None
+    def created(self) -> datetime.datetime:
+        if not self._raw_commit_flag:
+            raise OgrException("Raw commit flag not set, this should not happen.")
+
+        return datetime.datetime.strptime(
+            self._raw_commit_flag.created_at, "%Y-%m-%dT%H:%M:%S.%fZ"
         )
 
     @property

--- a/ogr/services/gitlab/flag.py
+++ b/ogr/services/gitlab/flag.py
@@ -3,7 +3,7 @@
 
 import logging
 import datetime
-from typing import List
+from typing import List, Optional
 
 import gitlab
 
@@ -93,9 +93,13 @@ class GitlabCommitFlag(BaseCommitFlag):
         return GitlabCommitFlag(raw_commit_flag=raw_status, project=project)
 
     @property
-    def created(self) -> datetime.datetime:
-        return datetime.datetime.strptime(
-            self._raw_commit_flag.created_at, "%Y-%m-%dT%H:%M:%S.%fZ"
+    def created(self) -> Optional[datetime.datetime]:
+        return (
+            datetime.datetime.strptime(
+                self._raw_commit_flag.created_at, "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
+            if self._raw_commit_flag
+            else None
         )
 
     @property

--- a/ogr/services/gitlab/issue.py
+++ b/ogr/services/gitlab/issue.py
@@ -47,7 +47,7 @@ class GitlabIssue(BaseIssue):
         return self._raw_issue.web_url
 
     @property
-    def assignees(self) -> list:
+    def assignees(self) -> Optional[list]:
         try:
             return self._raw_issue.assignees
         except AttributeError:

--- a/ogr/services/gitlab/issue.py
+++ b/ogr/services/gitlab/issue.py
@@ -47,7 +47,7 @@ class GitlabIssue(BaseIssue):
         return self._raw_issue.web_url
 
     @property
-    def assignees(self) -> Optional[list]:
+    def assignees(self) -> Optional[List[str]]:
         try:
             return self._raw_issue.assignees
         except AttributeError:

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -75,8 +75,8 @@ class GitlabProject(BaseGitProject):
         return None
 
     @property
-    def default_branch(self) -> Optional[str]:
-        return self.gitlab_repo.attributes.get("default_branch")
+    def default_branch(self) -> str:
+        return self.gitlab_repo.attributes["default_branch"]
 
     def __str__(self) -> str:
         return f'GitlabProject(namespace="{self.namespace}", repo="{self.repo}")'

--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -20,7 +20,7 @@ from ogr.services.gitlab.comments import GitlabPRComment
 class GitlabPullRequest(BasePullRequest):
     _raw_pr: _GitlabMergeRequest
     _target_project: "ogr_gitlab.GitlabProject"
-    _source_project: "ogr_gitlab.GitlabProject" = None
+    _source_project: Optional["ogr_gitlab.GitlabProject"] = None
     _merge_commit_status: Dict[str, MergeCommitStatus] = {
         "can_be_merged": MergeCommitStatus.can_be_merged,
         "cannot_be_merged": MergeCommitStatus.cannot_be_merged,
@@ -171,7 +171,7 @@ class GitlabPullRequest(BasePullRequest):
         target_id = None
 
         target_project = project
-        if project.is_fork and fork_username is None:
+        if project.parent and project.is_fork and fork_username is None:
             # handles fork -> upstream (called on fork)
             target_id = project.parent.gitlab_repo.attributes["id"]
             target_project = project.parent

--- a/ogr/services/gitlab/service.py
+++ b/ogr/services/gitlab/service.py
@@ -104,6 +104,8 @@ class GitlabService(BaseGitService):
             except gitlab.GitlabGetError as ex:
                 raise GitlabAPIException(f"Group {namespace} not found.") from ex
             data["namespace_id"] = group.id
+        else:
+            namespace = self.user.get_username()
 
         if description:
             data["description"] = description

--- a/ogr/services/pagure/flag.py
+++ b/ogr/services/pagure/flag.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import datetime
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 
 from ogr.abstract import CommitFlag, CommitStatus
@@ -73,13 +73,17 @@ class PagureCommitFlag(BaseCommitFlag):
         )
 
     @property
-    def created(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(
-            int(self._raw_commit_flag["date_created"])
+    def created(self) -> Optional[datetime.datetime]:
+        return (
+            datetime.datetime.fromtimestamp(int(self._raw_commit_flag["date_created"]))
+            if self._raw_commit_flag
+            else None
         )
 
     @property
-    def edited(self) -> datetime.datetime:
-        return datetime.datetime.fromtimestamp(
-            int(self._raw_commit_flag["date_updated"])
+    def edited(self) -> Optional[datetime.datetime]:
+        return (
+            datetime.datetime.fromtimestamp(int(self._raw_commit_flag["date_updated"]))
+            if self._raw_commit_flag
+            else None
         )

--- a/ogr/services/pagure/flag.py
+++ b/ogr/services/pagure/flag.py
@@ -8,6 +8,7 @@ from typing import List, Dict, Any, Optional
 from ogr.abstract import CommitFlag, CommitStatus
 from ogr.services import pagure as ogr_pagure
 from ogr.services.base import BaseCommitFlag
+from ogr.exceptions import OgrException
 
 
 class PagureCommitFlag(BaseCommitFlag):
@@ -73,11 +74,11 @@ class PagureCommitFlag(BaseCommitFlag):
         )
 
     @property
-    def created(self) -> Optional[datetime.datetime]:
-        return (
-            datetime.datetime.fromtimestamp(int(self._raw_commit_flag["date_created"]))
-            if self._raw_commit_flag
-            else None
+    def created(self) -> datetime.datetime:
+        if not self._raw_commit_flag:
+            raise OgrException("Raw commit flag not set, this should not happen.")
+        return datetime.datetime.fromtimestamp(
+            int(self._raw_commit_flag["date_created"])
         )
 
     @property

--- a/ogr/services/pagure/issue.py
+++ b/ogr/services/pagure/issue.py
@@ -57,7 +57,7 @@ class PagureIssue(BaseIssue):
         )
 
     @property
-    def assignee(self) -> str:
+    def assignee(self) -> Optional[str]:
         self.__update()
         try:
             return self._raw_issue["assignee"]["name"]

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -338,7 +338,7 @@ class PagureProject(BaseGitProject):
 
     def is_forked(self) -> bool:
         f = self._construct_fork_project()
-        return bool(f.exists() and f.parent.exists())
+        return bool(f.exists() and f.parent and f.parent.exists())
 
     def get_is_fork_from_api(self) -> bool:
         return bool(self.get_project_info()["parent"])

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class PagurePullRequest(BasePullRequest):
     _target_project: "ogr_pagure.PagureProject"
-    _source_project: "ogr_pagure.PagureProject" = None
+    _source_project: Optional["ogr_pagure.PagureProject"] = None
 
     def __init__(self, raw_pr, project):
         super().__init__(raw_pr, project)
@@ -150,10 +150,11 @@ class PagurePullRequest(BasePullRequest):
         }
 
         caller = project
-        if project.is_fork:
+        if project.is_fork and caller.parent:
             data["repo_from"] = project.repo
             data["repo_from_username"] = project._user
-            data["repo_from_namespace"] = project.namespace
+            if project.namespace:
+                data["repo_from_namespace"] = project.namespace
 
             # running the call from the parent project
             caller = caller.parent
@@ -166,7 +167,8 @@ class PagurePullRequest(BasePullRequest):
             )
             data["repo_from_username"] = fork_username
             data["repo_from"] = fork_project.repo
-            data["repo_from_namespace"] = fork_project.namespace
+            if fork_project.namespace:
+                data["repo_from_namespace"] = fork_project.namespace
 
         response = caller._call_project_api(
             "pull-request", "new", method="POST", data=data

--- a/ogr/services/pagure/release.py
+++ b/ogr/services/pagure/release.py
@@ -71,8 +71,12 @@ class PagureRelease(Release):
         message: str,
         ref: Optional[str] = None,
     ) -> "Release":
+        """
+        Raises:
+            ValueError, if ref is not specified.
+        """
         if not ref:
-            raise PagureAPIException("Release ref must be specified")
+            raise ValueError("Release ref must be specified")
         payload = {
             "tagname": tag,
             "commit_hash": ref,

--- a/ogr/services/pagure/release.py
+++ b/ogr/services/pagure/release.py
@@ -35,7 +35,7 @@ class PagureRelease(Release):
 
     @property
     def created_at(self) -> datetime.datetime:
-        return None
+        raise OperationNotSupported("Pagure API does not provide timestamps")
 
     @property
     def tarball_url(self) -> str:
@@ -71,6 +71,8 @@ class PagureRelease(Release):
         message: str,
         ref: Optional[str] = None,
     ) -> "Release":
+        if not ref:
+            raise PagureAPIException("Release ref must be specified")
         payload = {
             "tagname": tag,
             "commit_hash": ref,

--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -332,6 +332,8 @@ class PagureService(BaseGitService):
             parameters["description"] = repo
         if namespace:
             parameters["namespace"] = namespace
+        else:
+            namespace = self.user.get_username()
 
         try:
             self.call_api(request_url, "POST", data=parameters)

--- a/tests/integration/pagure/test_data/test_pull_requests/PullRequests.test_pr_create_from_fork.yaml
+++ b/tests/integration/pagure/test_data/test_pull_requests/PullRequests.test_pr_create_from_fork.yaml
@@ -5,17 +5,30 @@ _requre:
 requests.sessions:
   send:
     GET:
-      https://pagure.io/api/0/fork/ttomecek/ogr-tests:
+      https://pagure.io/api/0/fork/fnecas/ogr-tests:
       - metadata:
-          latency: 0.32079267501831055
+          latency: 0.31185078620910645
           module_call_list:
           - unittest.case
-          - requre.online_replacing
+          - requre.record_and_replace
           - tests.integration.pagure.test_pull_requests
+          - ogr.abstract
           - ogr.read_only
-          - ogr.services.pagure.project
+          - ogr.utils
+          - ogr.abstract
           - ogr.services.pagure.pull_request
           - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
           - ogr.services.pagure.service
           - requests.sessions
           - requre.objects
@@ -35,16 +48,16 @@ requests.sessions:
               collaborator: []
               commit: []
               owner:
-              - ttomecek
+              - fnecas
               ticket: []
             close_status: []
             custom_keys: []
-            date_created: '1578319442'
-            date_modified: '1578319442'
+            date_created: '1657792363'
+            date_modified: '1657792363'
             description: Testing repository for python-ogr package.
-            full_url: https://pagure.io/fork/ttomecek/ogr-tests
-            fullname: forks/ttomecek/ogr-tests
-            id: 7254
+            full_url: https://pagure.io/fork/fnecas/ogr-tests
+            fullname: forks/fnecas/ogr-tests
+            id: 12194
             milestones: {}
             name: ogr-tests
             namespace: null
@@ -56,9 +69,11 @@ requests.sessions:
                 ticket: []
               access_users:
                 admin:
+                - jpopelka
                 - jscotka
                 - lbarczio
                 - mfocko
+                - nikromen
                 collaborator: []
                 commit: []
                 owner:
@@ -67,7 +82,7 @@ requests.sessions:
               close_status: []
               custom_keys: []
               date_created: '1570568389'
-              date_modified: '1570568529'
+              date_modified: '1651242136'
               description: Testing repository for python-ogr package.
               full_url: https://pagure.io/ogr-tests
               fullname: ogr-tests
@@ -86,27 +101,30 @@ requests.sessions:
                 url_path: user/lachmanfrantisek
             priorities: {}
             tags: []
-            url_path: fork/ttomecek/ogr-tests
+            url_path: fork/fnecas/ogr-tests
             user:
-              full_url: https://pagure.io/user/ttomecek
-              fullname: Tomas Tomecek
-              name: ttomecek
-              url_path: user/ttomecek
+              full_url: https://pagure.io/user/fnecas
+              fullname: "Franti\u0161ek Ne\u010Das"
+              name: fnecas
+              url_path: user/fnecas
           _next: null
-          elapsed: 0.2
-          encoding: null
+          elapsed: 0.311148
+          encoding: utf-8
           headers:
             Connection: Keep-Alive
-            Content-Length: '1876'
-            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
-              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
-              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Length: '1917'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-Gy68mAECE8e7LCO1cGnP1rDV1';
+              style-src 'self' 'nonce-Gy68mAECE8e7LCO1cGnP1rDV1'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
             Content-Type: application/json
-            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Date: Thu, 14 Jul 2022 12:15:05 GMT
             Keep-Alive: timeout=5, max=99
             Referrer-Policy: same-origin
-            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
               Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZjc2NDA2NzM4OThhOTEzOWM1MjJmZjZjMDg1OTY0NWYyYWY5MTk0NSJ9.FbGaSQ.3ZpI_KnJODfcCQUXw2dyExQjLVE;
+              Expires=Sun, 14-Aug-2022 12:15:05 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -115,15 +133,26 @@ requests.sessions:
           reason: OK
           status_code: 200
       - metadata:
-          latency: 0.3482825756072998
+          latency: 0.33807802200317383
           module_call_list:
           - unittest.case
-          - requre.online_replacing
+          - requre.record_and_replace
           - tests.integration.pagure.test_pull_requests
+          - ogr.abstract
           - ogr.read_only
-          - ogr.services.pagure.project
+          - ogr.utils
+          - ogr.abstract
           - ogr.services.pagure.pull_request
           - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
           - ogr.services.pagure.service
           - requests.sessions
           - requre.objects
@@ -143,16 +172,16 @@ requests.sessions:
               collaborator: []
               commit: []
               owner:
-              - ttomecek
+              - fnecas
               ticket: []
             close_status: []
             custom_keys: []
-            date_created: '1578319442'
-            date_modified: '1578319442'
+            date_created: '1657792363'
+            date_modified: '1657792363'
             description: Testing repository for python-ogr package.
-            full_url: https://pagure.io/fork/ttomecek/ogr-tests
-            fullname: forks/ttomecek/ogr-tests
-            id: 7254
+            full_url: https://pagure.io/fork/fnecas/ogr-tests
+            fullname: forks/fnecas/ogr-tests
+            id: 12194
             milestones: {}
             name: ogr-tests
             namespace: null
@@ -164,9 +193,11 @@ requests.sessions:
                 ticket: []
               access_users:
                 admin:
+                - jpopelka
                 - jscotka
                 - lbarczio
                 - mfocko
+                - nikromen
                 collaborator: []
                 commit: []
                 owner:
@@ -175,7 +206,7 @@ requests.sessions:
               close_status: []
               custom_keys: []
               date_created: '1570568389'
-              date_modified: '1570568529'
+              date_modified: '1651242136'
               description: Testing repository for python-ogr package.
               full_url: https://pagure.io/ogr-tests
               fullname: ogr-tests
@@ -194,27 +225,280 @@ requests.sessions:
                 url_path: user/lachmanfrantisek
             priorities: {}
             tags: []
-            url_path: fork/ttomecek/ogr-tests
+            url_path: fork/fnecas/ogr-tests
             user:
-              full_url: https://pagure.io/user/ttomecek
-              fullname: Tomas Tomecek
-              name: ttomecek
-              url_path: user/ttomecek
+              full_url: https://pagure.io/user/fnecas
+              fullname: "Franti\u0161ek Ne\u010Das"
+              name: fnecas
+              url_path: user/fnecas
           _next: null
-          elapsed: 0.2
-          encoding: null
+          elapsed: 0.337425
+          encoding: utf-8
           headers:
             Connection: Keep-Alive
-            Content-Length: '1876'
-            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
-              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
-              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Length: '1917'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-ayU5v3JkaABqwayKbsEQzwmwE';
+              style-src 'self' 'nonce-ayU5v3JkaABqwayKbsEQzwmwE'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
             Content-Type: application/json
-            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Date: Thu, 14 Jul 2022 12:15:06 GMT
             Keep-Alive: timeout=5, max=98
             Referrer-Policy: same-origin
-            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
               Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZjc2NDA2NzM4OThhOTEzOWM1MjJmZjZjMDg1OTY0NWYyYWY5MTk0NSJ9.FbGaSg.pfGA4qe3MCLu9bX4RMDeXdYOPu8;
+              Expires=Sun, 14-Aug-2022 12:15:06 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 13.0456223487854
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_pull_requests
+          - ogr.abstract
+          - ogr.read_only
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.pull_request
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_groups:
+              admin: []
+              collaborator: []
+              commit: []
+              ticket: []
+            access_users:
+              admin: []
+              collaborator: []
+              commit: []
+              owner:
+              - fnecas
+              ticket: []
+            close_status: []
+            custom_keys: []
+            date_created: '1657792363'
+            date_modified: '1657792363'
+            description: Testing repository for python-ogr package.
+            full_url: https://pagure.io/fork/fnecas/ogr-tests
+            fullname: forks/fnecas/ogr-tests
+            id: 12194
+            milestones: {}
+            name: ogr-tests
+            namespace: null
+            parent:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin:
+                - jpopelka
+                - jscotka
+                - lbarczio
+                - mfocko
+                - nikromen
+                collaborator: []
+                commit: []
+                owner:
+                - lachmanfrantisek
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1570568389'
+              date_modified: '1651242136'
+              description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/ogr-tests
+              fullname: ogr-tests
+              id: 6826
+              milestones: {}
+              name: ogr-tests
+              namespace: null
+              parent: null
+              priorities: {}
+              tags: []
+              url_path: ogr-tests
+              user:
+                full_url: https://pagure.io/user/lachmanfrantisek
+                fullname: "Franti\u0161ek Lachman"
+                name: lachmanfrantisek
+                url_path: user/lachmanfrantisek
+            priorities: {}
+            tags: []
+            url_path: fork/fnecas/ogr-tests
+            user:
+              full_url: https://pagure.io/user/fnecas
+              fullname: "Franti\u0161ek Ne\u010Das"
+              name: fnecas
+              url_path: user/fnecas
+          _next: null
+          elapsed: 13.044939
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '1917'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-GUOQQJXM7Kf0NbiMVGzvJGIqB';
+              style-src 'self' 'nonce-GUOQQJXM7Kf0NbiMVGzvJGIqB'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Thu, 14 Jul 2022 12:15:06 GMT
+            Keep-Alive: timeout=5, max=97
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZjc2NDA2NzM4OThhOTEzOWM1MjJmZjZjMDg1OTY0NWYyYWY5MTk0NSJ9.FbGaVw.m1NTmGBFJGP7_rNQKefNX1Be_-U;
+              Expires=Sun, 14-Aug-2022 12:15:19 GMT; Secure; HttpOnly; Path=/
+            Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: ALLOW-FROM https://pagure.io/
+            X-Xss-Protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.5162193775177002
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.pagure.test_pull_requests
+          - ogr.abstract
+          - ogr.read_only
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.pagure.pull_request
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_groups:
+              admin: []
+              collaborator: []
+              commit: []
+              ticket: []
+            access_users:
+              admin: []
+              collaborator: []
+              commit: []
+              owner:
+              - fnecas
+              ticket: []
+            close_status: []
+            custom_keys: []
+            date_created: '1657792363'
+            date_modified: '1657792363'
+            description: Testing repository for python-ogr package.
+            full_url: https://pagure.io/fork/fnecas/ogr-tests
+            fullname: forks/fnecas/ogr-tests
+            id: 12194
+            milestones: {}
+            name: ogr-tests
+            namespace: null
+            parent:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin:
+                - jpopelka
+                - jscotka
+                - lbarczio
+                - mfocko
+                - nikromen
+                collaborator: []
+                commit: []
+                owner:
+                - lachmanfrantisek
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1570568389'
+              date_modified: '1651242136'
+              description: Testing repository for python-ogr package.
+              full_url: https://pagure.io/ogr-tests
+              fullname: ogr-tests
+              id: 6826
+              milestones: {}
+              name: ogr-tests
+              namespace: null
+              parent: null
+              priorities: {}
+              tags: []
+              url_path: ogr-tests
+              user:
+                full_url: https://pagure.io/user/lachmanfrantisek
+                fullname: "Franti\u0161ek Lachman"
+                name: lachmanfrantisek
+                url_path: user/lachmanfrantisek
+            priorities: {}
+            tags: []
+            url_path: fork/fnecas/ogr-tests
+            user:
+              full_url: https://pagure.io/user/fnecas
+              fullname: "Franti\u0161ek Ne\u010Das"
+              name: fnecas
+              url_path: user/fnecas
+          _next: null
+          elapsed: 0.515658
+          encoding: utf-8
+          headers:
+            Connection: Keep-Alive
+            Content-Length: '1917'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-cmNPC19iMylZG74CyRP7B2NHM';
+              style-src 'self' 'nonce-cmNPC19iMylZG74CyRP7B2NHM'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
+            Content-Type: application/json
+            Date: Thu, 14 Jul 2022 12:15:19 GMT
+            Keep-Alive: timeout=5, max=96
+            Referrer-Policy: same-origin
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
+              Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZjc2NDA2NzM4OThhOTEzOWM1MjJmZjZjMDg1OTY0NWYyYWY5MTk0NSJ9.FbGaVw.m1NTmGBFJGP7_rNQKefNX1Be_-U;
+              Expires=Sun, 14-Aug-2022 12:15:19 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -225,13 +509,19 @@ requests.sessions:
     POST:
       https://pagure.io/api/0/-/whoami:
       - metadata:
-          latency: 0.6586136817932129
+          latency: 0.7824890613555908
           module_call_list:
           - unittest.case
-          - requre.online_replacing
+          - requre.record_and_replace
           - tests.integration.pagure.test_pull_requests
           - tests.integration.pagure.base
+          - ogr.abstract
           - ogr.services.pagure.user
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
           - ogr.services.pagure.service
           - requests.sessions
           - requre.objects
@@ -241,22 +531,25 @@ requests.sessions:
         output:
           __store_indicator: 2
           _content:
-            username: ttomecek
+            username: fnecas
           _next: null
-          elapsed: 0.2
-          encoding: null
+          elapsed: 0.78182
+          encoding: utf-8
           headers:
             Connection: Keep-Alive
-            Content-Length: '29'
-            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
-              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
-              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Length: '27'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-4ybKhcJELnV999F9nmadNdP3C';
+              style-src 'self' 'nonce-4ybKhcJELnV999F9nmadNdP3C'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
             Content-Type: application/json
-            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Date: Thu, 14 Jul 2022 12:15:05 GMT
             Keep-Alive: timeout=5, max=100
             Referrer-Policy: same-origin
-            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
               Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZjc2NDA2NzM4OThhOTEzOWM1MjJmZjZjMDg1OTY0NWYyYWY5MTk0NSJ9.FbGaSQ.3ZpI_KnJODfcCQUXw2dyExQjLVE;
+              Expires=Sun, 14-Aug-2022 12:15:05 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/
@@ -266,15 +559,23 @@ requests.sessions:
           status_code: 200
       https://pagure.io/api/0/ogr-tests/pull-request/new:
       - metadata:
-          latency: 0.6659791469573975
+          latency: 1.055509090423584
           module_call_list:
           - unittest.case
-          - requre.online_replacing
+          - requre.record_and_replace
           - tests.integration.pagure.test_pull_requests
+          - ogr.abstract
           - ogr.read_only
-          - ogr.services.pagure.project
+          - ogr.utils
+          - ogr.abstract
           - ogr.services.pagure.pull_request
+          - ogr.abstract
           - ogr.services.pagure.project
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
+          - ogr.services.pagure.service
+          - ogr.abstract
           - ogr.services.pagure.service
           - requests.sessions
           - requre.objects
@@ -293,11 +594,11 @@ requests.sessions:
             comments: []
             commit_start: null
             commit_stop: null
-            date_created: '1615384140'
-            full_url: https://pagure.io/ogr-tests/pull-request/12
-            id: 12
+            date_created: '1657800920'
+            full_url: https://pagure.io/ogr-tests/pull-request/21
+            id: 21
             initial_comment: Body of the testing PR.
-            last_updated: '1615384140'
+            last_updated: '1657800920'
             project:
               access_groups:
                 admin: []
@@ -306,9 +607,11 @@ requests.sessions:
                 ticket: []
               access_users:
                 admin:
+                - jpopelka
                 - jscotka
                 - lbarczio
                 - mfocko
+                - nikromen
                 collaborator: []
                 commit: []
                 owner:
@@ -317,7 +620,7 @@ requests.sessions:
               close_status: []
               custom_keys: []
               date_created: '1570568389'
-              date_modified: '1570568529'
+              date_modified: '1651242136'
               description: Testing repository for python-ogr package.
               full_url: https://pagure.io/ogr-tests
               fullname: ogr-tests
@@ -346,16 +649,16 @@ requests.sessions:
                 collaborator: []
                 commit: []
                 owner:
-                - ttomecek
+                - fnecas
                 ticket: []
               close_status: []
               custom_keys: []
-              date_created: '1578319442'
-              date_modified: '1578319442'
+              date_created: '1657792363'
+              date_modified: '1657792363'
               description: Testing repository for python-ogr package.
-              full_url: https://pagure.io/fork/ttomecek/ogr-tests
-              fullname: forks/ttomecek/ogr-tests
-              id: 7254
+              full_url: https://pagure.io/fork/fnecas/ogr-tests
+              fullname: forks/fnecas/ogr-tests
+              id: 12194
               milestones: {}
               name: ogr-tests
               namespace: null
@@ -367,9 +670,11 @@ requests.sessions:
                   ticket: []
                 access_users:
                   admin:
+                  - jpopelka
                   - jscotka
                   - lbarczio
                   - mfocko
+                  - nikromen
                   collaborator: []
                   commit: []
                   owner:
@@ -378,7 +683,7 @@ requests.sessions:
                 close_status: []
                 custom_keys: []
                 date_created: '1570568389'
-                date_modified: '1570568529'
+                date_modified: '1651242136'
                 description: Testing repository for python-ogr package.
                 full_url: https://pagure.io/ogr-tests
                 fullname: ogr-tests
@@ -397,38 +702,41 @@ requests.sessions:
                   url_path: user/lachmanfrantisek
               priorities: {}
               tags: []
-              url_path: fork/ttomecek/ogr-tests
+              url_path: fork/fnecas/ogr-tests
               user:
-                full_url: https://pagure.io/user/ttomecek
-                fullname: Tomas Tomecek
-                name: ttomecek
-                url_path: user/ttomecek
+                full_url: https://pagure.io/user/fnecas
+                fullname: "Franti\u0161ek Ne\u010Das"
+                name: fnecas
+                url_path: user/fnecas
             status: Open
             tags: []
             threshold_reached: null
             title: Testing PR
-            uid: 69ac8585242a44cdac9e200cada7e9c3
-            updated_on: '1615384140'
+            uid: 627b92c9cee8459eaae6a75e5377d9b2
+            updated_on: '1657800920'
             user:
-              full_url: https://pagure.io/user/ttomecek
-              fullname: Tomas Tomecek
-              name: ttomecek
-              url_path: user/ttomecek
+              full_url: https://pagure.io/user/fnecas
+              fullname: "Franti\u0161ek Ne\u010Das"
+              name: fnecas
+              url_path: user/fnecas
           _next: null
-          elapsed: 0.2
-          encoding: null
+          elapsed: 1.054946
+          encoding: utf-8
           headers:
             Connection: Keep-Alive
-            Content-Length: '3839'
-            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
-              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
-              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Length: '3932'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-DtT5iDYDUQpymzI60yot8p7vv';
+              style-src 'self' 'nonce-DtT5iDYDUQpymzI60yot8p7vv'; object-src 'none';base-uri
+              'self';img-src 'self' https:;connect-src 'self' https://pagure.io:8088;frame-src
+              https://docs.pagure.org;frame-ancestors https://pagure.io;
             Content-Type: application/json
-            Date: Fri, 01 Nov 2019 13-36-03 GMT
-            Keep-Alive: timeout=5, max=97
+            Date: Thu, 14 Jul 2022 12:15:20 GMT
+            Keep-Alive: timeout=5, max=95
             Referrer-Policy: same-origin
-            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1g mod_wsgi/4.6.4
+            Server: Apache/2.4.37 (Red Hat Enterprise Linux) OpenSSL/1.1.1k mod_wsgi/4.6.4
               Python/3.6
+            Set-Cookie: pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiZjc2NDA2NzM4OThhOTEzOWM1MjJmZjZjMDg1OTY0NWYyYWY5MTk0NSJ9.FbGaWA.x_e7UP7xGwI6gShZYnk2-uTnTBs;
+              Expires=Sun, 14-Aug-2022 12:15:20 GMT; Secure; HttpOnly; Path=/
             Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
             X-Content-Type-Options: nosniff
             X-Frame-Options: ALLOW-FROM https://pagure.io/


### PR DESCRIPTION
Some of these fixes are not perfect, in a few places I added `Optional` where I feel it shouldn't really be. However, it's not really possible any other way without significant refactoring which would break the API (which I don't want to do). Sometimes a specific forge may return `None` so it was necessary to update the type of the abstract class.

I tried to not make any functional changes, most of these are just to align the typing with the actual implementation.

TODO:

- [ ] regenerate some requre responses (the failing tests). I may need some help with this, I managed to do this for one of the failing tests but not for the repo creation yet.

Fixes #696 

Related to #251 

Merge before/after
