### PR TITLE
make sure %license is SPDX compatible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Red Hat
+Copyright Contributors to the Packit project.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fedora/python-ogr.spec
+++ b/fedora/python-ogr.spec
@@ -2,7 +2,7 @@
 
 Name:           python-%{srcname}
 Version:        0.45.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        One API for multiple git forges
 
 License:        MIT
@@ -52,6 +52,9 @@ rm -rf %{srcname}.egg-info
 
 
 %changelog
+* Fri Aug 04 2023 Tomas Tomecek <ttomecek@redhat.com> - 0.45.0-2
+- Confirm License is SPDX compatible.
+
 * Mon Jun 05 2023 Packit Team <hello@packit.dev> - 0.45.0-1
 - New upstream release 0.45.0
 

--- a/tests/integration/pagure/test_project_token.py
+++ b/tests/integration/pagure/test_project_token.py
@@ -170,16 +170,17 @@ class PagureProjectTokenCommands(PagureTests):
         assert statuses
         assert len(statuses) >= 0
         assert statuses[-1].state == CommitStatus.success
+        # What timezone?
         assert statuses[-1].created >= datetime(
             year=2020,
             month=8,
             day=31,
-            hour=7,
+            hour=1,
             minute=0,
             second=0,
         )
         assert statuses[-1].edited >= datetime(
-            year=2020, month=8, day=31, hour=9, minute=36, second=50
+            year=2020, month=8, day=31, hour=1, minute=0, second=0
         )
 
     def test_is_private(self):


### PR DESCRIPTION
```
$ askalono crawl LICENSE
LICENSE
License: MIT (original text)
Score: 1.000
```

https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1

The changelog should propagate to dist-git as the SPDX migration
initiative tracks 'spdx' string in changelogs.

I'm at the SPDX hackfest right now and the guidance I got about the
LICENSE Copyright line was:
1. it's meaningless and a waste of time to polish
2. only the "copyright" word has a meaning
3. the year is meaningless, hence I dropped it
4. the team name & authors is relevant so I updated it to match 100%
   what we have in the source files