### PR TITLE
Add README to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
     { name = "Red Hat", email = "user-cont-team@redhat.com" },
 ]
 description = "One API for multiple git forges."
+readme = "README.md"
 license = "MIT"
 license-files = { paths = ["LICENSE"] }
 requires-python = ">=3.9"


### PR DESCRIPTION
It turns out that it's not implicitly included and not having it prevents PyPI upload.

See: https://github.com/packit/ogr/actions/runs/6431356823/job/17464105404#step:6:13