### PR TITLE
Drop support for EPEL 8 and Python < 3.9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,20 +34,17 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-all
-      - epel-8
       - epel-9
 
   - job: copr_build
     trigger: pull_request
     targets:
       - fedora-all
-      - epel-8
       - epel-9
   - job: tests
     trigger: pull_request
     targets:
       - fedora-all
-      - epel-8
       - epel-9
 
   - job: production_build
@@ -61,7 +58,6 @@ jobs:
     branch: main
     targets:
       - fedora-all
-      - epel-8
       - epel-9
     project: packit-dev
     list_on_homepage: True
@@ -72,7 +68,6 @@ jobs:
     branch: stable
     targets:
       - fedora-stable
-      - epel-8
       - epel-9
     project: packit-stable
     list_on_homepage: True
@@ -82,7 +77,6 @@ jobs:
     trigger: release
     targets:
       - fedora-all
-      - epel-8
       - epel-9
     project: packit-releases
     list_on_homepage: True
@@ -95,7 +89,6 @@ jobs:
     allowed_pr_authors: ["packit-stg", "packit"]
     dist_git_branches:
       - fedora-all
-      - epel-8
       - epel-9
   - job: bodhi_update
     trigger: commit
@@ -103,5 +96,4 @@ jobs:
     dist_git_branches:
       - fedora-latest # branched version, rawhide updates are created automatically
       - fedora-stable
-      - epel-8
       - epel-9

--- a/ogr/__init__.py
+++ b/ogr/__init__.py
@@ -5,6 +5,8 @@
 Module providing one api for multiple git services (github/gitlab/pagure)
 """
 
+from importlib.metadata import PackageNotFoundError, distribution
+
 from ogr.factory import (
     get_project,
     get_service_class,
@@ -14,12 +16,6 @@ from ogr.factory import (
 from ogr.services.github import GithubService
 from ogr.services.gitlab import GitlabService
 from ogr.services.pagure import PagureService
-
-try:
-    from importlib.metadata import PackageNotFoundError, distribution
-except ImportError:
-    from importlib_metadata import PackageNotFoundError  # type: ignore
-    from importlib_metadata import distribution  # type: ignore
 
 try:
     __version__ = distribution(__name__).version

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,11 +19,9 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development
     Topic :: Utilities
 keywords =
@@ -44,8 +42,7 @@ install_requires =
     PyYAML
     requests
     urllib3
-    importlib-metadata;python_version<"3.8"
-python_requires = >=3.6
+python_requires = >=3.9
 include_package_data = True
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
RELEASE NOTES BEGIN
ogr now requires Python 3.9 or later.
RELEASE NOTES END
