### PR TITLE
Handle timezone-aware timestamps

### DIFF
--- a/tests/integration/github/test_generic_commands.py
+++ b/tests/integration/github/test_generic_commands.py
@@ -190,10 +190,10 @@ class GenericCommands(GithubTests):
         assert last_flag.state == CommitStatus.success
         assert last_flag.context == "test"
         assert last_flag.uid
-        assert last_flag.created == datetime(
+        assert last_flag.created.replace(tzinfo=None) == datetime(
             year=2019, month=9, day=19, hour=12, minute=21, second=6
         )
-        assert last_flag.edited == datetime(
+        assert last_flag.edited.replace(tzinfo=None) == datetime(
             year=2019, month=9, day=19, hour=12, minute=21, second=6
         )
 


### PR DESCRIPTION
Since version 2.1.0, timestamps in PyGithub are [timezone-aware](https://github.com/PyGithub/PyGithub/commit/0177f7c51327039c8b96b7ebb2731e32b20a8eae).
Remove tzinfo in tests for easy comparison.

Related to https://github.com/packit/requre/pull/275.