### PR TITLE
Configure `setuptools-scm` to work with arbitrary non-tagged commits

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$


### PR DESCRIPTION
This patch introduces compatibility with the recent setuptools-scm that makes use of modern Git to be able to generate intermediate untagged versions.

This will make `pip install install https://github.com/packit/ogr/archive/main.tar.gz` work correctly and produce a nice version.