### PR TITLE
fix: remove unreachable exception handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -26,14 +26,14 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+    rev: v1.11.2
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
         additional_dependencies:
           [types-setuptools, types-requests, types-Deprecated]
   - repo: https://github.com/teemtee/tmt.git
-    rev: 1.31.0
+    rev: 1.35.0
     hooks:
       - id: tmt-lint
         # Do not run in pre-commit.ci as it requires an internet access
@@ -56,12 +56,12 @@ repos:
         stages: [manual, push]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.2
+    rev: v0.6.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.0
+    rev: 0.29.2
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]

--- a/examples/list_prs_since_release.ipynb
+++ b/examples/list_prs_since_release.ipynb
@@ -45,8 +45,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": "Bigger release from 2020-05-06 15:53:23.\n"
     }
    ],
@@ -69,6 +69,7 @@
    "outputs": [],
    "source": [
     "from ogr.abstract import PRStatus\n",
+    "\n",
     "prs = project.get_pr_list(status=PRStatus.all)"
    ]
   },
@@ -87,8 +88,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": "#435: Sourcery refactor\n#433: 0.12.2 release\n#431: Job metadata key 'dist_git_branch' was renamed to 'dist_git_branches'\n#430: Replace Python version glob with macro\n#429: Fix get_file_content() returning bytes\n#428: Copr build for master and releases\n#419: Pull requests on Gitlab\n#427: Zuul & pre-commit related changes\n#425: Implement PagurePullRequest.get_flags() (not merged)\n#426: Improve the message when marking issues as stale\n#411: Creating PRs from `fork` to `other-fork` on Github\n#422: 0.12.1 release\n#418: Fix factory.get_project\n#415: Add PullRequest.patch property\n#410: GitHub: query only one user when telling if a user can merge PRs\n"
     }
    ],
@@ -101,6 +102,10 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.3 64-bit",
+   "name": "python38364bit3ec8239d0440456baaf370e87148ec69"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -113,11 +118,7 @@
    "pygments_lexer": "ipython3",
    "version": "3.8.3-final"
   },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python38364bit3ec8239d0440456baaf370e87148ec69",
-   "display_name": "Python 3.8.3 64-bit"
-  }
+  "orig_nbformat": 2
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/examples/releases.ipynb
+++ b/examples/releases.ipynb
@@ -1,32 +1,11 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.4-final"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python38364bit3ec8239d0440456baaf370e87148ec69",
-   "display_name": "Python 3.8.3 64-bit"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Listing releases"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -60,7 +39,10 @@
     "import datetime\n",
     "\n",
     "since = datetime.datetime(year=2020, month=1, day=1)\n",
