### PR TITLE
Remove rpmautospec-rpm-macros from TF playbooks since it's no longer needed

### DIFF
--- a/files/tasks/generic-dnf-requirements.yaml
+++ b/files/tasks/generic-dnf-requirements.yaml
@@ -10,10 +10,3 @@
       - python3-gitlab
       - python3-pytest-cov
   become: true
-- name: Install rpmautospec-rpm-macros
-  dnf:
-    name:
-      - rpmautospec-rpm-macros
-  # rpmautospec-rpm-macros is not in epel
-  when: ansible_distribution == 'Fedora'
-  become: true


### PR DESCRIPTION
Fixes:

```
[31mCommand 'ansible-playbook --ssh-common-args '-oForwardX11=no -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oServerAliveInterval=60 -oServerAliveCountMax=5 -oIdentitiesOnly=yes -p22 -i /etc/citool.d/id_rsa_artemis -S/tmp/tmpon0grbsm' -i root@3.128.27.241, /var/ARTIFACTS/git-a4801b0bef6f0b6364115e9e2d8cd8a8906626cbohn_tken/files/packit-testing-farm-prepare.yaml' returned 2.[0m
        stdout (16 lines)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        PLAY [This is a recipe for preparing the environment when running tests inside testing-farm] ***
        TASK [Gathering Facts] *********************************************************
        ok: [root@3.128.27.241]
        TASK [include_tasks] ***********************************************************
        included: /var/ARTIFACTS/git-a4801b0bef6f0b6364115e9e2d8cd8a8906626cbohn_tken/files/tasks/generic-dnf-requirements.yaml for root@3.128.27.241
        TASK [Install generic RPM packages] ********************************************
        changed: [root@3.128.27.241]
        TASK [Install rpmautospec-rpm-macros] ******************************************
        fatal: [root@3.128.27.241]: FAILED! => {"changed": false, "failures": ["No package rpmautospec-rpm-macros available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
        PLAY RECAP *********************************************************************
        root@3.128.27.241          : ok=3    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
