### PR TITLE
fix(tests): add missing GitLab response

### DIFF
--- a/tests/integration/gitlab/test_data/test_issues/Issues.test_issue_list_labels.yaml
+++ b/tests/integration/gitlab/test_data/test_issues/Issues.test_issue_list_labels.yaml
@@ -815,6 +815,891 @@ requests.sessions:
             raw: !!binary ""
             reason: OK
             status_code: 200
+      ? https://gitlab.com/api/v4/projects/14233409/issues?id=14233409&labels%5B%5D=testing-label-for-test-issue-list-labels&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false&labels=testing-label-for-test-issue-list-labels
+      : - metadata:
+            latency: 0.46969151496887207
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_issues
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.issue
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/39/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/39/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/39
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:17:10.798Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer:
+
+
+                Description for issue abc'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330874
+              iid: 39
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#39
+                relative: '#39'
+                short: '#39'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 14
+              type: ISSUE
+              updated_at: '2020-02-27T09:26:06.021Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/39
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/38/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/38/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/38
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:14:07.121Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer:
+
+                {repo.get_issue(id=i).description}'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330780
+              iid: 38
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#38
+                relative: '#38'
+                short: '#38'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 13
+              type: ISSUE
+              updated_at: '2020-02-27T09:26:04.029Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/38
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/37/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/37/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/37
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:13:56.029Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer:
+
+                {repo.get_issue(id=i).description}'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330772
+              iid: 37
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#37
+                relative: '#37'
+                short: '#37'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 12
+              type: ISSUE
+              updated_at: '2020-02-27T09:26:02.257Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/37
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/36/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/36/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/36
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:13:45.325Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer:
+
+                {repo.get_issue(id=i).description}'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330762
+              iid: 36
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#36
+                relative: '#36'
+                short: '#36'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 11
+              type: ISSUE
+              updated_at: '2020-02-27T09:26:00.474Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/36
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/35/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/35/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/35
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:13:34.579Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer:
+
+                {repo.get_issue(id=i).description}'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330758
+              iid: 35
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#35
+                relative: '#35'
+                short: '#35'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 10
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:58.459Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/35
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/33/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/33/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/33
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:10:46.282Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer.'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330654
+              iid: 33
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#33
+                relative: '#33'
+                short: '#33'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 8
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:54.778Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/33
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/32/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/32/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/32
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:10:40.393Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer.'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330653
+              iid: 32
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#32
+                relative: '#32'
+                short: '#32'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 7
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:51.691Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/32
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/31/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/31/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/31
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:10:34.696Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer.'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330651
+              iid: 31
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#31
+                relative: '#31'
+                short: '#31'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 6
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:49.725Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/31
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/30/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/30/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/30
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:10:28.965Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340
+
+
+                And here, we need to add some text to not be detected as a spammer.'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330649
+              iid: 30
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#30
+                relative: '#30'
+                short: '#30'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 5
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:47.329Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/30
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/28/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/28/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/28
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:07:45.866Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330544
+              iid: 28
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#28
+                relative: '#28'
+                short: '#28'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 4
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:21.823Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/28
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/27/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/27/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/27
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:07:44.358Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330543
+              iid: 27
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#27
+                relative: '#27'
+                short: '#27'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 3
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:20.077Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/27
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/26/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/26/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/26
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:07:43.521Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330541
+              iid: 26
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#26
+                relative: '#26'
+                short: '#26'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 2
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:18.397Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/26
+              weight: null
+            - _links:
+                award_emoji: https://gitlab.com/api/v4/projects/14233409/issues/25/award_emoji
+                closed_as_duplicate_of: null
+                notes: https://gitlab.com/api/v4/projects/14233409/issues/25/notes
+                project: https://gitlab.com/api/v4/projects/14233409
+                self: https://gitlab.com/api/v4/projects/14233409/issues/25
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_issues_count: 0
+              closed_at: null
+              closed_by: null
+              confidential: false
+              created_at: '2020-02-27T09:07:42.435Z'
+              description: 'We need to test project with bigger number of issues.
+
+
+                Relevant ogr PR: https://github.com/packit-service/ogr/pull/340'
+              discussion_locked: null
+              downvotes: 0
+              due_date: null
+              has_tasks: false
+              health_status: null
+              id: 31330540
+              iid: 25
+              issue_type: issue
+              labels:
+              - testing-label-for-test-issue-list-labels
+              merge_requests_count: 0
+              milestone: null
+              moved_to_id: null
+              project_id: 14233409
+              references:
+                full: packit-service/ogr-tests#25
+                relative: '#25'
+                short: '#25'
+              service_desk_reply_to: null
+              severity: UNKNOWN
+              state: opened
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: test-issue 1
+              type: ISSUE
+              updated_at: '2020-02-27T09:25:16.599Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/issues/25
+              weight: null
+            _next: null
+            elapsed: 0.467798
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: DYNAMIC
+              CF-RAY: 73e6919fad76b365-PRG
+              Cache-Control: max-age=0, private, must-revalidate
+              Connection: keep-alive
+              Content-Encoding: gzip
+              Content-Security-Policy: default-src 'none'
+              Content-Type: application/json
+              Date: Sun, 21 Aug 2022 21:47:44 GMT
+              Etag: W/"7fa5d7d7221fd865b1456b784752f8c9"
+              Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+              GitLab-LB: fe-19-lb-gprd
+              GitLab-SV: localhost
+              Link: <https://gitlab.com/api/v4/projects/14233409/issues?id=14233409&labels%5B%5D=testing-label-for-test-issue-list-labels&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/issues?id=14233409&labels%5B%5D=testing-label-for-test-issue-list-labels&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/issues?id=14233409&labels%5B%5D=testing-label-for-test-issue-list-labels&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false>;
+                rel="last"
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              RateLimit-Limit: '2000'
+              RateLimit-Observed: '63'
+              RateLimit-Remaining: '1937'
+              RateLimit-Reset: '1661118524'
+              RateLimit-ResetTime: Sun, 21 Aug 2022 21:48:44 GMT
+              Referrer-Policy: strict-origin-when-cross-origin
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=PHDVtJpv4Bh4DFhXcenqlzQcFoRw6cCfafErdZ5KVo%2BI8gS%2Fp1hgQtUMjikMiFAn2OAqPehA8nV%2Fr3Y2trQTrKdJ9gqxHfLdNTdjfuqYPgrQ86s%2BokFrGY0T2rk%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Strict-Transport-Security: max-age=31536000
+              Transfer-Encoding: chunked
+              Vary: Origin
+              X-Content-Type-Options: nosniff
+              X-Frame-Options: SAMEORIGIN
+              X-Next-Page: ''
+              X-Page: '2'
+              X-Per-Page: '20'
+              X-Prev-Page: '1'
+              X-Request-Id: 9409f8350f5714fba62da41ea1bd8d12
+              X-Runtime: '0.282518'
+              X-Total: '33'
+              X-Total-Pages: '2'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
       ? https://gitlab.com/api/v4/projects/14233409/issues?id=14233409&labels%5B%5D=testing-label-for-test-issue-list-labels&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false&state=all&order_by=updated_at&sort=desc&labels=testing-label-for-test-issue-list-labels
       : - metadata:
             latency: 0.39310669898986816


### PR DESCRIPTION
Add missing GitLab response after ‹python-gitlab› release.

Fixes #726

Signed-off-by: Matej Focko <mfocko@redhat.com>