### PR TITLE
Use github-actions bot to run prepare-release steps

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -11,8 +11,9 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') && github.repository_owner == 'packit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - run: |
+      - uses: actions/checkout@v3
+      - name: Create GitHub release
+        run: |
           VERSION=$(grep -oP '^# \K[0-9.]*' CHANGELOG.md | head -n 1)
           # Take the lines between the first two headers from CHANGELOG.md,
           # and use it as a description for the new release.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and push docs
         run: |
           git config user.name Packit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -21,13 +21,10 @@ jobs:
         with:
           version: ${{ inputs.version }}
           specfiles: fedora/python-ogr.spec
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           labels: release
-          token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
           commit-message: Release ${{ inputs.version }}
           title: Release ${{ inputs.version }}
           body: Update the changelog and the specfile for release ${{ inputs.version }}.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
 
       - name: Build a source tarball and a binary wheel

--- a/files/tasks/project-dir.yaml
+++ b/files/tasks/project-dir.yaml
@@ -1,17 +1,17 @@
 ---
-- set_fact:
+- ansible.builtin.set_fact:
     project_dir: "{{ playbook_dir }}/.."
   when: zuul is not defined
-- set_fact:
+- ansible.builtin.set_fact:
     project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
   when: zuul is defined
 - name: stat {{ project_dir }}
-  stat:
+  ansible.builtin.stat:
     path: "{{ project_dir }}"
   tags:
     - no-cache
   register: src_path
-- name: Make sure {{ project_dir }} is present
-  assert:
+- name: Assert project_dir is present
+  ansible.builtin.assert:
     that:
       - src_path.stat.isdir

--- a/files/zuul-install-requirements-pip.yaml
+++ b/files/zuul-install-requirements-pip.yaml
@@ -2,10 +2,10 @@
 - name: Install dependencies for PIP ogr
   hosts: all
   tasks:
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/python-compile-deps.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/python-compile-deps.yaml
     - name: Install deps from PyPI
-      pip:
+      ansible.builtin.pip:
         name: "{{ item }}"
       with_items:
         - PyGithub

--- a/files/zuul-install-requirements-rpms.yaml
+++ b/files/zuul-install-requirements-rpms.yaml
@@ -2,11 +2,11 @@
 - name: Install RPM dependencies for ogr
   hosts: all
   tasks:
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/build-rpm-deps.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/build-rpm-deps.yaml
     - name: Install deps as RPMs
-      dnf:
+      ansible.builtin.dnf:
         name:
           - python3-pygithub
           - python3-gitlab

--- a/files/zuul-reverse-dep-packit.yaml
+++ b/files/zuul-reverse-dep-packit.yaml
@@ -2,11 +2,11 @@
 - name: Check if we are not breaking packit
   hosts: all
   tasks:
-    - set_fact:
+    - ansible.builtin.set_fact:
         reverse_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/packit/packit'].src_dir }}"
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/rpm-test-deps.yaml
-    - include_tasks: tasks/packit-requirements.yaml
-    - include_tasks: tasks/install-ogr.yaml
-    - include_tasks: tasks/packit-tests.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
+    - ansible.builtin.include_tasks: tasks/packit-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/install-ogr.yaml
+    - ansible.builtin.include_tasks: tasks/packit-tests.yaml

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -2,11 +2,11 @@
 - name: This is a recipe for how to run ogr tests
   hosts: all
   tasks:
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/rpm-test-deps.yaml
-    - include_tasks: tasks/install-ogr.yaml
-    - include_tasks: tasks/configure-git.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
+    - ansible.builtin.include_tasks: tasks/install-ogr.yaml
+    - ansible.builtin.include_tasks: tasks/configure-git.yaml
     - name: Run tests
-      command: make check
+      ansible.builtin.command: make check
       args:
         chdir: "{{ project_dir }}"

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -6,11 +6,11 @@
     with_testing: false
 
   tasks:
-    - set_fact:
+    - ansible.builtin.set_fact:
         project_dir: "{{ ansible_user_dir }}/{{ zuul.project.src_dir }}"
       when: zuul is defined
     - name: Install all packages needed to hack on ogr.
-      dnf:
+      ansible.builtin.dnf:
         name:
           - make
           - python3-flexmock
@@ -24,20 +24,20 @@
           - python3-tox
       become: true
     - name: Install latest twine for sake of check command
-      pip:
+      ansible.builtin.pip:
         name:
           - twine # we need newest twine, b/c of the check command
           - readme_renderer[md]
         state: latest
       become: true
     - name: Install requre
-      pip:
+      ansible.builtin.pip:
         name:
           - git+https://github.com/packit/requre
         state: latest
       become: true
     - name: Install dependencies for git APIs
-      dnf:
+      ansible.builtin.dnf:
         name:
           - python3-requests
           - python3-pygithub
@@ -45,22 +45,22 @@
         state: present
       become: true
     - name: stat {{ project_dir }}
-      stat:
+      ansible.builtin.stat:
         path: "{{ project_dir }}"
       tags:
         - no-cache
       register: src_path
-    - name: Make sure {{ project_dir }} is present
-      assert:
+    - name: Assert project_dir is present
+      ansible.builtin.assert:
         that:
           - src_path.stat.isdir
     # this requires to have sources mounted inside at /src
     - name: Install ogr from {{ project_dir }}
-      pip:
+      ansible.builtin.pip:
         name: "{{ project_dir }}"
       become: true
     - name: Run tests
-      command: tox
+      ansible.builtin.command: tox
       args:
         chdir: "{{ project_dir }}"
       when: with_testing


### PR DESCRIPTION
Both, the [packit/prepare-release](https://github.com/peter-evans/create-pull-request#action-inputs) & [peter-evans/create-pull-request](https://github.com/packit/prepare-release#packitprepare-release) default to using (autogenerated) [secrets.GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) if no token is provided.

That token should be enough because the steps are repo-scoped and [don't trigger any other workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) since the PR which triggers the 'Create GitHub release' is manually merged by a user.

Seems to work OK - jpopelka/packit#1