### PR TITLE
gitlab list MRs: return all, not just 20

### DIFF
--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -240,10 +240,14 @@ class GitlabPullRequest(BasePullRequest):
         status: PRStatus = PRStatus.open,
     ) -> list["PullRequest"]:
         # Gitlab API has status 'opened', not 'open'
+        # f"Calling a `list()` method without specifying `get_all=True` or "
+        # f"`iterator=True` will return a maximum of 20 items. "
         mrs = project.gitlab_repo.mergerequests.list(
             state=status.name if status != PRStatus.open else "opened",
             order_by="updated_at",
             sort="desc",
+            # gitlab 3.3 syntax was all=True
+            get_all=True,
         )
         return [GitlabPullRequest(mr, project) for mr in mrs]
 

--- a/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_mr_list_limit.yaml
+++ b/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_mr_list_limit.yaml
@@ -1,0 +1,6707 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      ? https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false
+      : - metadata:
+            latency: 1.3196947574615479
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - allow_collaboration: true
+              allow_maintainer_to_push: true
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+                id: 6466632
+                locked: false
+                name: Ben Crocker
+                state: active
+                username: bcrocker
+                web_url: https://gitlab.com/bcrocker
+              blocking_discussions_resolved: true
+              closed_at: '2021-04-12T21:11:54.865Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+                id: 6466632
+                locked: false
+                name: Ben Crocker
+                state: active
+                username: bcrocker
+                web_url: https://gitlab.com/bcrocker
+              created_at: '2021-04-12T21:11:53.700Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 95613808
+              iid: 69
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2021-04-12T21:11:53.700Z'
+              project_id: 14233409
+              reference: '!69'
+              references:
+                full: packit-service/ogr-tests!69
+                relative: '!69'
+                short: '!69'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 25840586
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2021-04-12T21:11:54.843Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/69
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:29:00.315Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:59.493Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049229
+              iid: 68
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:59.493Z'
+              project_id: 14233409
+              reference: '!68'
+              references:
+                full: packit-service/ogr-tests!68
+                relative: '!68'
+                short: '!68'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2020-10-12T10:29:00.300Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/68
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:49.714Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:48.412Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049201
+              iid: 67
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:48.412Z'
+              project_id: 14233409
+              reference: '!67'
+              references:
+                full: packit-service/ogr-tests!67
+                relative: '!67'
+                short: '!67'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2020-10-12T10:28:49.698Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/67
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:33.601Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:32.071Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 74049173
+              iid: 66
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:32.071Z'
+              project_id: 14233409
+              reference: '!66'
+              references:
+                full: packit-service/ogr-tests!66
+                relative: '!66'
+                short: '!66'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-10-12T10:28:33.584Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/66
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:29.406Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:26.977Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049163
+              iid: 65
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:26.977Z'
+              project_id: 14233409
+              reference: '!65'
+              references:
+                full: packit-service/ogr-tests!65
+                relative: '!65'
+                short: '!65'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-10-12T10:28:29.392Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/65
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:22.684Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:21.327Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049145
+              iid: 64
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:21.327Z'
+              project_id: 14233409
+              reference: '!64'
+              references:
+                full: packit-service/ogr-tests!64
+                relative: '!64'
+                short: '!64'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-10-12T10:28:22.668Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/64
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-09-03T09:53:44.881Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-09-03T09:50:58.837Z'
+              description: pull request body
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69664587
+              iid: 63
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-09-03T09:50:58.837Z'
+              project_id: 14233409
+              reference: '!63'
+              references:
+                full: packit-service/ogr-tests!63
+                relative: '!63'
+                short: '!63'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test: fork(master) <- fork'
+              updated_at: '2020-09-03T09:53:44.859Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/63
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-09-03T09:50:05.870Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:11:32.195Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042578
+              iid: 59
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:11:32.195Z'
+              project_id: 14233409
+              reference: '!59'
+              references:
+                full: packit-service/ogr-tests!59
+                relative: '!59'
+                short: '!59'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-09-03T09:50:05.844Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/59
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-31T08:34:29.197Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-31T08:34:28.114Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69198741
+              iid: 62
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-31T08:34:28.114Z'
+              project_id: 14233409
+              reference: '!62'
+              references:
+                full: packit-service/ogr-tests!62
+                relative: '!62'
+                short: '!62'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2020-08-31T08:34:29.180Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/62
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-31T08:34:22.758Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-31T08:34:22.004Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69198731
+              iid: 61
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-31T08:34:22.004Z'
+              project_id: 14233409
+              reference: '!61'
+              references:
+                full: packit-service/ogr-tests!61
+                relative: '!61'
+                short: '!61'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2020-08-31T08:34:22.744Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/61
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-31T08:34:10.164Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-31T08:34:08.657Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 69198715
+              iid: 60
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-31T08:34:08.657Z'
+              project_id: 14233409
+              reference: '!60'
+              references:
+                full: packit-service/ogr-tests!60
+                relative: '!60'
+                short: '!60'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-31T08:34:10.147Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/60
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:11:01.258Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:09:45.221Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042373
+              iid: 58
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:09:45.221Z'
+              project_id: 14233409
+              reference: '!58'
+              references:
+                full: packit-service/ogr-tests!58
+                relative: '!58'
+                short: '!58'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-28T09:11:01.241Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/58
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:09:26.747Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:08:53.394Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042267
+              iid: 57
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:08:53.394Z'
+              project_id: 14233409
+              reference: '!57'
+              references:
+                full: packit-service/ogr-tests!57
+                relative: '!57'
+                short: '!57'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-28T09:09:26.730Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/57
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:08:25.387Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:08:00.355Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042182
+              iid: 56
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:08:00.355Z'
+              project_id: 14233409
+              reference: '!56'
+              references:
+                full: packit-service/ogr-tests!56
+                relative: '!56'
+                short: '!56'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-28T09:08:25.354Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/56
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:05:12.861Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:05:11.433Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69041783
+              iid: 55
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:05:11.433Z'
+              project_id: 14233409
+              reference: '!55'
+              references:
+                full: packit-service/ogr-tests!55
+                relative: '!55'
+                short: '!55'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> other_fork'
+              updated_at: '2020-08-28T09:05:12.823Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/55
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2020-08-28T08:54:42.124Z'
+              description: ''
+              detailed_merge_status: draft_status
+              discussion_locked: null
+              downvotes: 0
+              draft: true
+              force_remove_source_branch: true
+              has_conflicts: true
+              id: 69040653
+              iid: 54
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T08:54:42.124Z'
+              project_id: 14233409
+              reference: '!54'
+              references:
+                full: packit-service/ogr-tests!54
+                relative: '!54'
+                short: '!54'
+              reviewers: []
+              sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+              should_remove_source_branch: null
+              source_branch: pr-test1
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: opened
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'Draft: Pr test1'
+              updated_at: '2020-08-28T08:54:42.124Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/54
+              work_in_progress: true
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2020-08-28T08:49:02.322Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 69040003
+              iid: 53
+              labels: []
+              merge_commit_sha: 353361738fdefd9cd4f9fd669fa1c5792b9fe299
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              merge_when_pipeline_succeeds: false
+              merged_at: '2020-08-28T08:51:03.924Z'
+              merged_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              milestone: null
+              prepared_at: '2020-08-28T08:49:02.322Z'
+              project_id: 14233409
+              reference: '!53'
+              references:
+                full: packit-service/ogr-tests!53
+                relative: '!53'
+                short: '!53'
+              reviewers: []
+              sha: 59b1a9bab5b5198c619270646410867788685c16
+              should_remove_source_branch: null
+              source_branch: test_branch
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: pr-test1
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Test branch
+              updated_at: '2020-08-28T08:51:03.883Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/53
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T08:46:17.711Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T08:46:16.866Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69039661
+              iid: 51
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T08:46:16.866Z'
+              project_id: 14233409
+              reference: '!51'
+              references:
+                full: packit-service/ogr-tests!51
+                relative: '!51'
+                short: '!51'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2020-08-28T08:46:17.690Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/51
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T08:45:39.619Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T08:45:38.273Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69039593
+              iid: 50
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T08:45:38.273Z'
+              project_id: 14233409
+              reference: '!50'
+              references:
+                full: packit-service/ogr-tests!50
+                relative: '!50'
+                short: '!50'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2020-08-28T08:45:39.600Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/50
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T08:45:16.144Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-04-28T19:17:22.548Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: true
+              id: 57207332
+              iid: 23
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-04-28T19:17:22.548Z'
+              project_id: 14233409
+              reference: '!23'
+              references:
+                full: packit-service/ogr-tests!23
+                relative: '!23'
+                short: '!23'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'WIP: Pr 3'
+              updated_at: '2020-08-28T08:45:16.118Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/23
+              work_in_progress: false
+            _next: null
+            elapsed: 1.317807
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c0e003af99b33c-PRG
+              Connection: keep-alive
+              Content-Encoding: br
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 07:09:41 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Dfcfvz07KdY02rX9tOXpEl2e%2B0F7lrfGO4uQ1jU7GdUwAAq6GcZkwM6%2Fh51nL1NPP%2F9qGayrlD%2FbFLwexnWbcFGes3pKTduGzyumU5DnNcJx%2FQxXc%2F%2FqFYbZkEY%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"91fdc7775b5964f8f13465e55bf3315e"
+              gitlab-lb: haproxy-main-05-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=3&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '125'
+              ratelimit-remaining: '1877'
+              ratelimit-reset: '1698304241'
+              ratelimit-resettime: Thu, 26 Oct 2023 07:10:41 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"dc63f33e896847033a26b6d688040120","version":"1"}'
+              x-next-page: '3'
+              x-page: '2'
+              x-per-page: '20'
+              x-prev-page: '1'
+              x-request-id: dc63f33e896847033a26b6d688040120
+              x-runtime: '1.156931'
+              x-total: '84'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      ? https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=3&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false
+      : - metadata:
+            latency: 0.5786917209625244
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-27T09:58:27.607Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-04-28T19:27:39.008Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: true
+              has_conflicts: true
+              id: 57208001
+              iid: 24
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-04-28T19:27:39.008Z'
+              project_id: 14233409
+              reference: '!24'
+              references:
+                full: packit-service/ogr-tests!24
+                relative: '!24'
+                short: '!24'
+              reviewers: []
+              sha: 6970eae72f9ecee667183f52880ca76126bd8b38
+              should_remove_source_branch: null
+              source_branch: pr-test3
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'WIP: Pr test3'
+              updated_at: '2020-08-27T09:58:27.495Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/24
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-27T09:58:25.268Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-04-27T21:39:58.418Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: true
+              has_conflicts: true
+              id: 57082404
+              iid: 22
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-04-27T21:39:58.418Z'
+              project_id: 14233409
+              reference: '!22'
+              references:
+                full: packit-service/ogr-tests!22
+                relative: '!22'
+                short: '!22'
+              reviewers: []
+              sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+              should_remove_source_branch: null
+              source_branch: pr-test1
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: gotta try with fork
+              updated_at: '2020-08-27T09:58:24.777Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/22
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T13:42:35.236Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T13:42:33.694Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68570514
+              iid: 49
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T13:42:33.694Z'
+              project_id: 14233409
+              reference: '!49'
+              references:
+                full: packit-service/ogr-tests!49
+                relative: '!49'
+                short: '!49'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> other_fork'
+              updated_at: '2020-08-24T13:42:35.220Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/49
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:32.268Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:30.490Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68533159
+              iid: 48
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:30.490Z'
+              project_id: 14233409
+              reference: '!48'
+              references:
+                full: packit-service/ogr-tests!48
+                relative: '!48'
+                short: '!48'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-24T08:44:32.238Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/48
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:28.943Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:26.179Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68533151
+              iid: 47
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:26.179Z'
+              project_id: 14233409
+              reference: '!47'
+              references:
+                full: packit-service/ogr-tests!47
+                relative: '!47'
+                short: '!47'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-24T08:44:28.923Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/47
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:22.849Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:21.315Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68533146
+              iid: 46
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:21.315Z'
+              project_id: 14233409
+              reference: '!46'
+              references:
+                full: packit-service/ogr-tests!46
+                relative: '!46'
+                short: '!46'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-24T08:44:22.833Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/46
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:13.532Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:12.269Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68533133
+              iid: 45
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:12.269Z'
+              project_id: 14233409
+              reference: '!45'
+              references:
+                full: packit-service/ogr-tests!45
+                relative: '!45'
+                short: '!45'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-24T08:44:13.515Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/45
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:54.695Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:52.428Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68529235
+              iid: 44
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:52.428Z'
+              project_id: 14233409
+              reference: '!44'
+              references:
+                full: packit-service/ogr-tests!44
+                relative: '!44'
+                short: '!44'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-24T08:18:54.670Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/44
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:50.412Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:47.562Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68529229
+              iid: 43
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:47.562Z'
+              project_id: 14233409
+              reference: '!43'
+              references:
+                full: packit-service/ogr-tests!43
+                relative: '!43'
+                short: '!43'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-24T08:18:50.387Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/43
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:43.866Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:42.639Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68529220
+              iid: 42
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:42.639Z'
+              project_id: 14233409
+              reference: '!42'
+              references:
+                full: packit-service/ogr-tests!42
+                relative: '!42'
+                short: '!42'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-24T08:18:43.848Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/42
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:32.865Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:31.714Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68529205
+              iid: 41
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:31.714Z'
+              project_id: 14233409
+              reference: '!41'
+              references:
+                full: packit-service/ogr-tests!41
+                relative: '!41'
+                short: '!41'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-24T08:18:32.850Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/41
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:25.061Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:23.503Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68322048
+              iid: 40
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:23.503Z'
+              project_id: 14233409
+              reference: '!40'
+              references:
+                full: packit-service/ogr-tests!40
+                relative: '!40'
+                short: '!40'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-21T10:59:25.041Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/40
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:21.790Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:18.756Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68322043
+              iid: 39
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:18.756Z'
+              project_id: 14233409
+              reference: '!39'
+              references:
+                full: packit-service/ogr-tests!39
+                relative: '!39'
+                short: '!39'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-21T10:59:21.773Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/39
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:14.219Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:12.834Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68322035
+              iid: 38
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:12.834Z'
+              project_id: 14233409
+              reference: '!38'
+              references:
+                full: packit-service/ogr-tests!38
+                relative: '!38'
+                short: '!38'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-21T10:59:14.202Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/38
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:02.657Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:00.771Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68322018
+              iid: 37
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:00.771Z'
+              project_id: 14233409
+              reference: '!37'
+              references:
+                full: packit-service/ogr-tests!37
+                relative: '!37'
+                short: '!37'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-21T10:59:02.638Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/37
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:26:10.533Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:26:08.378Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68303260
+              iid: 36
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:26:08.378Z'
+              project_id: 14233409
+              reference: '!36'
+              references:
+                full: packit-service/ogr-tests!36
+                relative: '!36'
+                short: '!36'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-21T09:26:10.518Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/36
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:26:06.135Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:26:02.104Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68303239
+              iid: 35
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:26:02.104Z'
+              project_id: 14233409
+              reference: '!35'
+              references:
+                full: packit-service/ogr-tests!35
+                relative: '!35'
+                short: '!35'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-21T09:26:06.114Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/35
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:25:57.173Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:25:55.751Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68303222
+              iid: 34
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:25:55.751Z'
+              project_id: 14233409
+              reference: '!34'
+              references:
+                full: packit-service/ogr-tests!34
+                relative: '!34'
+                short: '!34'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-21T09:25:57.157Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/34
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:25:44.572Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:25:43.287Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68303186
+              iid: 33
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:25:43.287Z'
+              project_id: 14233409
+              reference: '!33'
+              references:
+                full: packit-service/ogr-tests!33
+                relative: '!33'
+                short: '!33'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-21T09:25:44.554Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/33
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T16:03:41.881Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T16:03:39.030Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59951889
+              iid: 32
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T16:03:39.030Z'
+              project_id: 14233409
+              reference: '!32'
+              references:
+                full: packit-service/ogr-tests!32
+                relative: '!32'
+                short: '!32'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-28T16:03:41.867Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/32
+              work_in_progress: false
+            _next: null
+            elapsed: 0.576214
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c0e00bfe04b33c-PRG
+              Connection: keep-alive
+              Content-Encoding: br
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 07:09:41 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=DfggeV%2FwLnQnycRSqlGVMhRqStC%2Fzfu56QZLYotkTf7mbw32h5iNs%2B6PLTJ4WfVmyizkeZH9wY7LRTXK1f%2Be4gytkXdagzaKbxVl6hFH2T9bcOVlnr61m0yoiBo%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"dce6e6cc887353b4be634152f94bd0bc"
+              gitlab-lb: haproxy-main-05-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=4&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '126'
+              ratelimit-remaining: '1874'
+              ratelimit-reset: '1698304241'
+              ratelimit-resettime: Thu, 26 Oct 2023 07:10:41 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"e7c234a6fb0b3c588641628dd00e19ed","version":"1"}'
+              x-next-page: '4'
+              x-page: '3'
+              x-per-page: '20'
+              x-prev-page: '2'
+              x-request-id: e7c234a6fb0b3c588641628dd00e19ed
+              x-runtime: '0.406634'
+              x-total: '84'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      ? https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=4&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false
+      : - metadata:
+            latency: 0.7964165210723877
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T15:57:17.781Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T15:57:15.997Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59951325
+              iid: 31
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T15:57:15.997Z'
+              project_id: 14233409
+              reference: '!31'
+              references:
+                full: packit-service/ogr-tests!31
+                relative: '!31'
+                short: '!31'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-05-28T15:57:17.764Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/31
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-11T12:50:59.119Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 37057948
+              iid: 3
+              labels: []
+              merge_commit_sha: 1050fc5e57a5d145ebaadb0e1748fbc1d94e7b4c
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-11T13:06:45.154Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              milestone: null
+              prepared_at: '2019-09-11T12:50:59.119Z'
+              project_id: 14233409
+              reference: '!3'
+              references:
+                full: packit-service/ogr-tests!3
+                relative: '!3'
+                short: '!3'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: change
+              updated_at: '2020-05-28T15:49:44.446Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/3
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T15:49:31.639Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T15:49:28.672Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59950182
+              iid: 30
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T15:49:28.672Z'
+              project_id: 14233409
+              reference: '!30'
+              references:
+                full: packit-service/ogr-tests!30
+                relative: '!30'
+                short: '!30'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-28T15:49:31.624Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/30
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T14:53:01.493Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T14:43:39.719Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 59942750
+              iid: 29
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T14:43:39.719Z'
+              project_id: 14233409
+              reference: '!29'
+              references:
+                full: packit-service/ogr-tests!29
+                relative: '!29'
+                short: '!29'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-28T14:53:01.452Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/29
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T14:43:25.661Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T14:43:23.207Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59942703
+              iid: 28
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T14:43:23.207Z'
+              project_id: 14233409
+              reference: '!28'
+              references:
+                full: packit-service/ogr-tests!28
+                relative: '!28'
+                short: '!28'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-05-28T14:43:25.629Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/28
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-26T10:30:55.679Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-26T10:30:53.730Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59675507
+              iid: 27
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-26T10:30:53.730Z'
+              project_id: 14233409
+              reference: '!27'
+              references:
+                full: packit-service/ogr-tests!27
+                relative: '!27'
+                short: '!27'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-05-26T10:30:55.662Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/27
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-26T10:30:52.214Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-26T10:30:50.952Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 59675500
+              iid: 26
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-26T10:30:50.952Z'
+              project_id: 14233409
+              reference: '!26'
+              references:
+                full: packit-service/ogr-tests!26
+                relative: '!26'
+                short: '!26'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-26T10:30:52.192Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/26
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-11T09:13:38.702Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 37006068
+              iid: 2
+              labels: []
+              merge_commit_sha: 13b8ff7a38426989ce7093bb97d889a8ffb9b0a2
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-11T12:04:09.318Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              milestone: null
+              prepared_at: '2019-09-11T09:13:38.702Z'
+              project_id: 14233409
+              reference: '!2'
+              references:
+                full: packit-service/ogr-tests!2
+                relative: '!2'
+                short: '!2'
+              reviewers: []
+              sha: 11b37d913374b14f8519d16c2a2cca3ebc14ac64
+              should_remove_source_branch: null
+              source_branch: pr-2
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: new
+              updated_at: '2020-05-26T10:30:43.692Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/2
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                locked: false
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2020-05-15T11:03:08.893Z'
+              description: ''
+              detailed_merge_status: broken_status
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: true
+              id: 58760686
+              iid: 25
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-15T11:03:08.893Z'
+              project_id: 14233409
+              reference: '!25'
+              references:
+                full: packit-service/ogr-tests!25
+                relative: '!25'
+                short: '!25'
+              reviewers: []
+              sha: 9ea58e21114d8ea9fdd4bdb733d3a6db1d9d244a
+              should_remove_source_branch: null
+              source_branch: lachmanfrantisek-master-patch-55321
+              source_project_id: 14255608
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: opened
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Check commit status.
+              updated_at: '2020-05-15T11:03:08.893Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/25
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2019-11-26T19:46:02.513Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2019-11-26T19:45:28.528Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 43305723
+              iid: 21
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-11-26T19:45:28.528Z'
+              project_id: 14233409
+              reference: '!21'
+              references:
+                full: packit-service/ogr-tests!21
+                relative: '!21'
+                short: '!21'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-11-26T19:46:02.482Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/21
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2019-11-26T19:44:39.087Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2019-11-26T19:44:37.895Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 43305693
+              iid: 20
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-11-26T19:44:37.895Z'
+              project_id: 14233409
+              reference: '!20'
+              references:
+                full: packit-service/ogr-tests!20
+                relative: '!20'
+                short: '!20'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-11-26T19:44:39.064Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/20
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2019-11-26T19:43:54.391Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2019-11-26T18:52:20.310Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 43301514
+              iid: 18
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-11-26T18:52:20.310Z'
+              project_id: 14233409
+              reference: '!18'
+              references:
+                full: packit-service/ogr-tests!18
+                relative: '!18'
+                short: '!18'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-11-26T19:43:54.370Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/18
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-27T08:41:50.321Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 38318253
+              iid: 17
+              labels: []
+              merge_commit_sha: 3d278426b64647aa92fb63c8d7ccdb4d8c4919ff
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-27T08:42:56.335Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              milestone: null
+              prepared_at: '2019-09-27T08:41:50.321Z'
+              project_id: 14233409
+              reference: '!17'
+              references:
+                full: packit-service/ogr-tests!17
+                relative: '!17'
+                short: '!17'
+              reviewers: []
+              sha: 6970eae72f9ecee667183f52880ca76126bd8b38
+              should_remove_source_branch: null
+              source_branch: pr-test3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Update README.md
+              updated_at: '2019-09-27T08:42:56.305Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/17
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-27T08:39:52.398Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-27T08:39:51.246Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38318126
+              iid: 16
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-27T08:39:51.246Z'
+              project_id: 14233409
+              reference: '!16'
+              references:
+                full: packit-service/ogr-tests!16
+                relative: '!16'
+                short: '!16'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-27T08:39:52.377Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/16
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-27T08:39:45.246Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-27T08:39:44.190Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38318111
+              iid: 15
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-27T08:39:44.190Z'
+              project_id: 14233409
+              reference: '!15'
+              references:
+                full: packit-service/ogr-tests!15
+                relative: '!15'
+                short: '!15'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-27T08:39:45.226Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/15
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-26T14:08:08.843Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 38258502
+              iid: 12
+              labels: []
+              merge_commit_sha: f6de56d97ec3ec74cd5194e79175162d9f969195
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-26T14:20:35.371Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              milestone: null
+              prepared_at: '2019-09-26T14:08:08.843Z'
+              project_id: 14233409
+              reference: '!12'
+              references:
+                full: packit-service/ogr-tests!12
+                relative: '!12'
+                short: '!12'
+              reviewers: []
+              sha: 2543f1728c7e1c2b8772d0dc11dc8b1870f4db60
+              should_remove_source_branch: null
+              source_branch: pr-test2
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Update README.md
+              updated_at: '2019-09-26T14:20:35.342Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/12
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T14:20:32.693Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T14:20:31.245Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38259455
+              iid: 14
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T14:20:31.245Z'
+              project_id: 14233409
+              reference: '!14'
+              references:
+                full: packit-service/ogr-tests!14
+                relative: '!14'
+                short: '!14'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-26T14:20:32.667Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/14
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T14:20:27.037Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T14:20:26.028Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38259445
+              iid: 13
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T14:20:26.028Z'
+              project_id: 14233409
+              reference: '!13'
+              references:
+                full: packit-service/ogr-tests!13
+                relative: '!13'
+                short: '!13'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-26T14:20:27.010Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/13
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-26T10:42:40.907Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 38240250
+              iid: 7
+              labels: []
+              merge_commit_sha: ff3df8288306e95ad76f803d6b9e398efe0b754d
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-26T10:55:32.234Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              milestone: null
+              prepared_at: '2019-09-26T10:42:40.907Z'
+              project_id: 14233409
+              reference: '!7'
+              references:
+                full: packit-service/ogr-tests!7
+                relative: '!7'
+                short: '!7'
+              reviewers: []
+              sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+              should_remove_source_branch: null
+              source_branch: pr-test1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Update README.md
+              updated_at: '2019-09-26T10:55:32.202Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/7
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:55:27.610Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:55:26.676Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38241250
+              iid: 11
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:55:26.676Z'
+              project_id: 14233409
+              reference: '!11'
+              references:
+                full: packit-service/ogr-tests!11
+                relative: '!11'
+                short: '!11'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-26T10:55:27.587Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/11
+              work_in_progress: false
+            _next: null
+            elapsed: 0.795025
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c0e00fccd8b33c-PRG
+              Connection: keep-alive
+              Content-Encoding: br
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 07:09:42 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=r3p0CUHIY1nQ7YLdvikconXjLu8LmMzet1nP%2FRRnzU8uO15a%2FT0%2FtcRzbDqCAPvg58tevXEQvYv86vKuEU9f%2BVpAtp6nSfbauDahe7sp7ECo0z0Ea8YhZaDR1fA%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"33cbc01fad4ece9d43be9fee0bfaf7a7"
+              gitlab-lb: haproxy-main-15-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=3&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '129'
+              ratelimit-remaining: '1872'
+              ratelimit-reset: '1698304242'
+              ratelimit-resettime: Thu, 26 Oct 2023 07:10:42 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"5387d214c51102b856805c8a3578f709","version":"1"}'
+              x-next-page: '5'
+              x-page: '4'
+              x-per-page: '20'
+              x-prev-page: '3'
+              x-request-id: 5387d214c51102b856805c8a3578f709
+              x-runtime: '0.620696'
+              x-total: '84'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      ? https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false
+      : - metadata:
+            latency: 0.49272608757019043
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:54:23.368Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:53:36.779Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38241101
+              iid: 9
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:53:36.779Z'
+              project_id: 14233409
+              reference: '!9'
+              references:
+                full: packit-service/ogr-tests!9
+                relative: '!9'
+                short: '!9'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-26T10:54:23.349Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/9
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:43:07.886Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:43:06.982Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38240288
+              iid: 8
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:43:06.982Z'
+              project_id: 14233409
+              reference: '!8'
+              references:
+                full: packit-service/ogr-tests!8
+                relative: '!8'
+                short: '!8'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-26T10:43:07.864Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/8
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:39:07.283Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:33:40.187Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38239482
+              iid: 5
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:33:40.187Z'
+              project_id: 14233409
+              reference: '!5'
+              references:
+                full: packit-service/ogr-tests!5
+                relative: '!5'
+                short: '!5'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-26T10:39:07.267Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/5
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:30:20.820Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:30:12.047Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: true
+              id: 38239261
+              iid: 4
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:30:12.047Z'
+              project_id: 14233409
+              reference: '!4'
+              references:
+                full: packit-service/ogr-tests!4
+                relative: '!4'
+                short: '!4'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'WIP: Pr 3'
+              updated_at: '2019-09-26T10:30:20.802Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/4
+              work_in_progress: false
+            _next: null
+            elapsed: 0.491657
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c0e014fcceb33c-PRG
+              Connection: keep-alive
+              Content-Encoding: br
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 07:09:43 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=LU924fJxiHTmt3NUMT7eAc0%2F5huvgCH4Zf2KqMznRrandhh9myRMPw6wpUNgGmUrP8Z%2Fr8%2B3vnKP0Akv4Yg3udl44Lp%2FEWdSOgqQV4BxYA722KJi%2FLzu6C4%2Bsqg%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"febb85a7fdd6691a107ed39866ac9adf"
+              gitlab-lb: haproxy-main-27-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=4&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '132'
+              ratelimit-remaining: '1870'
+              ratelimit-reset: '1698304242'
+              ratelimit-resettime: Thu, 26 Oct 2023 07:10:42 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"e6d340e805ae6ed0b140b2e86855e669","version":"1"}'
+              x-next-page: ''
+              x-page: '5'
+              x-per-page: '20'
+              x-prev-page: '4'
+              x-request-id: e6d340e805ae6ed0b140b2e86855e669
+              x-runtime: '0.330873'
+              x-total: '84'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://gitlab.com/api/v4/projects/14233409/merge_requests?state=all&order_by=updated_at&sort=desc:
+      - metadata:
+          latency: 0.7655141353607178
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.gitlab.pull_request
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2952463/avatar.png
+              id: 2952463
+              locked: false
+              name: Jiri Popelka
+              state: active
+              username: jpopelka
+              web_url: https://gitlab.com/jpopelka
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2022-04-29T14:19:43.343Z'
+            description: Description
+            detailed_merge_status: broken_status
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 152883878
+            iid: 86
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-04-29T14:19:43.343Z'
+            project_id: 14233409
+            reference: '!86'
+            references:
+              full: packit-service/ogr-tests!86
+              relative: '!86'
+              short: '!86'
+            reviewers: []
+            sha: db843cde94391923c6acb4cce938d830477a9732
+            should_remove_source_branch: null
+            source_branch: pr-3
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: New PR of pr-3
+            updated_at: '2022-04-29T14:19:45.492Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/86
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              locked: false
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2019-09-10T14:03:24.365Z'
+            description: description of mergerequest
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 36948617
+            iid: 1
+            labels:
+            - test_lb1
+            - test_lb2
+            merge_commit_sha: 101a42bbbe174d04b465d49caf274dc3b4defeca
+            merge_status: can_be_merged
+            merge_user:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              locked: false
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            merge_when_pipeline_succeeds: false
+            merged_at: '2019-09-11T08:55:32.822Z'
+            merged_by:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              locked: false
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            milestone: null
+            prepared_at: '2019-09-10T14:03:24.365Z'
+            project_id: 14233409
+            reference: '!1'
+            references:
+              full: packit-service/ogr-tests!1
+              relative: '!1'
+              short: '!1'
+            reviewers: []
+            sha: d490ec67dd98f69dfdc1732b98bb3189f0e0aace
+            should_remove_source_branch: null
+            source_branch: change
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: merged
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: change
+            updated_at: '2022-01-05T18:43:40.814Z'
+            upvotes: 0
+            user_notes_count: 3
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/1
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:43:09.562Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:43:08.503Z'
+            description: Description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835961
+            iid: 85
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:43:08.503Z'
+            project_id: 14233409
+            reference: '!85'
+            references:
+              full: packit-service/ogr-tests!85
+              relative: '!85'
+              short: '!85'
+            reviewers: []
+            sha: db843cde94391923c6acb4cce938d830477a9732
+            should_remove_source_branch: null
+            source_branch: pr-3
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: some special title
+            updated_at: '2022-01-05T18:43:09.539Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/85
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2019-11-26T19:39:01.381Z'
+            description: test2
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 43305101
+            iid: 19
+            labels: []
+            merge_commit_sha: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+            merge_status: can_be_merged
+            merge_user:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            merge_when_pipeline_succeeds: false
+            merged_at: '2019-11-26T19:40:49.350Z'
+            merged_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            milestone: null
+            prepared_at: '2019-11-26T19:39:01.381Z'
+            project_id: 14233409
+            reference: '!19'
+            references:
+              full: packit-service/ogr-tests!19
+              relative: '!19'
+              short: '!19'
+            reviewers: []
+            sha: 59b1a9bab5b5198c619270646410867788685c16
+            should_remove_source_branch: null
+            source_branch: test_branch
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: merged
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Got to merge something
+            updated_at: '2022-01-05T18:43:00.560Z'
+            upvotes: 0
+            user_notes_count: 2
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/19
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:42:58.565Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:42:57.361Z'
+            description: Description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835943
+            iid: 84
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:42:57.361Z'
+            project_id: 14233409
+            reference: '!84'
+            references:
+              full: packit-service/ogr-tests!84
+              relative: '!84'
+              short: '!84'
+            reviewers: []
+            sha: db843cde94391923c6acb4cce938d830477a9732
+            should_remove_source_branch: null
+            source_branch: pr-3
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: New PR of pr-3
+            updated_at: '2022-01-05T18:42:58.547Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/84
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:42:31.924Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:42:28.415Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835861
+            iid: 83
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:42:28.415Z'
+            project_id: 14233409
+            reference: '!83'
+            references:
+              full: packit-service/ogr-tests!83
+              relative: '!83'
+              short: '!83'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 20772752
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2022-01-05T18:42:31.909Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/83
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:42:22.183Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:42:20.823Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835844
+            iid: 82
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:42:20.823Z'
+            project_id: 14233409
+            reference: '!82'
+            references:
+              full: packit-service/ogr-tests!82
+              relative: '!82'
+              short: '!82'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 20772752
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork -> upstream'
+            updated_at: '2022-01-05T18:42:22.166Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/82
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-08-19T12:17:22.116Z'
+            description: 'Signed-off-by: Matej Focko <mfocko@redhat.com>'
+            detailed_merge_status: mergeable
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 113023810
+            iid: 81
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-08-19T12:17:22.116Z'
+            project_id: 14233409
+            reference: '!81'
+            references:
+              full: packit-service/ogr-tests!81
+              relative: '!81'
+              short: '!81'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Create new file for test
+            updated_at: '2021-08-19T12:17:22.116Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/81
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2020-08-28T08:46:56.751Z'
+            description: ''
+            detailed_merge_status: draft_status
+            discussion_locked: null
+            downvotes: 0
+            draft: true
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 69039752
+            iid: 52
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2020-08-28T08:46:56.751Z'
+            project_id: 14233409
+            reference: '!52'
+            references:
+              full: packit-service/ogr-tests!52
+              relative: '!52'
+              short: '!52'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: test_branch
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'Draft: Pr test1'
+            updated_at: '2021-08-19T12:17:00.957Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/52
+            work_in_progress: true
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-08-19T12:12:35.889Z'
+            description: ''
+            detailed_merge_status: broken_status
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: true
+            id: 113023110
+            iid: 80
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-08-19T12:12:35.889Z'
+            project_id: 14233409
+            reference: '!80'
+            references:
+              full: packit-service/ogr-tests!80
+              relative: '!80'
+              short: '!80'
+            reviewers: []
+            sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+            should_remove_source_branch: null
+            source_branch: test-branch1
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Adding more to README
+            updated_at: '2021-08-19T12:12:35.889Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/80
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-08-05T09:29:28.037Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2021-06-23T21:58:14.249Z'
+            description: 'Signed-off-by: Ben Crocker <bcrocker@redhat.com>'
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: true
+            has_conflicts: false
+            id: 105586464
+            iid: 78
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-23T21:58:14.249Z'
+            project_id: 14233409
+            reference: '!78'
+            references:
+              full: packit-service/ogr-tests!78
+              relative: '!78'
+              short: '!78'
+            reviewers: []
+            sha: 019a5f5e80fcc9ded82ca6ee013552c1c776f9b2
+            should_remove_source_branch: null
+            source_branch: 2-bac-conflict
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Changes based on initial commit of README.md
+            updated_at: '2021-08-05T09:29:28.003Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/78
+            work_in_progress: false
+          - allow_collaboration: false
+            allow_maintainer_to_push: false
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2952463/avatar.png
+              id: 2952463
+              locked: false
+              name: Jiri Popelka
+              state: active
+              username: jpopelka
+              web_url: https://gitlab.com/jpopelka
+            blocking_discussions_resolved: true
+            closed_at: '2021-08-03T15:01:44.866Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2952463/avatar.png
+              id: 2952463
+              locked: false
+              name: Jiri Popelka
+              state: active
+              username: jpopelka
+              web_url: https://gitlab.com/jpopelka
+            created_at: '2021-06-24T12:21:59.290Z'
+            description: This MR can't be merged because of a conflict.
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: true
+            has_conflicts: true
+            id: 105673770
+            iid: 79
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-24T12:21:59.290Z'
+            project_id: 14233409
+            reference: '!79'
+            references:
+              full: packit-service/ogr-tests!79
+              relative: '!79'
+              short: '!79'
+            reviewers: []
+            sha: 45e3737aea87a9fd14adcf6a42070cb4f8665ada
+            should_remove_source_branch: null
+            source_branch: create-conflict
+            source_project_id: null
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Conflict
+            updated_at: '2021-08-03T15:01:44.485Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/79
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-06-23T17:49:13.269Z'
+            description: 'Signed-off-by: Ben Crocker <bcrocker@redhat.com>'
+            detailed_merge_status: mergeable
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: true
+            has_conflicts: false
+            id: 105564125
+            iid: 77
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-23T17:49:13.269Z'
+            project_id: 14233409
+            reference: '!77'
+            references:
+              full: packit-service/ogr-tests!77
+              relative: '!77'
+              short: '!77'
+            reviewers: []
+            sha: 6592475b6f0cd952a4626247a8acb9e250810d29
+            should_remove_source_branch: null
+            source_branch: 1-bac-test
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: bac.txt initial 2-liner
+            updated_at: '2021-06-23T21:35:05.438Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/77
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-06-23T15:04:45.476Z'
+            description: 'Signed-off-by: Ben Crocker <bcrocker@redhat.com>'
+            detailed_merge_status: draft_status
+            discussion_locked: null
+            downvotes: 0
+            draft: true
+            force_remove_source_branch: true
+            has_conflicts: false
+            id: 105544200
+            iid: 76
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-23T15:04:45.476Z'
+            project_id: 14233409
+            reference: '!76'
+            references:
+              full: packit-service/ogr-tests!76
+              relative: '!76'
+              short: '!76'
+            reviewers: []
+            sha: 60c6e2fd8f08077105fda8008b7954ee2c04bef6
+            should_remove_source_branch: null
+            source_branch: bac-test-1
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'Draft: Changed based on commit 257ce9fd8c5421d2e116337847710ba70d215aa6'
+            updated_at: '2021-06-23T15:04:45.476Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/76
+            work_in_progress: true
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T23:48:22.978Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T23:48:20.283Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104993952
+            iid: 75
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T23:48:20.283Z'
+            project_id: 14233409
+            reference: '!75'
+            references:
+              full: packit-service/ogr-tests!75
+              relative: '!75'
+              short: '!75'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2021-06-18T23:48:22.963Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/75
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T23:48:16.336Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T23:48:15.185Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104993949
+            iid: 74
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T23:48:15.185Z'
+            project_id: 14233409
+            reference: '!74'
+            references:
+              full: packit-service/ogr-tests!74
+              relative: '!74'
+              short: '!74'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork -> upstream'
+            updated_at: '2021-06-18T23:48:16.318Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/74
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T14:26:22.041Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T14:26:19.129Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104941511
+            iid: 73
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T14:26:19.129Z'
+            project_id: 14233409
+            reference: '!73'
+            references:
+              full: packit-service/ogr-tests!73
+              relative: '!73'
+              short: '!73'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2021-06-18T14:26:22.019Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/73
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T14:26:09.759Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T14:26:07.435Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104941489
+            iid: 72
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T14:26:07.435Z'
+            project_id: 14233409
+            reference: '!72'
+            references:
+              full: packit-service/ogr-tests!72
+              relative: '!72'
+              short: '!72'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork -> upstream'
+            updated_at: '2021-06-18T14:26:09.686Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/72
+            work_in_progress: false
+          - allow_collaboration: false
+            allow_maintainer_to_push: false
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/96d32a99efb796de3669943fcf6e5bbb?s=80&d=identicon
+              id: 551273
+              locked: false
+              name: csomh
+              state: active
+              username: csomh
+              web_url: https://gitlab.com/csomh
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-04-27T07:13:34.828Z'
+            description: "Signed-off-by: Hunor Csomort\xE1ni <csomh@redhat.com>"
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: true
+            has_conflicts: false
+            id: 97512283
+            iid: 71
+            labels: []
+            merge_commit_sha: dd9b6c54c0788301c86bdf058a8e91e3594a0a17
+            merge_status: can_be_merged
+            merge_user:
+              avatar_url: https://secure.gravatar.com/avatar/96d32a99efb796de3669943fcf6e5bbb?s=80&d=identicon
+              id: 551273
+              locked: false
+              name: csomh
+              state: active
+              username: csomh
+              web_url: https://gitlab.com/csomh
+            merge_when_pipeline_succeeds: false
+            merged_at: '2021-04-27T07:18:37.595Z'
+            merged_by:
+              avatar_url: https://secure.gravatar.com/avatar/96d32a99efb796de3669943fcf6e5bbb?s=80&d=identicon
+              id: 551273
+              locked: false
+              name: csomh
+              state: active
+              username: csomh
+              web_url: https://gitlab.com/csomh
+            milestone: null
+            prepared_at: '2021-04-27T07:13:34.828Z'
+            project_id: 14233409
+            reference: '!71'
+            references:
+              full: packit-service/ogr-tests!71
+              relative: '!71'
+              short: '!71'
+            reviewers: []
+            sha: 5dd0a9a1f5b9d3bf820e8849c4be7aafcbe9a8c7
+            should_remove_source_branch: null
+            source_branch: test-mr-merge
+            source_project_id: null
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: merged
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Comit to test merging MRs
+            updated_at: '2021-04-27T07:18:37.563Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/71
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-04-12T21:12:00.702Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-04-12T21:11:58.877Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 95613812
+            iid: 70
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-04-12T21:11:58.877Z'
+            project_id: 14233409
+            reference: '!70'
+            references:
+              full: packit-service/ogr-tests!70
+              relative: '!70'
+              short: '!70'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2021-04-12T21:12:00.644Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/70
+            work_in_progress: false
+          _next: null
+          elapsed: 0.764586
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 81c0dffeb80ab33c-PRG
+            Connection: keep-alive
+            Content-Encoding: br
+            Content-Type: application/json
+            Date: Thu, 26 Oct 2023 07:09:39 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=YoU2VQtSd3eNZLGSk1G2egDomYkcqif3FjRc7Y8anDU8jdX2wPOx%2BLFy%2F6EpVVPy%2By8dAAddH1pbgEIvJ3JJ83YQhqYF4aT3I3Y4b4AdoIbrv5uXQVlKwEtpsQ4%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"193c7192fe23d405c4af807259f1d864"
+            gitlab-lb: haproxy-main-32-lb-gprd
+            gitlab-sv: localhost
+            link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+              rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+              rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+              rel="last"
+            ratelimit-limit: '2000'
+            ratelimit-observed: '121'
+            ratelimit-remaining: '1880'
+            ratelimit-reset: '1698304239'
+            ratelimit-resettime: Thu, 26 Oct 2023 07:10:39 GMT
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"023b8a06101fcf0af351d487c0bfe735","version":"1"}'
+            x-next-page: '2'
+            x-page: '1'
+            x-per-page: '20'
+            x-prev-page: ''
+            x-request-id: 023b8a06101fcf0af351d487c0bfe735
+            x-runtime: '0.599752'
+            x-total: '84'
+            x-total-pages: '5'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.31386280059814453
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              cluster_agents: https://gitlab.com/api/v4/projects/14233409/cluster_agents
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_allow_fork_pipelines_to_run_in_parent_project: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_forward_deployment_rollback_allowed: true
+            ci_job_token_scope_enabled: false
+            ci_separated_caches: true
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            description_html: <p data-sourcepos="1:1-1:84" dir="auto">Testing repository
+              for python-ogr package.  |  <a href="https://github.com/packit-service/ogr"
+              rel="nofollow noreferrer noopener" target="_blank">https://github.com/packit-service/ogr</a></p>
+            emails_disabled: false
+            emails_enabled: true
+            empty_repo: false
+            enforce_auth_checks_on_uploads: true
+            environments_access_level: enabled
+            external_authorization_classification_label: ''
+            feature_flags_access_level: enabled
+            forking_access_level: enabled
+            forks_count: 6
+            group_runners_enabled: true
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_error: null
+            import_status: none
+            import_type: null
+            import_url: null
+            infrastructure_access_level: enabled
+            issue_branch_template: null
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2022-08-21T21:46:59.990Z'
+            lfs_enabled: true
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            model_experiments_access_level: enabled
+            monitor_access_level: enabled
+            name: ogr-tests
+            name_with_namespace: packit-service / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: packit-service
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 77
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access:
+                access_level: 50
+                notification_level: 3
+              project_access:
+                access_level: 40
+                notification_level: 3
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            releases_access_level: enabled
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runner_token_expiration_interval: null
+            runners_token: GR1348941sWEgsQKmwrxmdNipZmMH
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            updated_at: '2022-08-21T21:46:59.990Z'
+            visibility: public
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.313006
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 81c0dffc9c10b33c-PRG
+            Connection: keep-alive
+            Content-Encoding: br
+            Content-Type: application/json
+            Date: Thu, 26 Oct 2023 07:09:38 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Z%2BLg1G8z8iUTdOX%2BKEAmkbgT1h43xP6iOaX7fdzxJXbmNB9OVra5TyNbsgL2n%2Fz%2Bk60jaa9TKnM0fu8g5mftZp9j00ZuAEg8dypn4UIUFSrHun7nlvVIpu8QRe8%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"ef8a248fe18b88c502cc31c92be567fb"
+            gitlab-lb: haproxy-main-21-lb-gprd
+            gitlab-sv: localhost
+            ratelimit-limit: '2000'
+            ratelimit-observed: '118'
+            ratelimit-remaining: '1882'
+            ratelimit-reset: '1698304238'
+            ratelimit-resettime: Thu, 26 Oct 2023 07:10:38 GMT
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"01481e40d3bffe1e0d4255639b7fd899","version":"1"}'
+            x-request-id: 01481e40d3bffe1e0d4255639b7fd899
+            x-runtime: '0.144130'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.2541370391845703
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.v4.objects.users
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://secure.gravatar.com/avatar/86a332a848dc6260af0575f55ce1f499?s=80&d=identicon
+            bio: ''
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 4
+            commit_email: ttomecek@redhat.com
+            confirmed_at: '2016-09-22T07:20:22.540Z'
+            created_at: '2016-09-22T07:20:22.656Z'
+            current_sign_in_at: '2023-10-22T14:47:12.012Z'
+            discord: ''
+            email: ttomecek@redhat.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            id: 737640
+            identities:
+            - extern_uid: ttomecek
+              provider: group_saml
+              saml_provider_id: 2868
+            - extern_uid: 7b7b2dac-0d75-11e7-b082-28d244ea5a6d
+              provider: group_saml
+              saml_provider_id: 1769
+            - extern_uid: '1662493'
+              provider: github
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2023-10-26'
+            last_sign_in_at: '2023-09-14T08:18:57.131Z'
+            linkedin: ''
+            local_time: null
+            location: ''
+            locked: false
+            name: Tomas Tomecek
+            organization: ''
+            private_profile: false
+            projects_limit: 100000
+            pronouns: null
+            public_email: ''
+            scim_identities: []
+            shared_runners_minutes_limit: 2000
+            skype: ''
+            state: active
+            theme_id: 2
+            twitter: ''
+            two_factor_enabled: true
+            username: TomasTomecek
+            web_url: https://gitlab.com/TomasTomecek
+            website_url: ''
+            work_information: null
+          _next: null
+          elapsed: 0.252648
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 81c0dffaf903b33c-PRG
+            Connection: keep-alive
+            Content-Encoding: br
+            Content-Type: application/json
+            Date: Thu, 26 Oct 2023 07:09:38 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=9lqhen4QWmD8888888888888888888888888888kC5pVN5aoPDeJWtFxc7O3Uc0WsjgEEzP0QiV%2FqM999999999999999999999905wALGwj68xnfJGO95w4SBOZg%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Set-Cookie: _cfuvid=G0QGfDPNn3O_tGyytDQGy0666666666666664zqDK6g-1698377777712-0-604800000;
+              path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"86740b59f8eb3c7045666666666160c9"
+            gitlab-lb: haproxy-main-27-lb-gprd
+            gitlab-sv: localhost
+            ratelimit-limit: '2000'
+            ratelimit-observed: '116'
+            ratelimit-remaining: '1884'
+            ratelimit-reset: '1698304238'
+            ratelimit-resettime: Thu, 26 Oct 2023 07:10:38 GMT
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"d41c5f9f4666666666666615d53c5785","version":"1"}'
+            x-request-id: d41c5f9f4b666666457dd015d53c5666
+            x-runtime: '0.052445'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_mr_list_limit.yaml
+++ b/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_mr_list_limit.yaml
@@ -1514,6 +1514,1525 @@ requests.sessions:
             raw: !!binary ""
             reason: OK
             status_code: 200