-    "releases_in_20 = filter(lambda release: datetime.datetime.fromisoformat(release.created_at.split('.')[0]) >= since, all_releases)"
+    "releases_in_20 = filter(\n",
+    "    lambda release: datetime.datetime.fromisoformat(release.created_at.split('.')[0]) >= since,\n",
+    "    all_releases,\n",
+    ")"
    ]
   },
   {
@@ -71,9 +53,58 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "v0.7.0: aa672412a1942af47801ded9f466fa1bf6139c04\n(https://gitlab.com/Isleward/isleward/-/archive/v0.7.0/isleward-v0.7.0.tar.gz)\nv0.6.1.2: 17584a7a97d21a5b01ece52139922b2dbea771da\n(https://gitlab.com/Isleward/isleward/-/archive/v0.6.1.2/isleward-v0.6.1.2.tar.gz)\nv0.6.1.1: 4c3229825dd8dc7414a52e6028bb084e47db4022\n(https://gitlab.com/Isleward/isleward/-/archive/v0.6.1.1/isleward-v0.6.1.1.tar.gz)\nv0.6.1: a77c207652946f2282efd73867dd35a595139991\n(https://gitlab.com/Isleward/isleward/-/archive/v0.6.1/isleward-v0.6.1.tar.gz)\nv0.6.0.3: e921bccd0d8efd2dcb69ff1ca5501c8fab9b47bf\n(https://gitlab.com/Isleward/isleward/-/archive/v0.6.0.3/isleward-v0.6.0.3.tar.gz)\nv0.6.0.2: 91d0c51f23dbd7d10ca40cf89220335366462428\n(https://gitlab.com/Isleward/isleward/-/archive/v0.6.0.2/isleward-v0.6.0.2.tar.gz)\nv0.6.0.1: 426081daec84f7c99549f605cec6647c7273d5bd\n(https://gitlab.com/Isleward/isleward/-/archive/v0.6.0.1/isleward-v0.6.0.1.tar.gz)\nv0.6: 2b36286a41dc97a7fd80d0b3e5720c6ffb44ebf7\n(https://gitlab.com/Isleward/isleward/-/archive/v0.6/isleward-v0.6.tar.gz)\nv0.5.1.1: 0fd19a0704bf19addfa53e09ad9c8087d004af0a\n(https://gitlab.com/Isleward/isleward/-/archive/v0.5.1.1/isleward-v0.5.1.1.tar.gz)\nv0.5.1: 5ce3bb47e5945499b5152f9287b0e4934a8d9037\n(https://gitlab.com/Isleward/isleward/-/archive/v0.5.1/isleward-v0.5.1.tar.gz)\nv0.5: 7f1d3fb33a57144ce8427e448a8661ce844098b5\n(https://gitlab.com/Isleward/isleward/-/archive/v0.5/isleward-v0.5.tar.gz)\nv0.4.4.5: fc06a73c18e6c5b5b5796ecc41d85de40b71128c\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.5/isleward-v0.4.4.5.tar.gz)\nv0.4.4.4: 75ba773adb0328c8e3bcd52d55fe9090c84aa0b6\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.4/isleward-v0.4.4.4.tar.gz)\nv0.4.4.3: f5e937eb0828156a170bd0c4e6d2d5786d759abd\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.3/isleward-v0.4.4.3.tar.gz)\nv0.4.4.2: 4f9379a2d831b0d418c1c7843160f7f7e01e59d6\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.2/isleward-v0.4.4.2.tar.gz)\nv0.4.4.1: 2279d5d59e96d9285be90d4050e3e4f385533bfc\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.1/isleward-v0.4.4.1.tar.gz)\nv0.4.4: 99b5629b21df552fd50899eda5d13640a007d8f8\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4/isleward-v0.4.4.tar.gz)\nv0.4.3.1: e971964eefcfd8f1e3d6cea5e8c16babbd016249\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.3.1/isleward-v0.4.3.1.tar.gz)\nv0.4.3: 88f2e24755addeadfa164890623729965b05287b\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.3/isleward-v0.4.3.tar.gz)\nv0.4.2.4: 7cc57bde958824af45d30d5bd6dd51e4de7fc099\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.4/isleward-v0.4.2.4.tar.gz)\nv0.4.2.3: 81b8761bb8f5b3e3179ae1fd529746f18b70577c\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.3/isleward-v0.4.2.3.tar.gz)\nv0.4.2.2: 2980baa1eedb744673ff7c2efea015b81f6c0310\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.2/isleward-v0.4.2.2.tar.gz)\nv0.4.2.1: 66c156e29ac2c10a7c7159e6c537083b21d8a32f\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.1/isleward-v0.4.2.1.tar.gz)\nv0.4.2: 96e988416c76da5b37709ac0ce282c7b0d29c7fc\n(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2/isleward-v0.4.2.tar.gz)\n"
+     "output_type": "stream",
+     "text": [
+      "v0.7.0: aa672412a1942af47801ded9f466fa1bf6139c04\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.7.0/isleward-v0.7.0.tar.gz)\n",
+      "v0.6.1.2: 17584a7a97d21a5b01ece52139922b2dbea771da\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.6.1.2/isleward-v0.6.1.2.tar.gz)\n",
+      "v0.6.1.1: 4c3229825dd8dc7414a52e6028bb084e47db4022\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.6.1.1/isleward-v0.6.1.1.tar.gz)\n",
+      "v0.6.1: a77c207652946f2282efd73867dd35a595139991\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.6.1/isleward-v0.6.1.tar.gz)\n",
+      "v0.6.0.3: e921bccd0d8efd2dcb69ff1ca5501c8fab9b47bf\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.6.0.3/isleward-v0.6.0.3.tar.gz)\n",
+      "v0.6.0.2: 91d0c51f23dbd7d10ca40cf89220335366462428\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.6.0.2/isleward-v0.6.0.2.tar.gz)\n",
+      "v0.6.0.1: 426081daec84f7c99549f605cec6647c7273d5bd\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.6.0.1/isleward-v0.6.0.1.tar.gz)\n",
+      "v0.6: 2b36286a41dc97a7fd80d0b3e5720c6ffb44ebf7\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.6/isleward-v0.6.tar.gz)\n",
+      "v0.5.1.1: 0fd19a0704bf19addfa53e09ad9c8087d004af0a\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.5.1.1/isleward-v0.5.1.1.tar.gz)\n",
+      "v0.5.1: 5ce3bb47e5945499b5152f9287b0e4934a8d9037\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.5.1/isleward-v0.5.1.tar.gz)\n",
+      "v0.5: 7f1d3fb33a57144ce8427e448a8661ce844098b5\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.5/isleward-v0.5.tar.gz)\n",
+      "v0.4.4.5: fc06a73c18e6c5b5b5796ecc41d85de40b71128c\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.5/isleward-v0.4.4.5.tar.gz)\n",
+      "v0.4.4.4: 75ba773adb0328c8e3bcd52d55fe9090c84aa0b6\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.4/isleward-v0.4.4.4.tar.gz)\n",
+      "v0.4.4.3: f5e937eb0828156a170bd0c4e6d2d5786d759abd\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.3/isleward-v0.4.4.3.tar.gz)\n",
+      "v0.4.4.2: 4f9379a2d831b0d418c1c7843160f7f7e01e59d6\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.2/isleward-v0.4.4.2.tar.gz)\n",
+      "v0.4.4.1: 2279d5d59e96d9285be90d4050e3e4f385533bfc\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4.1/isleward-v0.4.4.1.tar.gz)\n",
+      "v0.4.4: 99b5629b21df552fd50899eda5d13640a007d8f8\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.4/isleward-v0.4.4.tar.gz)\n",
+      "v0.4.3.1: e971964eefcfd8f1e3d6cea5e8c16babbd016249\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.3.1/isleward-v0.4.3.1.tar.gz)\n",
+      "v0.4.3: 88f2e24755addeadfa164890623729965b05287b\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.3/isleward-v0.4.3.tar.gz)\n",
+      "v0.4.2.4: 7cc57bde958824af45d30d5bd6dd51e4de7fc099\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.4/isleward-v0.4.2.4.tar.gz)\n",
+      "v0.4.2.3: 81b8761bb8f5b3e3179ae1fd529746f18b70577c\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.3/isleward-v0.4.2.3.tar.gz)\n",
+      "v0.4.2.2: 2980baa1eedb744673ff7c2efea015b81f6c0310\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.2/isleward-v0.4.2.2.tar.gz)\n",
+      "v0.4.2.1: 66c156e29ac2c10a7c7159e6c537083b21d8a32f\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2.1/isleward-v0.4.2.1.tar.gz)\n",
+      "v0.4.2: 96e988416c76da5b37709ac0ce282c7b0d29c7fc\n",
+      "(https://gitlab.com/Isleward/isleward/-/archive/v0.4.2/isleward-v0.4.2.tar.gz)\n"
+     ]
     }
    ],
    "source": [
@@ -81,5 +112,26 @@
     "    print(f\"{release.title}: {release.git_tag.commit_sha}\\n({release.tarball_url})\")"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.3 64-bit",
+   "name": "python38364bit3ec8239d0440456baaf370e87148ec69"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.4-final"
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/examples/syncing_labels.ipynb
+++ b/examples/syncing_labels.ipynb
@@ -150,7 +150,7 @@
     }
    ],
    "source": [
-    "wanted_labels = list(filter(lambda l: \"/\" in l.name, labels))\n",
+    "wanted_labels = list(filter(lambda label: \"/\" in label.name, labels))\n",
     "\n",
     "wanted_labels"
    ]

