### PR TITLE
Explicitly specify Python interpreter options when running pytest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-test-image: recipe.yaml
 check:
 	@#`python3 -m pytest` doesn't work here b/c the way requre overrides import system:
 	@#`AttributeError: module 'importlib_metadata' has no attribute 'distributions'
-	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 pytest --verbose --showlocals $(TEST_TARGET)
+	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 /usr/bin/pytest --verbose --showlocals $(TEST_TARGET)
 
 check-in-container:
 	podman run --rm -it -v $(CURDIR):/src:Z -w /src --env TEST_TARGET $(OGR_IMAGE) make -e GITHUB_TOKEN=$(GITHUB_TOKEN) GITLAB_TOKEN=$(GITLAB_TOKEN) check

--- a/files/tasks/generic-dnf-requirements.yaml
+++ b/files/tasks/generic-dnf-requirements.yaml
@@ -6,6 +6,8 @@
       - git
       - dnf-utils
       - python3-pip
+      - python3-pygithub
+      - python3-gitlab
   become: true
 - name: Install rpmautospec-rpm-macros
   dnf:

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -2,7 +2,7 @@ summary:
   Unit & integration tests.
 prepare:
   how: ansible
-  playbooks:
+  playbook:
   - files/packit-testing-farm-prepare.yaml
 execute:
   script:


### PR DESCRIPTION
Starting with pytest 7, the shebang in `/usr/bin/pytest` passes the `-s` option to Python interpreter, which prevents importing pip-installed packages and breaks the tests. Fix that.