### PR TITLE
Avoid deepdiff version 8.0.0 in packit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
         additional_dependencies:
-          [types-pkg_resources, types-requests, types-Deprecated]
+          [types-setuptools, types-requests, types-Deprecated]
   - repo: https://github.com/teemtee/tmt.git
     rev: 1.31.0
     hooks:

--- a/plans/packit-integration.fmf
+++ b/plans/packit-integration.fmf
@@ -25,7 +25,7 @@ adjust:
       - how: install
         package: python3-pip
       - how: shell
-        script: pip3 install build deepdiff
+        script: pip3 install build 'deepdiff < 8.0.0' # version 8.0.0 depends on numpy, avoid it
 
   - when: "distro == rhel-8 or distro == centos-8 or distro == centos-stream-8"
     because: "packit doesn't support EL 8"


### PR DESCRIPTION
It depends on numpy