### PR TITLE
fix(pagure): raise network error for 50x

### DIFF
--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -12,6 +12,7 @@ from ogr.exceptions import (
     OgrException,
     OperationNotSupported,
     OgrNetworkError,
+    GitForgeInternalError,
 )
 from ogr.factory import use_for_service
 from ogr.parsing import parse_git_repo
@@ -203,6 +204,13 @@ class PagureService(BaseGitService):
         except requests.exceptions.ConnectionError as er:
             logger.error(er)
             raise OgrNetworkError(f"Cannot connect to url: '{url}'.") from er
+
+        if response.status_code >= 500:
+            raise GitForgeInternalError(
+                f"Pagure API returned {response.status_code} status for `{url}`"
+                f" with reason: `{response.reason}`"
+            )
+
         return response
 
     def get_raw_request(

--- a/tests/integration/pagure/test_generic_commands.py
+++ b/tests/integration/pagure/test_generic_commands.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import pytest
-from ogr.exceptions import PagureAPIException
+from ogr.exceptions import GitForgeInternalError
 
 from requre.online_replacing import record_requests_for_all_methods
 
@@ -92,7 +92,7 @@ class GenericCommands(PagureTests):
             self.ogr_project.get_file_content(".blablabla_nonexisting_file")
 
     def test_no_file_server_error(self):
-        with pytest.raises(PagureAPIException) as ex:
+        with pytest.raises(GitForgeInternalError) as ex:
             self.ogr_project.get_file_content(".blablabla_no_file")
         assert "INTERNAL SERVER ERROR" in str(ex)
 


### PR DESCRIPTION
After Maja's changes in c8ddf05, we were raising a ‹PagureAPIException›
also for 50x when getting files from Pagure, e.g. configs in service.

Aforementioned change is rather generic and handles 404s ideally, but not
so ideally 50x that should be retried, as they are the git forge internal
errors, rather than raised up in Sentry after their first occurence.

Let's check for ‹status code >= 500› and raise ‹GitForgeInternalError›
instead of the ‹PagureAPIException›.

TODO:

- [x] should be ‹GitForgeInternalError›

Signed-off-by: Matej Focko <mfocko@redhat.com>

RELEASE NOTES BEGIN
ogr now raises `GitForgeInternalError` rather than `PagureAPIException` when getting 50x response from the Pagure API.
RELEASE NOTES END
