### PR TITLE
Stop building wheel from Git checkout in CI/CD

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
         # https://pypa-build.readthedocs.io
         run: |
           python -m pip install build
-          python -m build --sdist --wheel
+          python -m build
 
       - name: Publish 📦 to PyPI
         # https://github.com/pypa/gh-action-pypi-publish


### PR DESCRIPTION
Passing `--sdist` and `--wheel` makes pypa/build create both from the current source checkout directory. When there's no args passed, though. It first creates an sdist, unpacks it temporarily, and then, creates a wheel out of that sdist source, not Git checkout. This is close to how `pip install` works for installing from sdist, as well as how downstream package stuff.

Adding these CLI options to the PUG guide was a historical mistake I made when writing it.
