### PR TITLE
Warnings make packit fail in parsing sandcastle command output

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,7 +20,7 @@ actions:
   create-archive:
     - python3 setup.py sdist --dist-dir ./fedora/
     - bash -c "ls -1t ./fedora/*.tar.gz | head -n 1"
-  get-current-version: python3 setup.py --version
+  get-current-version: python3 -W ignore setup.py --version # TODO: remove -W ignore when setup process is updated
 
 srpm_build_deps:
   - python3-pip # "python3 setup.py --version" needs it

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ url = https://github.com/packit/ogr
 author = Red Hat
 author_email = user-cont-team@redhat.com
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers


### PR DESCRIPTION
When we run the following as a sandcastle command:
`python3 setup.py --version`

we got 2 warning messages that make packit fail in **parsing the command output**:

1. `licence_file` is deprecated, which should be resolved by the first commit
2. `Requirements should be satisfied by a PEP 517 installer`:
    when packit/packit#1850 will be closed this should disappear,
    in the meantime just drop the warning, which should be solved by the second commit.



