### PR TITLE
fix: get all PRs in PagurePullRequest.get_list instead of one page

### DIFF
--- a/tests/integration/pagure/test_data/test_pull_requests/PullRequests.test_pr_list.yaml
+++ b/tests/integration/pagure/test_data/test_pull_requests/PullRequests.test_pr_list.yaml
@@ -5,7 +5,7 @@ _requre:
 requests.sessions:
   send:
     GET:
-      https://pagure.io/api/0/ogr-tests/pull-requests?status=All:
+      https://pagure.io/api/0/ogr-tests/pull-requests?page=1&status=All:
       - metadata:
           latency: 0.6439666748046875
           module_call_list:
@@ -745,7 +745,7 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
-      https://pagure.io/api/0/ogr-tests/pull-requests?status=Open:
+      https://pagure.io/api/0/ogr-tests/pull-requests?page=1&status=Open:
       - metadata:
           latency: 0.737177848815918
           module_call_list:


### PR DESCRIPTION
RELEASE NOTES BEGIN
A bug in ogr resulting in returning only first page of pull requests for Pagure has been fixed.
RELEASE NOTES END