+        - metadata:
+            latency: 0.7308533191680908
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/96d32a99efb796de3669943fcf6e5bbb?s=80&d=identicon
+                id: 551273
+                locked: false
+                name: csomh
+                state: active
+                username: csomh
+                web_url: https://gitlab.com/csomh
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2021-04-27T07:13:34.828Z'
+              description: "Signed-off-by: Hunor Csomort\xE1ni <csomh@redhat.com>"
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: true
+              has_conflicts: false
+              id: 97512283
+              iid: 71
+              labels: []
+              merge_commit_sha: dd9b6c54c0788301c86bdf058a8e91e3594a0a17
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/96d32a99efb796de3669943fcf6e5bbb?s=80&d=identicon
+                id: 551273
+                locked: false
+                name: csomh
+                state: active
+                username: csomh
+                web_url: https://gitlab.com/csomh
+              merge_when_pipeline_succeeds: false
+              merged_at: '2021-04-27T07:18:37.595Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/96d32a99efb796de3669943fcf6e5bbb?s=80&d=identicon
+                id: 551273
+                locked: false
+                name: csomh
+                state: active
+                username: csomh
+                web_url: https://gitlab.com/csomh
+              milestone: null
+              prepared_at: '2021-04-27T07:13:34.828Z'
+              project_id: 14233409
+              reference: '!71'
+              references:
+                full: packit-service/ogr-tests!71
+                relative: '!71'
+                short: '!71'
+              reviewers: []
+              sha: 5dd0a9a1f5b9d3bf820e8849c4be7aafcbe9a8c7
+              should_remove_source_branch: null
+              source_branch: test-mr-merge
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Comit to test merging MRs
+              updated_at: '2021-04-27T07:18:37.563Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/71
+              work_in_progress: false
+            - allow_collaboration: true
+              allow_maintainer_to_push: true
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+                id: 6466632
+                locked: false
+                name: Ben Crocker
+                state: active
+                username: bcrocker
+                web_url: https://gitlab.com/bcrocker
+              blocking_discussions_resolved: true
+              closed_at: '2021-04-12T21:12:00.702Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+                id: 6466632
+                locked: false
+                name: Ben Crocker
+                state: active
+                username: bcrocker
+                web_url: https://gitlab.com/bcrocker
+              created_at: '2021-04-12T21:11:58.877Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 95613812
+              iid: 70
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2021-04-12T21:11:58.877Z'
+              project_id: 14233409
+              reference: '!70'
+              references:
+                full: packit-service/ogr-tests!70
+                relative: '!70'
+                short: '!70'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 25840586
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2021-04-12T21:12:00.644Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/70
+              work_in_progress: false
+            - allow_collaboration: true
+              allow_maintainer_to_push: true
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+                id: 6466632
+                locked: false
+                name: Ben Crocker
+                state: active
+                username: bcrocker
+                web_url: https://gitlab.com/bcrocker
+              blocking_discussions_resolved: true
+              closed_at: '2021-04-12T21:11:54.865Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+                id: 6466632
+                locked: false
+                name: Ben Crocker
+                state: active
+                username: bcrocker
+                web_url: https://gitlab.com/bcrocker
+              created_at: '2021-04-12T21:11:53.700Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 95613808
+              iid: 69
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2021-04-12T21:11:53.700Z'
+              project_id: 14233409
+              reference: '!69'
+              references:
+                full: packit-service/ogr-tests!69
+                relative: '!69'
+                short: '!69'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 25840586
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2021-04-12T21:11:54.843Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/69
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:29:00.315Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:59.493Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049229
+              iid: 68
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:59.493Z'
+              project_id: 14233409
+              reference: '!68'
+              references:
+                full: packit-service/ogr-tests!68
+                relative: '!68'
+                short: '!68'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2020-10-12T10:29:00.300Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/68
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:49.714Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:48.412Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049201
+              iid: 67
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:48.412Z'
+              project_id: 14233409
+              reference: '!67'
+              references:
+                full: packit-service/ogr-tests!67
+                relative: '!67'
+                short: '!67'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2020-10-12T10:28:49.698Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/67
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:33.601Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:32.071Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 74049173
+              iid: 66
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:32.071Z'
+              project_id: 14233409
+              reference: '!66'
+              references:
+                full: packit-service/ogr-tests!66
+                relative: '!66'
+                short: '!66'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-10-12T10:28:33.584Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/66
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:29.406Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:26.977Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049163
+              iid: 65
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:26.977Z'
+              project_id: 14233409
+              reference: '!65'
+              references:
+                full: packit-service/ogr-tests!65
+                relative: '!65'
+                short: '!65'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-10-12T10:28:29.392Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/65
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-10-12T10:28:22.684Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-10-12T10:28:21.327Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 74049145
+              iid: 64
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-10-12T10:28:21.327Z'
+              project_id: 14233409
+              reference: '!64'
+              references:
+                full: packit-service/ogr-tests!64
+                relative: '!64'
+                short: '!64'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-10-12T10:28:22.668Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/64
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-09-03T09:53:44.881Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-09-03T09:50:58.837Z'
+              description: pull request body
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69664587
+              iid: 63
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-09-03T09:50:58.837Z'
+              project_id: 14233409
+              reference: '!63'
+              references:
+                full: packit-service/ogr-tests!63
+                relative: '!63'
+                short: '!63'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test: fork(master) <- fork'
+              updated_at: '2020-09-03T09:53:44.859Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/63
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-09-03T09:50:05.870Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:11:32.195Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042578
+              iid: 59
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:11:32.195Z'
+              project_id: 14233409
+              reference: '!59'
+              references:
+                full: packit-service/ogr-tests!59
+                relative: '!59'
+                short: '!59'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-09-03T09:50:05.844Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/59
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-31T08:34:29.197Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-31T08:34:28.114Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69198741
+              iid: 62
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-31T08:34:28.114Z'
+              project_id: 14233409
+              reference: '!62'
+              references:
+                full: packit-service/ogr-tests!62
+                relative: '!62'
+                short: '!62'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2020-08-31T08:34:29.180Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/62
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-31T08:34:22.758Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-31T08:34:22.004Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69198731
+              iid: 61
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-31T08:34:22.004Z'
+              project_id: 14233409
+              reference: '!61'
+              references:
+                full: packit-service/ogr-tests!61
+                relative: '!61'
+                short: '!61'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2020-08-31T08:34:22.744Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/61
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-31T08:34:10.164Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-31T08:34:08.657Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 69198715
+              iid: 60
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-31T08:34:08.657Z'
+              project_id: 14233409
+              reference: '!60'
+              references:
+                full: packit-service/ogr-tests!60
+                relative: '!60'
+                short: '!60'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-31T08:34:10.147Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/60
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:11:01.258Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:09:45.221Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042373
+              iid: 58
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:09:45.221Z'
+              project_id: 14233409
+              reference: '!58'
+              references:
+                full: packit-service/ogr-tests!58
+                relative: '!58'
+                short: '!58'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-28T09:11:01.241Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/58
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:09:26.747Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:08:53.394Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042267
+              iid: 57
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:08:53.394Z'
+              project_id: 14233409
+              reference: '!57'
+              references:
+                full: packit-service/ogr-tests!57
+                relative: '!57'
+                short: '!57'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-28T09:09:26.730Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/57
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:08:25.387Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:08:00.355Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69042182
+              iid: 56
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:08:00.355Z'
+              project_id: 14233409
+              reference: '!56'
+              references:
+                full: packit-service/ogr-tests!56
+                relative: '!56'
+                short: '!56'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-28T09:08:25.354Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/56
+              work_in_progress: false
+            - allow_collaboration: null
+              allow_maintainer_to_push: null
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T09:05:12.861Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T09:05:11.433Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69041783
+              iid: 55
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T09:05:11.433Z'
+              project_id: 14233409
+              reference: '!55'
+              references:
+                full: packit-service/ogr-tests!55
+                relative: '!55'
+                short: '!55'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> other_fork'
+              updated_at: '2020-08-28T09:05:12.823Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/55
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2020-08-28T08:54:42.124Z'
+              description: ''
+              detailed_merge_status: draft_status
+              discussion_locked: null
+              downvotes: 0
+              draft: true
+              force_remove_source_branch: true
+              has_conflicts: true
+              id: 69040653
+              iid: 54
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T08:54:42.124Z'
+              project_id: 14233409
+              reference: '!54'
+              references:
+                full: packit-service/ogr-tests!54
+                relative: '!54'
+                short: '!54'
+              reviewers: []
+              sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+              should_remove_source_branch: null
+              source_branch: pr-test1
+              source_project_id: 20772752
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: opened
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'Draft: Pr test1'
+              updated_at: '2020-08-28T08:54:42.124Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/54
+              work_in_progress: true
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2020-08-28T08:49:02.322Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 69040003
+              iid: 53
+              labels: []
+              merge_commit_sha: 353361738fdefd9cd4f9fd669fa1c5792b9fe299
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              merge_when_pipeline_succeeds: false
+              merged_at: '2020-08-28T08:51:03.924Z'
+              merged_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              milestone: null
+              prepared_at: '2020-08-28T08:49:02.322Z'
+              project_id: 14233409
+              reference: '!53'
+              references:
+                full: packit-service/ogr-tests!53
+                relative: '!53'
+                short: '!53'
+              reviewers: []
+              sha: 59b1a9bab5b5198c619270646410867788685c16
+              should_remove_source_branch: null
+              source_branch: test_branch
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: pr-test1
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Test branch
+              updated_at: '2020-08-28T08:51:03.883Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/53
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T08:46:17.711Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T08:46:16.866Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69039661
+              iid: 51
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T08:46:16.866Z'
+              project_id: 14233409
+              reference: '!51'
+              references:
+                full: packit-service/ogr-tests!51
+                relative: '!51'
+                short: '!51'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2020-08-28T08:46:17.690Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/51
+              work_in_progress: false
+            _next: null
+            elapsed: 0.730396
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c1ec622920b335-PRG
+              Connection: keep-alive
+              Content-Encoding: gzip
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 10:12:52 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=YTTMwriqIH1DwPs1Nab38JEzXBBRh1VtRHFnHxgpg6LQMofY7R1tSTjiDItszGI62pc1ra9YQzos4WLlt3umtL8J9x4oVOBJhmUoTk4lphLmvSQiLmKwi7De4oY%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"8f966280de986f43bbb7994d4141cb4d"
+              gitlab-lb: haproxy-main-05-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=3&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '102'
+              ratelimit-remaining: '1897'
+              ratelimit-reset: '1698315232'
+              ratelimit-resettime: Thu, 26 Oct 2023 10:13:52 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"1e1113c8a3f6d5c0cf67de801d404197","version":"1"}'
+              x-next-page: '3'
+              x-page: '2'
+              x-per-page: '20'
+              x-prev-page: '1'
+              x-request-id: 1e1113c8a3f6d5c0cf67de801d404197
+              x-runtime: '0.566189'
+              x-total: '86'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
       ? https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=3&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false
       : - metadata:
             latency: 0.5786917209625244
