### PR TITLE
Provide a GitHub token for the prepare-release action

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           version: ${{ inputs.version }}
           specfiles: fedora/python-ogr.spec
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
This is needed to read PR descriptions without hitting rate limits.