### PR TITLE
Increase log level in get_files_diff

### DIFF
--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -228,7 +228,7 @@ class PagurePullRequest(BasePullRequest):
                         f"While retrieving PR diffstats Pagure returned ENOPRSTATS. \n{ex}",
                     )
                     if attempt < retries:
-                        logger.debug(
+                        logger.error(
                             f"Trying again; attempt={attempt} after {wait_seconds}seconds",
                         )
                         attempt += 1


### PR DESCRIPTION
Ogr debug level strings don't reach Splunk.