@@ -3031,6 +4550,1522 @@ requests.sessions:
               x-request-id: e7c234a6fb0b3c588641628dd00e19ed
               x-runtime: '0.406634'
               x-total: '84'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+        - metadata:
+            latency: 0.9149799346923828
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T08:45:39.619Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-08-28T08:45:38.273Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 69039593
+              iid: 50
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-28T08:45:38.273Z'
+              project_id: 14233409
+              reference: '!50'
+              references:
+                full: packit-service/ogr-tests!50
+                relative: '!50'
+                short: '!50'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2020-08-28T08:45:39.600Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/50
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-28T08:45:16.144Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-04-28T19:17:22.548Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: true
+              id: 57207332
+              iid: 23
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-04-28T19:17:22.548Z'
+              project_id: 14233409
+              reference: '!23'
+              references:
+                full: packit-service/ogr-tests!23
+                relative: '!23'
+                short: '!23'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'WIP: Pr 3'
+              updated_at: '2020-08-28T08:45:16.118Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/23
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-27T09:58:27.607Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-04-28T19:27:39.008Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: true
+              has_conflicts: true
+              id: 57208001
+              iid: 24
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-04-28T19:27:39.008Z'
+              project_id: 14233409
+              reference: '!24'
+              references:
+                full: packit-service/ogr-tests!24
+                relative: '!24'
+                short: '!24'
+              reviewers: []
+              sha: 6970eae72f9ecee667183f52880ca76126bd8b38
+              should_remove_source_branch: null
+              source_branch: pr-test3
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'WIP: Pr test3'
+              updated_at: '2020-08-27T09:58:27.495Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/24
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-27T09:58:25.268Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-04-27T21:39:58.418Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: true
+              has_conflicts: true
+              id: 57082404
+              iid: 22
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-04-27T21:39:58.418Z'
+              project_id: 14233409
+              reference: '!22'
+              references:
+                full: packit-service/ogr-tests!22
+                relative: '!22'
+                short: '!22'
+              reviewers: []
+              sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+              should_remove_source_branch: null
+              source_branch: pr-test1
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: gotta try with fork
+              updated_at: '2020-08-27T09:58:24.777Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/22
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T13:42:35.236Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T13:42:33.694Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68570514
+              iid: 49
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T13:42:33.694Z'
+              project_id: 14233409
+              reference: '!49'
+              references:
+                full: packit-service/ogr-tests!49
+                relative: '!49'
+                short: '!49'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> other_fork'
+              updated_at: '2020-08-24T13:42:35.220Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/49
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:32.268Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:30.490Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68533159
+              iid: 48
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:30.490Z'
+              project_id: 14233409
+              reference: '!48'
+              references:
+                full: packit-service/ogr-tests!48
+                relative: '!48'
+                short: '!48'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-24T08:44:32.238Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/48
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:28.943Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:26.179Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68533151
+              iid: 47
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:26.179Z'
+              project_id: 14233409
+              reference: '!47'
+              references:
+                full: packit-service/ogr-tests!47
+                relative: '!47'
+                short: '!47'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-24T08:44:28.923Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/47
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:22.849Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:21.315Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68533146
+              iid: 46
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:21.315Z'
+              project_id: 14233409
+              reference: '!46'
+              references:
+                full: packit-service/ogr-tests!46
+                relative: '!46'
+                short: '!46'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-24T08:44:22.833Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/46
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:44:13.532Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:44:12.269Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68533133
+              iid: 45
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:44:12.269Z'
+              project_id: 14233409
+              reference: '!45'
+              references:
+                full: packit-service/ogr-tests!45
+                relative: '!45'
+                short: '!45'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-24T08:44:13.515Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/45
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:54.695Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:52.428Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68529235
+              iid: 44
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:52.428Z'
+              project_id: 14233409
+              reference: '!44'
+              references:
+                full: packit-service/ogr-tests!44
+                relative: '!44'
+                short: '!44'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-24T08:18:54.670Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/44
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:50.412Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:47.562Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68529229
+              iid: 43
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:47.562Z'
+              project_id: 14233409
+              reference: '!43'
+              references:
+                full: packit-service/ogr-tests!43
+                relative: '!43'
+                short: '!43'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-24T08:18:50.387Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/43
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:43.866Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:42.639Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68529220
+              iid: 42
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:42.639Z'
+              project_id: 14233409
+              reference: '!42'
+              references:
+                full: packit-service/ogr-tests!42
+                relative: '!42'
+                short: '!42'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-24T08:18:43.848Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/42
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-24T08:18:32.865Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-24T08:18:31.714Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68529205
+              iid: 41
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-24T08:18:31.714Z'
+              project_id: 14233409
+              reference: '!41'
+              references:
+                full: packit-service/ogr-tests!41
+                relative: '!41'
+                short: '!41'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-24T08:18:32.850Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/41
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:25.061Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:23.503Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68322048
+              iid: 40
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:23.503Z'
+              project_id: 14233409
+              reference: '!40'
+              references:
+                full: packit-service/ogr-tests!40
+                relative: '!40'
+                short: '!40'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-21T10:59:25.041Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/40
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:21.790Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:18.756Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68322043
+              iid: 39
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:18.756Z'
+              project_id: 14233409
+              reference: '!39'
+              references:
+                full: packit-service/ogr-tests!39
+                relative: '!39'
+                short: '!39'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-21T10:59:21.773Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/39
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:14.219Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:12.834Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68322035
+              iid: 38
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:12.834Z'
+              project_id: 14233409
+              reference: '!38'
+              references:
+                full: packit-service/ogr-tests!38
+                relative: '!38'
+                short: '!38'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-21T10:59:14.202Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/38
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T10:59:02.657Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T10:59:00.771Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68322018
+              iid: 37
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T10:59:00.771Z'
+              project_id: 14233409
+              reference: '!37'
+              references:
+                full: packit-service/ogr-tests!37
+                relative: '!37'
+                short: '!37'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-21T10:59:02.638Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/37
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:26:10.533Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:26:08.378Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 68303260
+              iid: 36
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:26:08.378Z'
+              project_id: 14233409
+              reference: '!36'
+              references:
+                full: packit-service/ogr-tests!36
+                relative: '!36'
+                short: '!36'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-08-21T09:26:10.518Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/36
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:26:06.135Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:26:02.104Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68303239
+              iid: 35
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:26:02.104Z'
+              project_id: 14233409
+              reference: '!35'
+              references:
+                full: packit-service/ogr-tests!35
+                relative: '!35'
+                short: '!35'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-08-21T09:26:06.114Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/35
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:25:57.173Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:25:55.751Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68303222
+              iid: 34
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:25:55.751Z'
+              project_id: 14233409
+              reference: '!34'
+              references:
+                full: packit-service/ogr-tests!34
+                relative: '!34'
+                short: '!34'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-08-21T09:25:57.157Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/34
+              work_in_progress: false
+            _next: null
+            elapsed: 0.912894
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c1ec66b969b335-PRG
+              Connection: keep-alive
+              Content-Encoding: gzip
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 10:12:53 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=Wdl7mI8taTvkyyNNbmAwqWf8X6jFfK28bIc2P8jiKr16cqnwsY7BRznkMNK32X04YQyvMuiRmWrAs%2B%2BiUKb25YdY6F4LKth7l3EvPqmtMZIAB%2FNZV%2F32gzQOmk4%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"6260922bc38569cc58590fa1044e02d6"
+              gitlab-lb: haproxy-main-16-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=4&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '102'
+              ratelimit-remaining: '1898'
+              ratelimit-reset: '1698315233'
+              ratelimit-resettime: Thu, 26 Oct 2023 10:13:53 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"dab238660888f41e683159be563637c9","version":"1"}'
+              x-next-page: '4'
+              x-page: '3'
+              x-per-page: '20'
+              x-prev-page: '2'
+              x-request-id: dab238660888f41e683159be563637c9
+              x-runtime: '0.383707'
+              x-total: '86'
               x-total-pages: '5'
             raw: !!binary ""
             reason: OK