--- a/examples/user_owned_repositories.ipynb
+++ b/examples/user_owned_repositories.ipynb
@@ -31,6 +31,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "\n",
     "TOKEN = os.environ.get(\"GITHUB_TOKEN\") # if variable is not set, you get `None`"
    ]
   },
@@ -101,8 +102,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": "mfocko/cascadia-code has 0 pull requests open\nmfocko/doom-emacs has 0 pull requests open\nmfocko/hello-world has 2 pull requests open\n"
     }
    ],

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -210,13 +210,7 @@ class GithubProject(BaseGitProject):
         return [self.github_repo.owner.login]
 
     def __get_collaborators(self) -> set[str]:
-        try:
-            collaborators = self._get_collaborators_with_permission()
-        except github.GithubException:
-            logger.debug(
-                "Current Github token must have push access to view repository permissions.",
-            )
-            return set()
+        collaborators = self._get_collaborators_with_permission()
 
         usernames = []
         for login, permission in collaborators.items():

--- a/tests/integration/github/test_generic_commands.py
+++ b/tests/integration/github/test_generic_commands.py
@@ -146,7 +146,7 @@ class GenericCommands(GithubTests):
 
     def test_get_owners(self):
         owners = self.ogr_project.get_owners()
-        assert ["packit"] == owners
+        assert owners == ["packit"]
 
     def test_issue_permissions(self):
         users = self.ogr_project.who_can_close_issue()

