### PR TITLE
Fix GithubRelease.url to not return API url

### DIFF
--- a/ogr/services/github/release.py
+++ b/ogr/services/github/release.py
@@ -56,7 +56,7 @@ class GithubRelease(Release):
 
     @property
     def url(self) -> Optional[str]:
-        return self._raw_release.url
+        return self._raw_release.html_url
 
     @property
     def created_at(self) -> datetime.datetime:


### PR DESCRIPTION
Change the property so that it returns the html_url of the raw release and not the url which is the API url.

Merge before/after

RELEASE NOTES BEGIN
We have fixed a bug that GithubRelease.url returned an API URL.
RELEASE NOTES END