@@ -4560,6 +7595,1527 @@ requests.sessions:
             raw: !!binary ""
             reason: OK
             status_code: 200
+        - metadata:
+            latency: 1.149815320968628
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2020-08-21T09:25:44.572Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2020-08-21T09:25:43.287Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 68303186
+              iid: 33
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-08-21T09:25:43.287Z'
+              project_id: 14233409
+              reference: '!33'
+              references:
+                full: packit-service/ogr-tests!33
+                relative: '!33'
+                short: '!33'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-08-21T09:25:44.554Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/33
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T16:03:41.881Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T16:03:39.030Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59951889
+              iid: 32
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T16:03:39.030Z'
+              project_id: 14233409
+              reference: '!32'
+              references:
+                full: packit-service/ogr-tests!32
+                relative: '!32'
+                short: '!32'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-28T16:03:41.867Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/32
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T15:57:17.781Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T15:57:15.997Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59951325
+              iid: 31
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T15:57:15.997Z'
+              project_id: 14233409
+              reference: '!31'
+              references:
+                full: packit-service/ogr-tests!31
+                relative: '!31'
+                short: '!31'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream (user ignored)'
+              updated_at: '2020-05-28T15:57:17.764Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/31
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-11T12:50:59.119Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 37057948
+              iid: 3
+              labels: []
+              merge_commit_sha: 1050fc5e57a5d145ebaadb0e1748fbc1d94e7b4c
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-11T13:06:45.154Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              milestone: null
+              prepared_at: '2019-09-11T12:50:59.119Z'
+              project_id: 14233409
+              reference: '!3'
+              references:
+                full: packit-service/ogr-tests!3
+                relative: '!3'
+                short: '!3'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: change
+              updated_at: '2020-05-28T15:49:44.446Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/3
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T15:49:31.639Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T15:49:28.672Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59950182
+              iid: 30
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T15:49:28.672Z'
+              project_id: 14233409
+              reference: '!30'
+              references:
+                full: packit-service/ogr-tests!30
+                relative: '!30'
+                short: '!30'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-28T15:49:31.624Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/30
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T14:53:01.493Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T14:43:39.719Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 59942750
+              iid: 29
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T14:43:39.719Z'
+              project_id: 14233409
+              reference: '!29'
+              references:
+                full: packit-service/ogr-tests!29
+                relative: '!29'
+                short: '!29'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-28T14:53:01.452Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/29
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-28T14:43:25.661Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-28T14:43:23.207Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59942703
+              iid: 28
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-28T14:43:23.207Z'
+              project_id: 14233409
+              reference: '!28'
+              references:
+                full: packit-service/ogr-tests!28
+                relative: '!28'
+                short: '!28'
+              reviewers: []
+              sha: 0ac77ed9a2b331b60ad6bc254c8592ca65096a4f
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: null
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork -> upstream'
+              updated_at: '2020-05-28T14:43:25.629Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/28
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-26T10:30:55.679Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-26T10:30:53.730Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: false
+              id: 59675507
+              iid: 27
+              labels: []
+              merge_commit_sha: null
+              merge_status: can_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-26T10:30:53.730Z'
+              project_id: 14233409
+              reference: '!27'
+              references:
+                full: packit-service/ogr-tests!27
+                relative: '!27'
+                short: '!27'
+              reviewers: []
+              sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+              should_remove_source_branch: null
+              source_branch: test-branch1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: upstream -> upstream'
+              updated_at: '2020-05-26T10:30:55.662Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/27
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2020-05-26T10:30:52.214Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2020-05-26T10:30:50.952Z'
+              description: test description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 59675500
+              iid: 26
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-26T10:30:50.952Z'
+              project_id: 14233409
+              reference: '!26'
+              references:
+                full: packit-service/ogr-tests!26
+                relative: '!26'
+                short: '!26'
+              reviewers: []
+              sha: null
+              should_remove_source_branch: null
+              source_branch: one-more-branch
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'test PR: fork:one-more-branch -> upstream'
+              updated_at: '2020-05-26T10:30:52.192Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/26
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-11T09:13:38.702Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 37006068
+              iid: 2
+              labels: []
+              merge_commit_sha: 13b8ff7a38426989ce7093bb97d889a8ffb9b0a2
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-11T12:04:09.318Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              milestone: null
+              prepared_at: '2019-09-11T09:13:38.702Z'
+              project_id: 14233409
+              reference: '!2'
+              references:
+                full: packit-service/ogr-tests!2
+                relative: '!2'
+                short: '!2'
+              reviewers: []
+              sha: 11b37d913374b14f8519d16c2a2cca3ebc14ac64
+              should_remove_source_branch: null
+              source_branch: pr-2
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: new
+              updated_at: '2020-05-26T10:30:43.692Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/2
+              work_in_progress: false
+            - allow_collaboration: false
+              allow_maintainer_to_push: false
+              approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/5a2e7f6710bff47b94d24b44b55fd7f7?s=80&d=identicon
+                id: 433670
+                locked: false
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2020-05-15T11:03:08.893Z'
+              description: ''
+              detailed_merge_status: broken_status
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: true
+              id: 58760686
+              iid: 25
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2020-05-15T11:03:08.893Z'
+              project_id: 14233409
+              reference: '!25'
+              references:
+                full: packit-service/ogr-tests!25
+                relative: '!25'
+                short: '!25'
+              reviewers: []
+              sha: 9ea58e21114d8ea9fdd4bdb733d3a6db1d9d244a
+              should_remove_source_branch: null
+              source_branch: lachmanfrantisek-master-patch-55321
+              source_project_id: 14255608
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: opened
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Check commit status.
+              updated_at: '2020-05-15T11:03:08.893Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/25
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2019-11-26T19:46:02.513Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2019-11-26T19:45:28.528Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 43305723
+              iid: 21
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-11-26T19:45:28.528Z'
+              project_id: 14233409
+              reference: '!21'
+              references:
+                full: packit-service/ogr-tests!21
+                relative: '!21'
+                short: '!21'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-11-26T19:46:02.482Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/21
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2019-11-26T19:44:39.087Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2019-11-26T19:44:37.895Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 43305693
+              iid: 20
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-11-26T19:44:37.895Z'
+              project_id: 14233409
+              reference: '!20'
+              references:
+                full: packit-service/ogr-tests!20
+                relative: '!20'
+                short: '!20'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-11-26T19:44:39.064Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/20
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              blocking_discussions_resolved: true
+              closed_at: '2019-11-26T19:43:54.391Z'
+              closed_by:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              created_at: '2019-11-26T18:52:20.310Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 43301514
+              iid: 18
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-11-26T18:52:20.310Z'
+              project_id: 14233409
+              reference: '!18'
+              references:
+                full: packit-service/ogr-tests!18
+                relative: '!18'
+                short: '!18'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-11-26T19:43:54.370Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/18
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-27T08:41:50.321Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 38318253
+              iid: 17
+              labels: []
+              merge_commit_sha: 3d278426b64647aa92fb63c8d7ccdb4d8c4919ff
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-27T08:42:56.335Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              milestone: null
+              prepared_at: '2019-09-27T08:41:50.321Z'
+              project_id: 14233409
+              reference: '!17'
+              references:
+                full: packit-service/ogr-tests!17
+                relative: '!17'
+                short: '!17'
+              reviewers: []
+              sha: 6970eae72f9ecee667183f52880ca76126bd8b38
+              should_remove_source_branch: null
+              source_branch: pr-test3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Update README.md
+              updated_at: '2019-09-27T08:42:56.305Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/17
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-27T08:39:52.398Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-27T08:39:51.246Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38318126
+              iid: 16
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-27T08:39:51.246Z'
+              project_id: 14233409
+              reference: '!16'
+              references:
+                full: packit-service/ogr-tests!16
+                relative: '!16'
+                short: '!16'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-27T08:39:52.377Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/16
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-27T08:39:45.246Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-27T08:39:44.190Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38318111
+              iid: 15
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-27T08:39:44.190Z'
+              project_id: 14233409
+              reference: '!15'
+              references:
+                full: packit-service/ogr-tests!15
+                relative: '!15'
+                short: '!15'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-27T08:39:45.226Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/15
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-26T14:08:08.843Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 38258502
+              iid: 12
+              labels: []
+              merge_commit_sha: f6de56d97ec3ec74cd5194e79175162d9f969195
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-26T14:20:35.371Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              milestone: null
+              prepared_at: '2019-09-26T14:08:08.843Z'
+              project_id: 14233409
+              reference: '!12'
+              references:
+                full: packit-service/ogr-tests!12
+                relative: '!12'
+                short: '!12'
+              reviewers: []
+              sha: 2543f1728c7e1c2b8772d0dc11dc8b1870f4db60
+              should_remove_source_branch: null
+              source_branch: pr-test2
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Update README.md
+              updated_at: '2019-09-26T14:20:35.342Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/12
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T14:20:32.693Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T14:20:31.245Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38259455
+              iid: 14
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T14:20:31.245Z'
+              project_id: 14233409
+              reference: '!14'
+              references:
+                full: packit-service/ogr-tests!14
+                relative: '!14'
+                short: '!14'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-26T14:20:32.667Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/14
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T14:20:27.037Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T14:20:26.028Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38259445
+              iid: 13
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T14:20:26.028Z'
+              project_id: 14233409
+              reference: '!13'
+              references:
+                full: packit-service/ogr-tests!13
+                relative: '!13'
+                short: '!13'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-26T14:20:27.010Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/13
+              work_in_progress: false
+            _next: null
+            elapsed: 1.147508
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c1ec6c7bfcb335-PRG
+              Connection: keep-alive
+              Content-Encoding: gzip
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 10:12:54 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=nD5%2BzUtuKKHJyUBTkBNwCEZIqRCHOYVUF8UadNsHJHoI%2FjCQNTTkuedwNtJxc%2BTN6bbVlH8s5IptaOQqzMJ%2BoYbjDMl%2F%2BJNuMvW808YO1N3IFsL03TwQsI3qPBs%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"c9e7303dc8bc05c7abb2f9777cc1f73e"
+              gitlab-lb: haproxy-main-37-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=3&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '101'
+              ratelimit-remaining: '1898'
+              ratelimit-reset: '1698315234'
+              ratelimit-resettime: Thu, 26 Oct 2023 10:13:54 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"9058647c7485026ed4dce4da11feed29","version":"1"}'
+              x-next-page: '5'
+              x-page: '4'
+              x-per-page: '20'
+              x-prev-page: '3'
+              x-request-id: 9058647c7485026ed4dce4da11feed29
+              x-runtime: '0.935337'
+              x-total: '86'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
       ? https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false
       : - metadata:
             latency: 0.49272608757019043
