### PR TITLE
Add known custom GitLab instances

### DIFF
--- a/ogr/services/gitlab/service.py
+++ b/ogr/services/gitlab/service.py
@@ -16,7 +16,20 @@ from ogr.services.gitlab.user import GitlabUser
 logger = logging.getLogger(__name__)
 
 
-@use_for_service("gitlab")
+@use_for_service("gitlab")  # anything containing a gitlab word in hostname
+# + list of community-hosted instances based on the following list
+# https://wiki.p2pfoundation.net/List_of_Community-Hosted_GitLab_Instances
+@use_for_service("salsa.debian.org")
+@use_for_service("git.fosscommunity.in")
+@use_for_service("framagit.org")
+@use_for_service("dev.gajim.org")
+@use_for_service("git.coop")
+@use_for_service("lab.libreho.st")
+@use_for_service("git.linux-kernel.at")
+@use_for_service("git.pleroma.social")
+@use_for_service("git.silence.dev")
+@use_for_service("code.videolan.org")
+@use_for_service("source.puri.sm")
 class GitlabService(BaseGitService):
     name = "gitlab"
 

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -43,6 +43,18 @@ from ogr.services.pagure import PagureProject
         ("https://pagure.something.com/ogr", None, PagureService),
         ("https://gitlab.com/someone/project", None, GitlabService),
         ("https://gitlab.abcd.def/someone/project", None, GitlabService),
+        # Known GitLab instances without gitlab word in a hostname:
+        ("https://salsa.debian.org/someone/project", None, GitlabService),
+        ("https://git.fosscommunity.in/someone/project", None, GitlabService),
+        ("https://framagit.org/someone/project", None, GitlabService),
+        ("https://dev.gajim.org/someone/project", None, GitlabService),
+        ("https://git.coop/someone/project", None, GitlabService),
+        ("https://lab.libreho.st/someone/project", None, GitlabService),
+        ("https://git.linux-kernel.at/someone/project", None, GitlabService),
+        ("https://git.pleroma.social/someone/project", None, GitlabService),
+        ("https://git.silence.dev/someone/project", None, GitlabService),
+        ("https://code.videolan.org/someone/project", None, GitlabService),
+        ("https://source.puri.sm/someone/project", None, GitlabService),
         (
             "https://src.fedoraproject.org/rpms/golang-gitlab-flimzy-testy",
             None,


### PR DESCRIPTION
So users do not need to use any custom mappings to support these. (Especially useful when the mapping is hidden in another tool.)

The list is based on https://wiki.p2pfoundation.net/List_of_Community-Hosted_GitLab_Instances

(Doing a test call to get that automatically would require more work and would result in extra API queries.)

RELEASE NOTES BEGIN
OGR now understands a few community-hosted GitLab instances that could not be determined automatically from the hostname. Thanks to that, you don't need to hardcode these instances to be mapped correctly.
RELEASE NOTES END
