### PR TITLE
Compare hostnames when using custom instances

### DIFF
--- a/ogr/factory.py
+++ b/ogr/factory.py
@@ -64,7 +64,7 @@ def get_project(
     Args:
         url: URL of the project, e.g. `"https://github.com/packit/ogr"`.
         service_mapping_update: Custom mapping from
-            service url (`str`) to service class.
+            service url/hostname (`str`) to service class.
 
             Defaults to no mapping.
         custom_instances: List of instances that will be
@@ -117,7 +117,7 @@ def get_service_class_or_none(
 
     Args:
         url: URL of the project, e.g. `"https://github.com/packit/ogr"`.
-        service_mapping_update: Custom mapping from service url (`str`) to service
+        service_mapping_update: Custom mapping from service url/hostname (`str`) to service
             class.
 
             Defaults to `None`.
@@ -132,7 +132,7 @@ def get_service_class_or_none(
 
     parsed_url = parse_git_repo(url)
     for service, service_kls in mapping.items():
-        if service in parsed_url.hostname:
+        if parse_git_repo(service).hostname in parsed_url.hostname:
             return service_kls
 
     return None
@@ -146,7 +146,7 @@ def get_service_class(
 
     Args:
         url: URL of the project, e.g. `"https://github.com/packit/ogr"`.
-        service_mapping_update: Custom mapping from service url (str) to service
+        service_mapping_update: Custom mapping from service url/hostname (str) to service
             class.
 
             Defaults to `None`.

--- a/ogr/factory.py
+++ b/ogr/factory.py
@@ -84,7 +84,7 @@ def get_project(
     mapping = service_mapping_update.copy() if service_mapping_update else {}
     custom_instances = custom_instances or []
     for instance in custom_instances:
-        mapping[instance.instance_url] = instance.__class__
+        mapping[instance.hostname] = instance.__class__
 
     kls = get_service_class(url=url, service_mapping_update=mapping)
     parsed_repo_url = parse_git_repo(url)

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -229,6 +229,19 @@ def test_get_service_class_not_found(url, mapping):
                 service=GithubService(instance_url="https://github.com/packit/ogr"),
             ),
         ),
+        (
+            "https://my.gtlb/packit/ogr",
+            None,
+            [
+                GitlabService(instance_url="https://my.gtlb"),
+            ],
+            False,
+            GitlabProject(
+                repo="ogr",
+                namespace="packit",
+                service=GitlabService(instance_url="https://my.gtlb"),
+            ),
+        ),
     ],
 )
 def test_get_project(url, mapping, instances, force_custom_instance, result):

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -29,6 +29,11 @@ from ogr.services.pagure import PagureProject
             GithubService,
         ),
         (
+            "https://some-url/packit-service/ogr",
+            {"https://some-url": GithubService},
+            GithubService,
+        ),
+        (
             "https://github.com/packit-service/ogr",
             {"github.com": PagureService},
             PagureService,
@@ -110,6 +115,15 @@ def test_get_service_class_not_found(url, mapping):
         (
             "https://some-url/packit-service/ogr",
             {"some-url": GithubService},
+            None,
+            True,
+            GithubProject(
+                namespace="packit-service", repo="ogr", service=GithubService()
+            ),
+        ),
+        (
+            "https://some-url/packit-service/ogr",
+            {"https://some-url": GithubService},
             None,
             True,
             GithubProject(


### PR DESCRIPTION
Fixes an issue with project->service mapping where the service with an url not containing the service type wasn't matched.

Related to

Merge before/after

RELEASE NOTES BEGIN
Fixes an issue with project->service mapping where the service with an url not containing the service type wasn't matched.
RELEASE NOTES END