@@ -4908,6 +9464,506 @@ requests.sessions:
               x-request-id: e6d340e805ae6ed0b140b2e86855e669
               x-runtime: '0.330873'
               x-total: '84'
+              x-total-pages: '5'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+        - metadata:
+            latency: 0.3919370174407959
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_pull_requests
+            - ogr.abstract
+            - ogr.utils
+            - ogr.abstract
+            - ogr.services.gitlab.pull_request
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: null
+              closed_by: null
+              created_at: '2019-09-26T10:42:40.907Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: false
+              id: 38240250
+              iid: 7
+              labels: []
+              merge_commit_sha: ff3df8288306e95ad76f803d6b9e398efe0b754d
+              merge_status: can_be_merged
+              merge_user:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              merge_when_pipeline_succeeds: false
+              merged_at: '2019-09-26T10:55:32.234Z'
+              merged_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              milestone: null
+              prepared_at: '2019-09-26T10:42:40.907Z'
+              project_id: 14233409
+              reference: '!7'
+              references:
+                full: packit-service/ogr-tests!7
+                relative: '!7'
+                short: '!7'
+              reviewers: []
+              sha: 257ce9fd8c5421d2e116337847710ba70d215aa6
+              should_remove_source_branch: null
+              source_branch: pr-test1
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: merged
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: Update README.md
+              updated_at: '2019-09-26T10:55:32.202Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/7
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:55:27.610Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:55:26.676Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38241250
+              iid: 11
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:55:26.676Z'
+              project_id: 14233409
+              reference: '!11'
+              references:
+                full: packit-service/ogr-tests!11
+                relative: '!11'
+                short: '!11'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-26T10:55:27.587Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/11
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:54:23.368Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:53:36.779Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38241101
+              iid: 9
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:53:36.779Z'
+              project_id: 14233409
+              reference: '!9'
+              references:
+                full: packit-service/ogr-tests!9
+                relative: '!9'
+                short: '!9'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: some special title
+              updated_at: '2019-09-26T10:54:23.349Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/9
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:43:07.886Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:43:06.982Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38240288
+              iid: 8
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:43:06.982Z'
+              project_id: 14233409
+              reference: '!8'
+              references:
+                full: packit-service/ogr-tests!8
+                relative: '!8'
+                short: '!8'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-26T10:43:07.864Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/8
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:39:07.283Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:33:40.187Z'
+              description: Description
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: null
+              has_conflicts: true
+              id: 38239482
+              iid: 5
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:33:40.187Z'
+              project_id: 14233409
+              reference: '!5'
+              references:
+                full: packit-service/ogr-tests!5
+                relative: '!5'
+                short: '!5'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: New PR of pr-3
+              updated_at: '2019-09-26T10:39:07.267Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/5
+              work_in_progress: false
+            - approvals_before_merge: null
+              assignee: null
+              assignees: []
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              blocking_discussions_resolved: true
+              closed_at: '2019-09-26T10:30:20.820Z'
+              closed_by:
+                avatar_url: https://secure.gravatar.com/avatar/e1ae3427f994784121371108f12eceb5?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              created_at: '2019-09-26T10:30:12.047Z'
+              description: ''
+              detailed_merge_status: not_open
+              discussion_locked: null
+              downvotes: 0
+              draft: false
+              force_remove_source_branch: false
+              has_conflicts: true
+              id: 38239261
+              iid: 4
+              labels: []
+              merge_commit_sha: null
+              merge_status: cannot_be_merged
+              merge_user: null
+              merge_when_pipeline_succeeds: false
+              merged_at: null
+              merged_by: null
+              milestone: null
+              prepared_at: '2019-09-26T10:30:12.047Z'
+              project_id: 14233409
+              reference: '!4'
+              references:
+                full: packit-service/ogr-tests!4
+                relative: '!4'
+                short: '!4'
+              reviewers: []
+              sha: db843cde94391923c6acb4cce938d830477a9732
+              should_remove_source_branch: null
+              source_branch: pr-3
+              source_project_id: 14233409
+              squash: false
+              squash_commit_sha: null
+              squash_on_merge: false
+              state: closed
+              target_branch: master
+              target_project_id: 14233409
+              task_completion_status:
+                completed_count: 0
+                count: 0
+              time_stats:
+                human_time_estimate: null
+                human_total_time_spent: null
+                time_estimate: 0
+                total_time_spent: 0
+              title: 'WIP: Pr 3'
+              updated_at: '2019-09-26T10:30:20.802Z'
+              upvotes: 0
+              user_notes_count: 0
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/4
+              work_in_progress: false
+            _next: null
+            elapsed: 0.391515
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 81c1ec73b8dcb335-PRG
+              Connection: keep-alive
+              Content-Encoding: gzip
+              Content-Type: application/json
+              Date: Thu, 26 Oct 2023 10:12:55 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=r2QFTNGuXkQEbSIf9TlWI0xSnyP1DvKO7s2IYwuyJnUhuR6e0M8bKhI6vpqAxvZlHWHfP6R8kEI0AkGU85kDNq64QYQhLOmCFa%2BvA1z2s4U3w5DwEEHcn8lFyQ8%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"e06ed789761842fb4d0a8e184e1cde4d"
+              gitlab-lb: haproxy-main-07-lb-gprd
+              gitlab-sv: localhost
+              link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=4&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+                rel="last"
+              ratelimit-limit: '2000'
+              ratelimit-observed: '102'
+              ratelimit-remaining: '1898'
+              ratelimit-reset: '1698315235'
+              ratelimit-resettime: Thu, 26 Oct 2023 10:13:55 GMT
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"943ab002b8632210928a9a60d8cc4073","version":"1"}'
+              x-next-page: ''
+              x-page: '5'
+              x-per-page: '20'
+              x-prev-page: '4'
+              x-request-id: 943ab002b8632210928a9a60d8cc4073
+              x-runtime: '0.214315'
+              x-total: '86'
               x-total-pages: '5'
             raw: !!binary ""
             reason: OK
