### PR TITLE
Fix get_fork for Pagure

### DIFF
--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -302,7 +302,7 @@ class PagureProject(BaseGitProject):
 
         for fork in self.get_forks():
             fork_info = fork.get_project_info()
-            if self._user in fork_info["user"]["name"]:
+            if self._user == fork_info["user"]["name"]:
                 return fork
 
         if not self.is_forked():


### PR DESCRIPTION
When getting the fork from existing forks, check for equality of the usernames and not only substring check with 'in' operator. This prevents getting a fork of 'packit-stg' for user 'packit'.

Fixes packit/packit-service#2178

RELEASE NOTES BEGIN
We have fixed a bug in `get_fork` method for Pagure about checking the usernames for a match when going through existing forks.
RELEASE NOTES END