--- a/tests/unit/test_github.py
+++ b/tests/unit/test_github.py
@@ -20,7 +20,7 @@ from ogr.services.github.project import GithubProject
 from ogr.services.github.pull_request import GithubPullRequest
 
 
-@pytest.fixture()
+@pytest.fixture
 def github_project(mock_github_repo):
     github_project = GithubProject(
         repo="test_repo",
@@ -42,7 +42,7 @@ def github_project(mock_github_repo):
     return github_project
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_pull_request():
     def mock_pull_request_factory(id):
         return flexmock(id=id)
@@ -50,7 +50,7 @@ def mock_pull_request():
     return mock_pull_request_factory
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_github_repo(mock_pull_request):
     def mock_github_repo_factory():
         return flexmock(create_pull=mock_pull_request(42))
@@ -154,7 +154,7 @@ def test_create_github_check_run_output(
     assert create_github_check_run_output(title, summary, text) == expected
 
 
-@pytest.fixture()
+@pytest.fixture
 def github_service_with_multiple_auth_methods():
     return GithubService(
         token="abcdef",
@@ -182,7 +182,7 @@ def test_set_reset_customized_auth_method(github_service_with_multiple_auth_meth
     assert isinstance(service.authentication, Tokman)
 
 
-@pytest.fixture()
+@pytest.fixture
 def github_service_with_one_auth_method():
     return GithubService(
         tokman_instance_url="http://tokman:8080",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,7 +9,7 @@ from ogr.abstract import PRComment
 from ogr.utils import filter_comments, search_in_comments
 
 
-@pytest.fixture()
+@pytest.fixture
 def comments():
     return [
         PRComment(


### PR DESCRIPTION
Remove the unreachable ‹except› block. Since the ‹collaborators› is populated from a helper method that can produce only exceptions that are wrapped in the ogr's exceptions (handled by the metaclass), hence the ‹github.GithubException› cannot be raised.

Fixes #760