@@ -6405,6 +11461,1491 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      - metadata:
+          latency: 0.8403353691101074
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.gitlab.pull_request
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2023-10-26T10:12:29.812Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2023-10-26T10:12:26.108Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 259296199
+            iid: 88
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2023-10-26T10:12:26.977Z'
+            project_id: 14233409
+            reference: '!88'
+            references:
+              full: packit-service/ogr-tests!88
+              relative: '!88'
+              short: '!88'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 20772752
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2023-10-26T10:12:29.467Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/88
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2023-10-26T10:12:21.394Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2023-10-26T10:12:19.046Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 259296170
+            iid: 87
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2023-10-26T10:12:20.115Z'
+            project_id: 14233409
+            reference: '!87'
+            references:
+              full: packit-service/ogr-tests!87
+              relative: '!87'
+              short: '!87'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 20772752
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork -> upstream'
+            updated_at: '2023-10-26T10:12:21.034Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/87
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2952463/avatar.png
+              id: 2952463
+              locked: false
+              name: Jiri Popelka
+              state: active
+              username: jpopelka
+              web_url: https://gitlab.com/jpopelka
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2022-04-29T14:19:43.343Z'
+            description: Description
+            detailed_merge_status: broken_status
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 152883878
+            iid: 86
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-04-29T14:19:43.343Z'
+            project_id: 14233409
+            reference: '!86'
+            references:
+              full: packit-service/ogr-tests!86
+              relative: '!86'
+              short: '!86'
+            reviewers: []
+            sha: db843cde94391923c6acb4cce938d830477a9732
+            should_remove_source_branch: null
+            source_branch: pr-3
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: New PR of pr-3
+            updated_at: '2022-04-29T14:19:45.492Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/86
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              locked: false
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2019-09-10T14:03:24.365Z'
+            description: description of mergerequest
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 36948617
+            iid: 1
+            labels:
+            - test_lb1
+            - test_lb2
+            merge_commit_sha: 101a42bbbe174d04b465d49caf274dc3b4defeca
+            merge_status: can_be_merged
+            merge_user:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              locked: false
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            merge_when_pipeline_succeeds: false
+            merged_at: '2019-09-11T08:55:32.822Z'
+            merged_by:
+              avatar_url: https://secure.gravatar.com/avatar/9c8d9a288151a8e563547e082c591f2a?s=80&d=identicon
+              id: 4594931
+              locked: false
+              name: "Laura Barcziov\xE1"
+              state: active
+              username: lbarcziova
+              web_url: https://gitlab.com/lbarcziova
+            milestone: null
+            prepared_at: '2019-09-10T14:03:24.365Z'
+            project_id: 14233409
+            reference: '!1'
+            references:
+              full: packit-service/ogr-tests!1
+              relative: '!1'
+              short: '!1'
+            reviewers: []
+            sha: d490ec67dd98f69dfdc1732b98bb3189f0e0aace
+            should_remove_source_branch: null
+            source_branch: change
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: merged
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: change
+            updated_at: '2022-01-05T18:43:40.814Z'
+            upvotes: 0
+            user_notes_count: 3
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/1
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:43:09.562Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:43:08.503Z'
+            description: Description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835961
+            iid: 85
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:43:08.503Z'
+            project_id: 14233409
+            reference: '!85'
+            references:
+              full: packit-service/ogr-tests!85
+              relative: '!85'
+              short: '!85'
+            reviewers: []
+            sha: db843cde94391923c6acb4cce938d830477a9732
+            should_remove_source_branch: null
+            source_branch: pr-3
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: some special title
+            updated_at: '2022-01-05T18:43:09.539Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/85
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2019-11-26T19:39:01.381Z'
+            description: test2
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 43305101
+            iid: 19
+            labels: []
+            merge_commit_sha: b8e18207cfdad954f1b3a96db34d0706b272e6cf
+            merge_status: can_be_merged
+            merge_user:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            merge_when_pipeline_succeeds: false
+            merged_at: '2019-11-26T19:40:49.350Z'
+            merged_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            milestone: null
+            prepared_at: '2019-11-26T19:39:01.381Z'
+            project_id: 14233409
+            reference: '!19'
+            references:
+              full: packit-service/ogr-tests!19
+              relative: '!19'
+              short: '!19'
+            reviewers: []
+            sha: 59b1a9bab5b5198c619270646410867788685c16
+            should_remove_source_branch: null
+            source_branch: test_branch
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: merged
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Got to merge something
+            updated_at: '2022-01-05T18:43:00.560Z'
+            upvotes: 0
+            user_notes_count: 2
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/19
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:42:58.565Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:42:57.361Z'
+            description: Description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835943
+            iid: 84
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:42:57.361Z'
+            project_id: 14233409
+            reference: '!84'
+            references:
+              full: packit-service/ogr-tests!84
+              relative: '!84'
+              short: '!84'
+            reviewers: []
+            sha: db843cde94391923c6acb4cce938d830477a9732
+            should_remove_source_branch: null
+            source_branch: pr-3
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: New PR of pr-3
+            updated_at: '2022-01-05T18:42:58.547Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/84
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:42:31.924Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:42:28.415Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835861
+            iid: 83
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:42:28.415Z'
+            project_id: 14233409
+            reference: '!83'
+            references:
+              full: packit-service/ogr-tests!83
+              relative: '!83'
+              short: '!83'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 20772752
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2022-01-05T18:42:31.909Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/83
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: '2022-01-05T18:42:22.183Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2022-01-05T18:42:20.823Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 133835844
+            iid: 82
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2022-01-05T18:42:20.823Z'
+            project_id: 14233409
+            reference: '!82'
+            references:
+              full: packit-service/ogr-tests!82
+              relative: '!82'
+              short: '!82'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 20772752
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork -> upstream'
+            updated_at: '2022-01-05T18:42:22.166Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/82
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-08-19T12:17:22.116Z'
+            description: 'Signed-off-by: Matej Focko <mfocko@redhat.com>'
+            detailed_merge_status: mergeable
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 113023810
+            iid: 81
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-08-19T12:17:22.116Z'
+            project_id: 14233409
+            reference: '!81'
+            references:
+              full: packit-service/ogr-tests!81
+              relative: '!81'
+              short: '!81'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Create new file for test
+            updated_at: '2021-08-19T12:17:22.116Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/81
+            work_in_progress: false
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2020-08-28T08:46:56.751Z'
+            description: ''
+            detailed_merge_status: draft_status
+            discussion_locked: null
+            downvotes: 0
+            draft: true
+            force_remove_source_branch: false
+            has_conflicts: false
+            id: 69039752
+            iid: 52
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2020-08-28T08:46:56.751Z'
+            project_id: 14233409
+            reference: '!52'
+            references:
+              full: packit-service/ogr-tests!52
+              relative: '!52'
+              short: '!52'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: test_branch
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'Draft: Pr test1'
+            updated_at: '2021-08-19T12:17:00.957Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/52
+            work_in_progress: true
+          - approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-08-19T12:12:35.889Z'
+            description: ''
+            detailed_merge_status: broken_status
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: false
+            has_conflicts: true
+            id: 113023110
+            iid: 80
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-08-19T12:12:35.889Z'
+            project_id: 14233409
+            reference: '!80'
+            references:
+              full: packit-service/ogr-tests!80
+              relative: '!80'
+              short: '!80'
+            reviewers: []
+            sha: af1ec13d0e232ff1d5f4cc042381da19ffa6f892
+            should_remove_source_branch: null
+            source_branch: test-branch1
+            source_project_id: 14233409
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Adding more to README
+            updated_at: '2021-08-19T12:12:35.889Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/80
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-08-05T09:29:28.037Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+              id: 375555
+              locked: false
+              name: Matej Focko
+              state: active
+              username: mfocko
+              web_url: https://gitlab.com/mfocko
+            created_at: '2021-06-23T21:58:14.249Z'
+            description: 'Signed-off-by: Ben Crocker <bcrocker@redhat.com>'
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: true
+            has_conflicts: false
+            id: 105586464
+            iid: 78
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-23T21:58:14.249Z'
+            project_id: 14233409
+            reference: '!78'
+            references:
+              full: packit-service/ogr-tests!78
+              relative: '!78'
+              short: '!78'
+            reviewers: []
+            sha: 019a5f5e80fcc9ded82ca6ee013552c1c776f9b2
+            should_remove_source_branch: null
+            source_branch: 2-bac-conflict
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Changes based on initial commit of README.md
+            updated_at: '2021-08-05T09:29:28.003Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/78
+            work_in_progress: false
+          - allow_collaboration: false
+            allow_maintainer_to_push: false
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2952463/avatar.png
+              id: 2952463
+              locked: false
+              name: Jiri Popelka
+              state: active
+              username: jpopelka
+              web_url: https://gitlab.com/jpopelka
+            blocking_discussions_resolved: true
+            closed_at: '2021-08-03T15:01:44.866Z'
+            closed_by:
+              avatar_url: https://gitlab.com/uploads/-/system/user/avatar/2952463/avatar.png
+              id: 2952463
+              locked: false
+              name: Jiri Popelka
+              state: active
+              username: jpopelka
+              web_url: https://gitlab.com/jpopelka
+            created_at: '2021-06-24T12:21:59.290Z'
+            description: This MR can't be merged because of a conflict.
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: true
+            has_conflicts: true
+            id: 105673770
+            iid: 79
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-24T12:21:59.290Z'
+            project_id: 14233409
+            reference: '!79'
+            references:
+              full: packit-service/ogr-tests!79
+              relative: '!79'
+              short: '!79'
+            reviewers: []
+            sha: 45e3737aea87a9fd14adcf6a42070cb4f8665ada
+            should_remove_source_branch: null
+            source_branch: create-conflict
+            source_project_id: null
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: Conflict
+            updated_at: '2021-08-03T15:01:44.485Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/79
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-06-23T17:49:13.269Z'
+            description: 'Signed-off-by: Ben Crocker <bcrocker@redhat.com>'
+            detailed_merge_status: mergeable
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: true
+            has_conflicts: false
+            id: 105564125
+            iid: 77
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-23T17:49:13.269Z'
+            project_id: 14233409
+            reference: '!77'
+            references:
+              full: packit-service/ogr-tests!77
+              relative: '!77'
+              short: '!77'
+            reviewers: []
+            sha: 6592475b6f0cd952a4626247a8acb9e250810d29
+            should_remove_source_branch: null
+            source_branch: 1-bac-test
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: bac.txt initial 2-liner
+            updated_at: '2021-06-23T21:35:05.438Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/77
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: null
+            closed_by: null
+            created_at: '2021-06-23T15:04:45.476Z'
+            description: 'Signed-off-by: Ben Crocker <bcrocker@redhat.com>'
+            detailed_merge_status: draft_status
+            discussion_locked: null
+            downvotes: 0
+            draft: true
+            force_remove_source_branch: true
+            has_conflicts: false
+            id: 105544200
+            iid: 76
+            labels: []
+            merge_commit_sha: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-23T15:04:45.476Z'
+            project_id: 14233409
+            reference: '!76'
+            references:
+              full: packit-service/ogr-tests!76
+              relative: '!76'
+              short: '!76'
+            reviewers: []
+            sha: 60c6e2fd8f08077105fda8008b7954ee2c04bef6
+            should_remove_source_branch: null
+            source_branch: bac-test-1
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'Draft: Changed based on commit 257ce9fd8c5421d2e116337847710ba70d215aa6'
+            updated_at: '2021-06-23T15:04:45.476Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/76
+            work_in_progress: true
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T23:48:22.978Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T23:48:20.283Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104993952
+            iid: 75
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T23:48:20.283Z'
+            project_id: 14233409
+            reference: '!75'
+            references:
+              full: packit-service/ogr-tests!75
+              relative: '!75'
+              short: '!75'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2021-06-18T23:48:22.963Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/75
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T23:48:16.336Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T23:48:15.185Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104993949
+            iid: 74
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T23:48:15.185Z'
+            project_id: 14233409
+            reference: '!74'
+            references:
+              full: packit-service/ogr-tests!74
+              relative: '!74'
+              short: '!74'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork -> upstream'
+            updated_at: '2021-06-18T23:48:16.318Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/74
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T14:26:22.041Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T14:26:19.129Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104941511
+            iid: 73
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T14:26:19.129Z'
+            project_id: 14233409
+            reference: '!73'
+            references:
+              full: packit-service/ogr-tests!73
+              relative: '!73'
+              short: '!73'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork:one-more-branch -> upstream'
+            updated_at: '2021-06-18T14:26:22.019Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/73
+            work_in_progress: false
+          - allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            blocking_discussions_resolved: true
+            closed_at: '2021-06-18T14:26:09.759Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/c7fe77b328a6631baf8705597be56406?s=80&d=identicon
+              id: 6466632
+              locked: false
+              name: Ben Crocker
+              state: active
+              username: bcrocker
+              web_url: https://gitlab.com/bcrocker
+            created_at: '2021-06-18T14:26:07.435Z'
+            description: test description
+            detailed_merge_status: not_open
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            force_remove_source_branch: null
+            has_conflicts: true
+            id: 104941489
+            iid: 72
+            labels: []
+            merge_commit_sha: null
+            merge_status: cannot_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            prepared_at: '2021-06-18T14:26:07.435Z'
+            project_id: 14233409
+            reference: '!72'
+            references:
+              full: packit-service/ogr-tests!72
+              relative: '!72'
+              short: '!72'
+            reviewers: []
+            sha: null
+            should_remove_source_branch: null
+            source_branch: one-more-branch
+            source_project_id: 25840586
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: 'test PR: fork -> upstream'
+            updated_at: '2021-06-18T14:26:09.686Z'
+            upvotes: 0
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/72
+            work_in_progress: false
+          _next: null
+          elapsed: 0.840075
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 81c1ec5cdfc8b335-PRG
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Thu, 26 Oct 2023 10:12:52 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=%2FK7NXWm8fdbRol96I3OMtYLSwngEsPPq6SpjuCAbulbPzaneenCfpzgs62m8tIsq5VT%2F9Ne68kcynopJ256nAzHYPkcRWsL5i06IJqWnmdfmcz05KbXJ4vDCpX4%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"6124ca01e0b4e710d8f4b3d8bca42fcf"
+            gitlab-lb: haproxy-main-20-lb-gprd
+            gitlab-sv: localhost
+            link: <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=2&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+              rel="next", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=1&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+              rel="first", <https://gitlab.com/api/v4/projects/14233409/merge_requests?id=14233409&order_by=updated_at&page=5&per_page=20&sort=desc&state=all&with_labels_details=false&with_merge_status_recheck=false>;
+              rel="last"
+            ratelimit-limit: '2000'
+            ratelimit-observed: '102'
+            ratelimit-remaining: '1897'
+            ratelimit-reset: '1698315232'
+            ratelimit-resettime: Thu, 26 Oct 2023 10:13:52 GMT
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"26d6959e0bdbff744c32197add85d803","version":"1"}'
+            x-next-page: '2'
+            x-page: '1'
+            x-per-page: '20'
+            x-prev-page: ''
+            x-request-id: 26d6959e0bdbff744c32197add85d803
+            x-runtime: '0.679536'
+            x-total: '86'
+            x-total-pages: '5'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
       https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
       - metadata:
           latency: 0.31386280059814453
