### PR TITLE
Deprecate CommitComment.comment in favour of body

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -30,6 +30,7 @@ from ogr.exceptions import (
     OgrNetworkError,
 )
 from ogr.parsing import parse_git_repo
+from ogr.deprecation import deprecate_and_set_removal
 
 try:
     from functools import cached_property as _cached_property
@@ -1028,17 +1029,28 @@ class CommitComment(OgrAbstractClass):
     """
     Attributes:
         sha (str): Hash of the related commit.
-        comment (str): Body of the comment.
+        body (str): Body of the comment.
         author (str): Login of the author.
     """
 
-    def __init__(self, sha: str, comment: str, author: str) -> None:
+    def __init__(self, sha: str, body: str, author: str) -> None:
         self.sha = sha
-        self.comment = comment
+        self.body = body
         self.author = author
 
+    @property  # type: ignore
+    @deprecate_and_set_removal(
+        since="0.41.0",
+        remove_in="0.46.0 (or 1.0.0 if it comes sooner)",
+        message="Use body",
+    )
+    def comment(self) -> str:
+        return self.body
+
     def __str__(self) -> str:
-        return f"CommitComment(commit={self.sha}, author={self.author}, comment={self.comment})"
+        return (
+            f"CommitComment(commit={self.sha}, author={self.author}, body={self.body})"
+        )
 
 
 class GitTag(OgrAbstractClass):

--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -6,8 +6,6 @@ from typing import Optional, Dict, Any
 import github
 import gitlab
 
-from ogr.deprecation import deprecate_and_set_removal
-
 
 class OgrException(Exception):
     """Something went wrong during our execution."""
@@ -50,15 +48,6 @@ class PagureAPIException(APIException):
 class GithubAPIException(APIException):
     """Exception related to Github API."""
 
-    @property  # type: ignore
-    @deprecate_and_set_removal(
-        since="0.30.0",
-        remove_in="0.35.0 (or 1.0.0 if it comes sooner)",
-        message="Use __cause__",
-    )
-    def github_error(self):
-        return self.__cause__
-
     @property
     def response_code(self):
         if self.__cause__ is None or not isinstance(
@@ -70,15 +59,6 @@ class GithubAPIException(APIException):
 
 class GitlabAPIException(APIException):
     """Exception related to Gitlab API."""
-
-    @property  # type: ignore
-    @deprecate_and_set_removal(
-        since="0.30.0",
-        remove_in="0.35.0 (or 1.0.0 if it comes sooner)",
-        message="Use __cause__",
-    )
-    def gitlab_error(self):
-        return self.__cause__
 
     @property
     def response_code(self):

--- a/ogr/read_only.py
+++ b/ogr/read_only.py
@@ -242,7 +242,7 @@ class GitProjectReadOnly:
     def commit_comment(
         cls, original_object: Any, commit: str, body: str
     ) -> "CommitComment":
-        return CommitComment(sha=commit, comment=body, author=cls.author)
+        return CommitComment(sha=commit, body=body, author=cls.author)
 
     @classmethod
     def set_commit_status(

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -339,7 +339,7 @@ class GithubProject(BaseGitProject):
         raw_commit_coment: GithubCommitComment,
     ) -> CommitComment:
         return CommitComment(
-            comment=raw_commit_coment.body,
+            body=raw_commit_coment.body,
             author=raw_commit_coment.user.login,
             sha=raw_commit_coment.commit_id,
         )

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -287,7 +287,7 @@ class GitlabProject(BaseGitProject):
     @staticmethod
     def _commit_comment_from_gitlab_object(raw_comment, commit) -> CommitComment:
         return CommitComment(
-            sha=commit, comment=raw_comment.note, author=raw_comment.author["username"]
+            sha=commit, body=raw_comment.note, author=raw_comment.author["username"]
         )
 
     def get_commit_comments(self, commit: str) -> List[CommitComment]:

--- a/tests/integration/github/test_generic_commands.py
+++ b/tests/integration/github/test_generic_commands.py
@@ -231,7 +231,7 @@ class GenericCommands(GithubTests):
             row=6,
         )
         assert comment.sha == "95069d7bedb6ae02def3fccce22169b412d08eac"
-        assert comment.comment == "Testing commit comment"
+        assert comment.body == "Testing commit comment"
         assert comment.author == self.service.user.get_username()
 
     def test_get_commit_comments(self):
@@ -240,7 +240,7 @@ class GenericCommands(GithubTests):
         )
         assert len(comments)
         assert comments[0].sha == "95069d7bedb6ae02def3fccce22169b412d08eac"
-        assert comments[0].comment == "Testing commit comment"
+        assert comments[0].body == "Testing commit comment"
 
     def test_get_web_url(self):
         url = self.ogr_project.get_web_url()

--- a/tests/integration/gitlab/test_generic_commands.py
+++ b/tests/integration/gitlab/test_generic_commands.py
@@ -182,7 +182,7 @@ class GenericCommands(GitlabTests):
             row=3,
         )
         assert comment.author == self.service.user.get_username()
-        assert comment.comment == "Comment to line 3"
+        assert comment.body == "Comment to line 3"
 
     def test_get_commit_comments(self):
         comments = self.project.get_commit_comments(
@@ -190,7 +190,7 @@ class GenericCommands(GitlabTests):
         )
         assert len(comments)
         assert comments[0].sha == "11b37d913374b14f8519d16c2a2cca3ebc14ac64"
-        assert comments[0].comment == "Comment to line 3"
+        assert comments[0].body == "Comment to line 3"
 
     def test_get_web_url(self):
         url = self.project.get_web_url()


### PR DESCRIPTION
Related to https://github.com/packit/packit-service/pull/1716

RELEASE NOTES BEGIN
CommitComment.comment has been deprecated in favour of CommitComment.body to make the naming consistent across objects.
RELEASE NOTES END