@@ -6592,6 +13133,190 @@ requests.sessions:
           raw: !!binary ""
           reason: OK
           status_code: 200
+      - metadata:
+          latency: 0.32617616653442383
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              cluster_agents: https://gitlab.com/api/v4/projects/14233409/cluster_agents
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_allow_fork_pipelines_to_run_in_parent_project: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_forward_deployment_rollback_allowed: true
+            ci_job_token_scope_enabled: false
+            ci_separated_caches: true
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            description_html: <p data-sourcepos="1:1-1:84" dir="auto">Testing repository
+              for python-ogr package.  |  <a href="https://github.com/packit-service/ogr"
+              rel="nofollow noreferrer noopener" target="_blank">https://github.com/packit-service/ogr</a></p>
+            emails_disabled: false
+            emails_enabled: true
+            empty_repo: false
+            enforce_auth_checks_on_uploads: true
+            environments_access_level: enabled
+            external_authorization_classification_label: ''
+            feature_flags_access_level: enabled
+            forking_access_level: enabled
+            forks_count: 6
+            group_runners_enabled: true
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_error: null
+            import_status: none
+            import_type: null
+            import_url: null
+            infrastructure_access_level: enabled
+            issue_branch_template: null
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2023-10-26T10:11:52.639Z'
+            lfs_enabled: true
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            model_experiments_access_level: enabled
+            monitor_access_level: enabled
+            name: ogr-tests
+            name_with_namespace: packit-service / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: packit-service
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 77
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access:
+                access_level: 50
+                notification_level: 3
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            releases_access_level: enabled
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            request_access_enabled: false
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runner_token_expiration_interval: null
+            runners_token: GR1348941sWEgsQKmwrxmdNipZmMH
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            updated_at: '2023-10-26T10:11:52.639Z'
+            visibility: public
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.32582
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 81c1ec5acc16b335-PRG
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Thu, 26 Oct 2023 10:12:51 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=pBs1agy3IH13WzHDaQ3ZMMdbCqp9zgW8sFbCc8t8rO1vDQrmyCJaYdCt3gLQLmImXh2CmHuZFRNmZsrayDIWvWZD1ls0b9jR1NPREkEbDZsosLxKzC%2BzvLj6pfw%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"7b01d6355044a684cc4e1e1795c63c14"
+            gitlab-lb: haproxy-main-06-lb-gprd
+            gitlab-sv: localhost
+            ratelimit-limit: '2000'
+            ratelimit-observed: '102'
+            ratelimit-remaining: '1898'
+            ratelimit-reset: '1698315231'
+            ratelimit-resettime: Thu, 26 Oct 2023 10:13:51 GMT
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"70c943a3d30057f7626a59bb76cd5f2f","version":"1"}'
+            x-request-id: 70c943a3d30057f7626a59bb76cd5f2f
+            x-runtime: '0.161043'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
       https://gitlab.com/api/v4/user:
       - metadata:
           latency: 0.2541370391845703
@@ -6702,6 +13427,125 @@ requests.sessions:
             x-gitlab-meta: '{"correlation_id":"d41c5f9f4666666666666615d53c5785","version":"1"}'
             x-request-id: d41c5f9f4b666666457dd015d53c5666
             x-runtime: '0.052445'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.27841615676879883
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.v4.objects.users
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+            bio: Associate SW Engineer @ Red Hat, Seminar Tutor @ FI MU. Fan of open-source,
+              Haskell, functional programming, containers and Linux.
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 2
+            commit_email: matej.focko@outlook.com
+            confirmed_at: '2020-07-24T20:00:33.764Z'
+            created_at: '2016-01-15T21:12:31.705Z'
+            current_sign_in_at: '2023-10-26T07:11:37.644Z'
+            discord: '443362586776567810'
+            email: matej.focko@outlook.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            id: 375555
+            identities:
+            - extern_uid: mfocko
+              provider: group_saml
+              saml_provider_id: 2868
+            - extern_uid: 46bd3cb0-73a0-11ea-8e0e-0a58ac142609
+              provider: group_saml
+              saml_provider_id: 1769
+            - extern_uid: '8149784'
+              provider: github
+              saml_provider_id: null
+            - extern_uid: '90177795'
+              provider: twitter
+              saml_provider_id: null
+            - extern_uid: '104088596414930556092'
+              provider: google_oauth2
+              saml_provider_id: null
+            job_title: Associate Software Engineer
+            last_activity_on: '2023-10-26'
+            last_sign_in_at: '2023-10-26T01:13:10.123Z'
+            linkedin: mfocko
+            local_time: 12:12 PM
+            location: Brno, Czechia
+            locked: false
+            name: Matej Focko
+            organization: Red Hat
+            private_profile: false
+            projects_limit: 100000
+            pronouns: he/him/his
+            public_email: ''
+            scim_identities: []
+            shared_runners_minutes_limit: 2000
+            skype: ''
+            state: active
+            theme_id: 11
+            twitter: m4tt_314
+            two_factor_enabled: true
+            username: mfocko
+            web_url: https://gitlab.com/mfocko
+            website_url: https://blog.mfocko.xyz
+            work_information: Associate Software Engineer at Red Hat
+          _next: null
+          elapsed: 0.278019
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 81c1ec597989b335-PRG
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Thu, 26 Oct 2023 10:12:50 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=I%2FbC0zpJ2%2BHT5%2BfTlEFfuCG1G1vtXx76t2JYmgUqskukBraQe024uN2CbeKO%2F2HDJ4An7XeivhvHne3tctNBuYlUHvnjeYlQ%2FyLMOXkiLog6am2L7N31qBBw46Y%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Set-Cookie: _cfuvid=ev6SBHjxufkr3YebSfkMaghLsLN0.3507.ZO4rRcbfE-1698315170981-0-604800000;
+              path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"d7281956c5d552dfa793a3e436920ab0"
+            gitlab-lb: haproxy-main-28-lb-gprd
+            gitlab-sv: localhost
+            ratelimit-limit: '2000'
+            ratelimit-observed: '101'
+            ratelimit-remaining: '1899'
+            ratelimit-reset: '1698315230'
+            ratelimit-resettime: Thu, 26 Oct 2023 10:13:50 GMT
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"1dec00ae3709d6d491cf13c8953fad97","version":"1"}'
+            x-request-id: 1dec00ae3709d6d491cf13c8953fad97
+            x-runtime: '0.038047'
           raw: !!binary ""
           reason: OK
           status_code: 200

--- a/tests/integration/gitlab/test_pull_requests.py
+++ b/tests/integration/gitlab/test_pull_requests.py
@@ -30,6 +30,11 @@ class PullRequests(GitlabTests):
         assert title == pr_list[0].title
         pr.close()
 
+    @pytest.mark.skipif(
+        is_gitlab_version_smaller_than_314(),
+        reason="URL syntax changed between versions and"
+        "our requre data don't work with older gitlab versions",
+    )
     def test_mr_list_limit(self):
         pr_list = self.project.get_pr_list(status=PRStatus.all)
         count = len({pr.id for pr in pr_list})

--- a/tests/integration/gitlab/test_pull_requests.py
+++ b/tests/integration/gitlab/test_pull_requests.py
@@ -32,7 +32,7 @@ class PullRequests(GitlabTests):
 
     def test_mr_list_limit(self):
         pr_list = self.project.get_pr_list(status=PRStatus.all)
-        count = len(pr_list)
+        count = len({pr.id for pr in pr_list})
         # 20 is internal gitlab's limit; there are 84 as of Oct 2023
         assert count > 20
 


### PR DESCRIPTION
TODO:

- [x] requre

> python-gitlab==3.14.0

```
Calling a `list()` method without specifying `get_all=True` or
`iterator=True` will return a maximum of 20 items. Your query returned
20 of 87 items.
```

RELEASE NOTES BEGIN
Fixed an issue where getting a list of GitLab merge requests using `.list()` would return only 20 items.
RELEASE NOTES END