### PR TITLE
Implement get_commit_comment method and refactor CommitComment

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -1031,7 +1031,7 @@ class CommitFlag(OgrAbstractClass):
         raise NotImplementedError()
 
 
-class CommitComment(OgrAbstractClass):
+class CommitComment(Comment):
     """
     Attributes:
         sha (str): Hash of the related commit.
@@ -1039,10 +1039,13 @@ class CommitComment(OgrAbstractClass):
         author (str): Login of the author.
     """
 
-    def __init__(self, sha: str, body: str, author: str) -> None:
+    def __init__(
+        self,
+        sha: str,
+        raw_comment: Any,
+    ) -> None:
+        super().__init__(raw_comment=raw_comment)
         self.sha = sha
-        self.body = body
-        self.author = author
 
     @property  # type: ignore
     @deprecate_and_set_removal(
@@ -1872,6 +1875,19 @@ class GitProject(OgrAbstractClass):
 
         Returns:
             List of all comments for the commit.
+        """
+        raise NotImplementedError()
+
+    def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
+        """
+        Get commit comment.
+
+        Args:
+            commit_sha: SHA of the commit
+            comment_id: ID of the commit comment
+
+        Returns:
+            Object representing the commit comment.
         """
         raise NotImplementedError()
 

--- a/ogr/read_only.py
+++ b/ogr/read_only.py
@@ -252,7 +252,7 @@ class GitProjectReadOnly:
         commit: str,
         body: str,
     ) -> "CommitComment":
-        return CommitComment(sha=commit, body=body, author=cls.author)
+        return CommitComment(sha=commit, raw_comment=original_object)
 
     @classmethod
     def set_commit_status(

--- a/ogr/services/github/comments.py
+++ b/ogr/services/github/comments.py
@@ -4,11 +4,12 @@
 import datetime
 from typing import Union
 
+from github.CommitComment import CommitComment as _GithubCommitComment
 from github.IssueComment import IssueComment as _GithubIssueComment
 from github.PullRequestComment import PullRequestComment as _GithubPullRequestComment
 from github.Reaction import Reaction as _Reaction
 
-from ogr.abstract import Comment, IssueComment, PRComment, Reaction
+from ogr.abstract import Comment, CommitComment, IssueComment, PRComment, Reaction
 
 
 class GithubReaction(Reaction):
@@ -24,7 +25,11 @@ class GithubReaction(Reaction):
 class GithubComment(Comment):
     def _from_raw_comment(
         self,
-        raw_comment: Union[_GithubIssueComment, _GithubPullRequestComment],
+        raw_comment: Union[
+            _GithubIssueComment,
+            _GithubPullRequestComment,
+            _GithubCommitComment,
+        ],
     ) -> None:
         self._raw_comment = raw_comment
         self._id = raw_comment.id
@@ -58,5 +63,10 @@ class GithubIssueComment(GithubComment, IssueComment):
 
 
 class GithubPRComment(GithubComment, PRComment):
+    def __str__(self) -> str:
+        return "Github" + super().__str__()
+
+
+class GithubCommitComment(GithubComment, CommitComment):
     def __str__(self) -> str:
         return "Github" + super().__str__()

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -8,7 +8,7 @@ from typing import ClassVar, Optional, Union
 import github
 from github import UnknownObjectException
 from github.Commit import Commit
-from github.CommitComment import CommitComment as GithubCommitComment
+from github.CommitComment import CommitComment as _GithubCommitComment
 from github.GithubException import GithubException
 from github.Repository import Repository
 
@@ -34,6 +34,7 @@ from ogr.services.github.check_run import (
     GithubCheckRunResult,
     GithubCheckRunStatus,
 )
+from ogr.services.github.comments import GithubCommitComment
 from ogr.services.github.flag import GithubCommitFlag
 from ogr.services.github.issue import GithubIssue
 from ogr.services.github.pull_request import GithubPullRequest
@@ -345,11 +346,10 @@ class GithubProject(BaseGitProject):
 
     @staticmethod
     def _commit_comment_from_github_object(
-        raw_commit_coment: GithubCommitComment,
+        raw_commit_coment: _GithubCommitComment,
     ) -> CommitComment:
-        return CommitComment(
-            body=raw_commit_coment.body,
-            author=raw_commit_coment.user.login,
+        return GithubCommitComment(
+            raw_comment=raw_commit_coment,
             sha=raw_commit_coment.commit_id,
         )
 
@@ -359,6 +359,11 @@ class GithubProject(BaseGitProject):
             self._commit_comment_from_github_object(comment)
             for comment in github_commit.get_comments()
         ]
+
+    def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
+        return self._commit_comment_from_github_object(
+            self.github_repo.get_comment(comment_id),
+        )
 
     @if_readonly(
         return_function=GitProjectReadOnly.set_commit_status,

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -482,6 +482,9 @@ class PagureProject(BaseGitProject):
     def get_commit_comments(self, commit: str) -> list[CommitComment]:
         raise OperationNotSupported("Commit comments are not supported on Pagure.")
 
+    def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
+        raise OperationNotSupported("Commit comments are not supported on Pagure.")
+
     @if_readonly(return_function=GitProjectReadOnly.set_commit_status)
     @indirect(PagureCommitFlag.set)
     def set_commit_status(

--- a/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_commit_comment.yaml
+++ b/tests/integration/github/test_data/test_generic_commands/GenericCommands.test_get_commit_comment.yaml
@@ -1,0 +1,327 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/hello-world:
+      - metadata:
+          latency: 0.4622993469238281
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            allow_update_branch: false
+            archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+            clone_url: https://github.com/packit/hello-world.git
+            collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+            created_at: '2019-05-02T18:54:46Z'
+            custom_properties: {}
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+            events_url: https://api.github.com/repos/packit/hello-world/events
+            fork: false
+            forks: 23
+            forks_count: 23
+            forks_url: https://api.github.com/repos/packit/hello-world/forks
+            full_name: packit/hello-world
+            git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+            git_url: git://github.com/packit/hello-world.git
+            has_discussions: false
+            has_downloads: true
+            has_issues: true
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+            html_url: https://github.com/packit/hello-world
+            id: 184635124
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merge_commit_message: PR_BODY
+            merge_commit_title: PR_TITLE
+            merges_url: https://api.github.com/repos/packit/hello-world/merges
+            milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 23
+            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+            notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+            open_issues: 98
+            open_issues_count: 98
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+              user_view_type: public
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+              user_view_type: public
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+            pushed_at: '2024-10-22T04:57:05Z'
+            releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+            security_and_analysis:
+              dependabot_security_updates:
+                status: enabled
+              secret_scanning:
+                status: enabled
+              secret_scanning_non_provider_patterns:
+                status: disabled
+              secret_scanning_push_protection:
+                status: disabled
+              secret_scanning_validity_checks:
+                status: disabled
+            size: 180
+            squash_merge_commit_message: COMMIT_MESSAGES
+            squash_merge_commit_title: COMMIT_OR_PR_TITLE
+            ssh_url: git@github.com:packit/hello-world.git
+            stargazers_count: 4
+            stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+            subscribers_count: 6
+            subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+            svn_url: https://github.com/packit/hello-world
+            tags_url: https://api.github.com/repos/packit/hello-world/tags
+            teams_url: https://api.github.com/repos/packit/hello-world/teams
+            temp_clone_token: ''
+            topics: []
+            trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+            updated_at: '2023-01-31T17:16:23Z'
+            url: https://api.github.com/repos/packit/hello-world
+            use_squash_pr_title_as_default: false
+            visibility: public
+            watchers: 4
+            watchers_count: 4
+            web_commit_signoff_required: false
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Last-Modified: Tue, 31 Jan 2023 17:16:23 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '9'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2024-10-29 07:28:00 UTC
+            x-github-api-version-selected: '2022-11-28'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/comments/74596713:
+      - metadata:
+          latency: 0.3889343738555908
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_generic_commands
+          - ogr.abstract
+          - ogr.services.github.project
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            author_association: MEMBER
+            body: Testing commit comment
+            commit_id: 95069d7bedb6ae02def3fccce22169b412d08eac
+            created_at: '2022-05-26T15:46:44Z'
+            html_url: https://github.com/packit/hello-world/commit/95069d7bedb6ae02def3fccce22169b412d08eac#r74596713
+            id: 74596713
+            line: null
+            node_id: CC_kwDOCwFO9M4EckFp
+            path: README.md
+            position: 6
+            reactions:
+              '+1': 0
+              '-1': 0
+              confused: 0
+              eyes: 0
+              heart: 0
+              hooray: 0
+              laugh: 0
+              rocket: 0
+              total_count: 0
+              url: https://api.github.com/repos/packit/hello-world/comments/74596713/reactions
+            updated_at: '2022-05-26T15:46:44Z'
+            url: https://api.github.com/repos/packit/hello-world/comments/74596713
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/288686?v=4
+              events_url: https://api.github.com/users/jpopelka/events{/privacy}
+              followers_url: https://api.github.com/users/jpopelka/followers
+              following_url: https://api.github.com/users/jpopelka/following{/other_user}
+              gists_url: https://api.github.com/users/jpopelka/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/jpopelka
+              id: 288686
+              login: jpopelka
+              node_id: MDQ6VXNlcjI4ODY4Ng==
+              organizations_url: https://api.github.com/users/jpopelka/orgs
+              received_events_url: https://api.github.com/users/jpopelka/received_events
+              repos_url: https://api.github.com/users/jpopelka/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/jpopelka/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/jpopelka/subscriptions
+              type: User
+              url: https://api.github.com/users/jpopelka
+              user_view_type: public
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Last-Modified: Wed, 09 Oct 2024 11:20:50 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '10'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2024-10-29 07:28:00 UTC
+            x-github-api-version-selected: '2022-11-28'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/github/test_generic_commands.py
+++ b/tests/integration/github/test_generic_commands.py
@@ -259,6 +259,15 @@ class GenericCommands(GithubTests):
         assert comments[0].sha == "95069d7bedb6ae02def3fccce22169b412d08eac"
         assert comments[0].body == "Testing commit comment"
 
+    def test_get_commit_comment(self):
+        comment = self.hello_world_project.get_commit_comment(
+            "95069d7bedb6ae02def3fccce22169b412d08eac",
+            74596713,
+        )
+        assert comment
+        assert comment.sha == "95069d7bedb6ae02def3fccce22169b412d08eac"
+        assert comment.body == "Testing commit comment"
+
     def test_get_web_url(self):
         url = self.ogr_project.get_web_url()
         assert url == "https://github.com/packit/ogr"

--- a/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_commit_comment.yaml
+++ b/tests/integration/gitlab/test_data/test_generic_commands/GenericCommands.test_get_commit_comment.yaml
@@ -1,0 +1,1250 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64:
+      - metadata:
+          latency: 0.4733545780181885
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.commits
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            author_email: lbarczio@redhat.com
+            author_name: Laura Barcziova
+            authored_date: '2019-09-11T11:13:22.000+02:00'
+            committed_date: '2019-09-11T11:13:22.000+02:00'
+            committer_email: lbarczio@redhat.com
+            committer_name: Laura Barcziova
+            created_at: '2019-09-11T11:13:22.000+02:00'
+            extended_trailers: {}
+            id: 11b37d913374b14f8519d16c2a2cca3ebc14ac64
+            last_pipeline:
+              created_at: '2019-09-12T13:15:31.185Z'
+              id: 81824705
+              iid: 1
+              project_id: 14233409
+              ref: master
+              sha: 11b37d913374b14f8519d16c2a2cca3ebc14ac64
+              source: external
+              status: success
+              updated_at: '2019-09-12T13:18:11.317Z'
+              web_url: https://gitlab.com/packit-service/ogr-tests/-/pipelines/81824705
+            message: 'new
+
+              '
+            parent_ids:
+            - 101a42bbbe174d04b465d49caf274dc3b4defeca
+            project_id: 14233409
+            short_id: 11b37d91
+            stats:
+              additions: 1
+              deletions: 3
+              total: 4
+            status: success
+            title: new
+            trailers: {}
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/commit/11b37d913374b14f8519d16c2a2cca3ebc14ac64
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 8d67d24c486da3be-BTS
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=Gd4%2Bo7AVd00vu0hOAakDh2fP1tbi%2Bn9P9Xaz6QfTshD%2BHcxwbIBiHmnNUIXwXMxcrp0zbQ4baQC4UN57BnB9G6sUXt6oW9%2FTNtiCnuOUpzPCw%2FRyIs543MP2hi0%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"ab45a0867d3beaa20ccca6299921808e"
+            gitlab-lb: haproxy-main-54-lb-gprd
+            gitlab-sv: api-gke-us-east1-b
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"564571d2342e630f3f485230c3a932ca","version":"1"}'
+            x-request-id: 564571d2342e630f3f485230c3a932ca
+            x-runtime: '0.147306'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions:
+      - metadata:
+          latency: 0.561051607131958
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - id: a1276faf49b56e0888e63251444f07fc9d41b29a
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/7eaddaccb0af615d1017591ff12acf8566265d393e05dfb853ee08108951e0f7?s=80&d=identicon
+                id: 4594931
+                locked: false
+                name: "Laura Barcziov\xE1"
+                state: active
+                username: lbarcziova
+                web_url: https://gitlab.com/lbarcziova
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-12T13:07:55.637Z'
+              id: 216270202
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-12T13:07:55.637Z'
+          - id: 491e340e6870ba40c65459720ed3b2c5f2f128c8
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/9b3966cd5266e84a03e584aeb2067f00580ca2e04f477c251778aee5a96f9921?s=80&d=identicon
+                id: 433670
+                locked: false
+                name: "Franti\u0161ek Lachman"
+                state: active
+                username: lachmanfrantisek
+                web_url: https://gitlab.com/lachmanfrantisek
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-18T14:13:12.302Z'
+              id: 218874053
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-18T14:13:12.302Z'
+          - id: c5f8c95d038a69a9420083eb1244d6b2293e1204
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T09:58:41.456Z'
+              id: 222442032
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T09:58:41.456Z'
+          - id: 9f1d9d8ef9632cdc0a02eb5f02284309c18e52d4
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T10:11:15.464Z'
+              id: 222448864
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T10:11:15.464Z'
+          - id: 73610b23235e9f03d527a0be951b3d9335904aba
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T10:11:55.369Z'
+              id: 222449227
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T10:11:55.369Z'
+          - id: 1d4224e475c5f10b6223ae32964cdaa744d1614f
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T10:13:00.130Z'
+              id: 222449760
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T10:13:00.130Z'
+          - id: 5b92e574f4653c8a73de837b2abd880e28243066
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T10:14:09.928Z'
+              id: 222450351
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T10:14:09.928Z'
+          - id: 92c0d20b2a005af3fd5863e426ecfe36296ebae1
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T10:15:13.730Z'
+              id: 222450883
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T10:15:13.730Z'
+          - id: a03725e9c0013269e6799b88648b08272173c668
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T10:18:33.229Z'
+              id: 222452426
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T10:18:33.229Z'
+          - id: 4bcaeba5b1a923499ab7643892135396c8bfa02c
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T10:21:48.830Z'
+              id: 222454052
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T10:21:48.830Z'
+          - id: 5aac765129d8a9dd3f68332b5588c3228eec71a7
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-26T14:19:52.759Z'
+              id: 222596266
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-26T14:19:52.759Z'
+          - id: e369cd24ebf165e08f9da39b5be4e7cf7ff822f9
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-09-27T08:38:40.270Z'
+              id: 222987607
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-09-27T08:38:40.270Z'
+          - id: 0b1fe07ad6751393796de7b789032846522f7f96
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2019-10-08T16:03:07.888Z'
+              id: 227600652
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2019-10-08T16:03:07.888Z'
+          - id: d72dbc7e79b499aca3de39d34908848cdac95409
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2020-08-21T09:24:35.046Z'
+              id: 399900674
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2020-08-21T09:24:35.046Z'
+          - id: 232f7d2514e9573bc5ed120988b1349a3f14b224
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2020-08-21T10:57:54.787Z'
+              id: 399976143
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2020-08-21T10:57:54.787Z'
+          - id: a484d1de64c8bab8414ffa2936daecd3273b9dfd
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2020-08-21T13:32:32.199Z'
+              id: 400076518
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2020-08-21T13:32:32.199Z'
+          - id: d9026d38ce239eef881e3863626c2029f47ca641
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2020-08-24T08:16:55.396Z'
+              id: 400879834
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2020-08-24T08:16:55.396Z'
+          - id: dbfbdc27881a37f66db4dbd62ab9850a5ba15387
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://secure.gravatar.com/avatar/3bd00d5dc2fe535afffc72a22cf42c5b214f28b1cf2703adba20c105cc57cc66?s=80&d=identicon
+                id: 4626962
+                locked: false
+                name: jscotka
+                state: active
+                username: jscotka
+                web_url: https://gitlab.com/jscotka
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2020-08-24T08:43:08.733Z'
+              id: 400909028
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2020-08-24T08:43:08.733Z'
+          - id: 2ce22b76e52d9bb9b0b3699fbc8735d193fb2349
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2020-08-27T09:19:39.848Z'
+              id: 403064356
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2020-08-27T09:19:39.848Z'
+          - id: 1fad978c5d26091b2b9b79d50ab2e0fc0a0eca65
+            individual_note: false
+            notes:
+            - attachment: null
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2020-08-31T08:32:54.689Z'
+              id: 404466769
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2020-08-31T08:32:54.689Z'
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 8d67d24f4cada3be-BTS
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=yEjDPeMMcxETY9%2BUjtWZKmY%2Bl%2BEN7oL9bwlaKnw0rZm2hvnQ8FB6v%2Bwr%2BIjskdpXV4eh0JWst6sW5%2Bw5J33M6y5xZrjOEVcvI5pUR3kJ1seIj4BiDjr1QtcTQtw%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"2967160dbf87300801badd607c627da7"
+            gitlab-lb: haproxy-main-58-lb-gprd
+            gitlab-sv: api-gke-us-east1-c
+            link: <https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions?id=14233409&noteable_id=11b37d913374b14f8519d16c2a2cca3ebc14ac64&page=2&per_page=20>;
+              rel="next", <https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions?id=14233409&noteable_id=11b37d913374b14f8519d16c2a2cca3ebc14ac64&page=1&per_page=20>;
+              rel="first", <https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions?id=14233409&noteable_id=11b37d913374b14f8519d16c2a2cca3ebc14ac64&page=2&per_page=20>;
+              rel="last"
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"93f9577c9fea031c784d051b41b6eedd","version":"1"}'
+            x-next-page: '2'
+            x-page: '1'
+            x-per-page: '20'
+            x-prev-page: ''
+            x-request-id: 93f9577c9fea031c784d051b41b6eedd
+            x-runtime: '0.329237'
+            x-total: '24'
+            x-total-pages: '2'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      ? https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions/6b6301cf0cc9a9d12806dcb4362ba387bef653df/notes/1619912175
+      : - metadata:
+            latency: 0.3954479694366455
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_generic_commands
+            - ogr.abstract
+            - ogr.services.gitlab.project
+            - gitlab.v4.objects.notes
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              attachment: null
+              author:
+                avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                id: 375555
+                locked: false
+                name: Matej Focko
+                state: active
+                username: mfocko
+                web_url: https://gitlab.com/mfocko
+              body: Comment to line 3
+              commands_changes: {}
+              confidential: false
+              created_at: '2023-10-26T10:11:51.117Z'
+              id: 1619912175
+              imported: false
+              imported_from: none
+              internal: false
+              noteable_id: null
+              noteable_iid: null
+              noteable_type: Commit
+              project_id: 14233409
+              resolvable: false
+              system: false
+              type: LegacyDiffNote
+              updated_at: '2023-10-26T10:11:51.117Z'
+            _next: null
+            elapsed: 0.2
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 8d67d25839dca3be-BTS
+              Connection: keep-alive
+              Content-Encoding: gzip
+              Content-Type: application/json
+              Date: Fri, 01 Nov 2019 13-36-03 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=5cPYIi1rYm7BdoetiaFx%2FvzvYljr9zlhHgM%2BJLxOoPuQsAswAEzhzNpwAGJiTW8dlGhYmuZJmT8E85COlFQB3iMWOmHscFfLeT283Q49TF4aKV9GLYomyVJSp00%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"6e41821fa9ec3a6f85112969f61e5519"
+              gitlab-lb: haproxy-main-13-lb-gprd
+              gitlab-sv: api-gke-us-east1-c
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"d686edb8a3c1099310cb9890af94dc2e","version":"1"}'
+              x-request-id: d686edb8a3c1099310cb9890af94dc2e
+              x-runtime: '0.134725'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      ? https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions?id=14233409&noteable_id=11b37d913374b14f8519d16c2a2cca3ebc14ac64&page=2&per_page=20
+      : - metadata:
+            latency: 0.8535094261169434
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests.integration.gitlab.test_generic_commands
+            - ogr.abstract
+            - ogr.services.gitlab.project
+            - gitlab.exceptions
+            - gitlab.mixins
+            - gitlab.client
+            - gitlab._backends.requests_backend
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - id: ae2d1476a1ba52e77865fbe2ebdd394fc8e59627
+              individual_note: false
+              notes:
+              - attachment: null
+                author:
+                  avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                  id: 375555
+                  locked: false
+                  name: Matej Focko
+                  state: active
+                  username: mfocko
+                  web_url: https://gitlab.com/mfocko
+                body: Comment to line 3
+                commands_changes: {}
+                confidential: false
+                created_at: '2020-10-12T10:27:00.416Z'
+                id: 428056003
+                imported: false
+                imported_from: none
+                internal: false
+                noteable_id: null
+                noteable_iid: null
+                noteable_type: Commit
+                project_id: 14233409
+                resolvable: false
+                system: false
+                type: LegacyDiffNote
+                updated_at: '2020-10-12T10:27:00.416Z'
+            - id: 4376c12971f34d4f7009cbd23a0e5400b3983165
+              individual_note: false
+              notes:
+              - attachment: null
+                author:
+                  avatar_url: https://secure.gravatar.com/avatar/6b565cb18c3fad52f24b6239c182bc8c4f50a9204afabea762f359dfb6d06564?s=80&d=identicon
+                  id: 6466632
+                  locked: false
+                  name: Ben Crocker
+                  state: active
+                  username: bcrocker
+                  web_url: https://gitlab.com/bcrocker
+                body: Comment to line 3
+                commands_changes: {}
+                confidential: false
+                created_at: '2021-04-12T21:10:45.927Z'
+                id: 550099480
+                imported: false
+                imported_from: none
+                internal: false
+                noteable_id: null
+                noteable_iid: null
+                noteable_type: Commit
+                project_id: 14233409
+                resolvable: false
+                system: false
+                type: LegacyDiffNote
+                updated_at: '2021-04-12T21:10:45.927Z'
+            - id: b169dc45729309a05ed4f2e682157228a78eb688
+              individual_note: false
+              notes:
+              - attachment: null
+                author:
+                  avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                  id: 375555
+                  locked: false
+                  name: Matej Focko
+                  state: active
+                  username: mfocko
+                  web_url: https://gitlab.com/mfocko
+                body: Comment to line 3
+                commands_changes: {}
+                confidential: false
+                created_at: '2022-01-05T18:40:30.419Z'
+                id: 802380207
+                imported: false
+                imported_from: none
+                internal: false
+                noteable_id: null
+                noteable_iid: null
+                noteable_type: Commit
+                project_id: 14233409
+                resolvable: false
+                system: false
+                type: LegacyDiffNote
+                updated_at: '2022-01-05T18:40:30.419Z'
+            - id: 6b6301cf0cc9a9d12806dcb4362ba387bef653df
+              individual_note: false
+              notes:
+              - attachment: null
+                author:
+                  avatar_url: https://gitlab.com/uploads/-/system/user/avatar/375555/avatar.png
+                  id: 375555
+                  locked: false
+                  name: Matej Focko
+                  state: active
+                  username: mfocko
+                  web_url: https://gitlab.com/mfocko
+                body: Comment to line 3
+                commands_changes: {}
+                confidential: false
+                created_at: '2023-10-26T10:11:51.117Z'
+                id: 1619912175
+                imported: false
+                imported_from: none
+                internal: false
+                noteable_id: null
+                noteable_iid: null
+                noteable_type: Commit
+                project_id: 14233409
+                resolvable: false
+                system: false
+                type: LegacyDiffNote
+                updated_at: '2023-10-26T10:11:51.117Z'
+            _next: null
+            elapsed: 0.2
+            encoding: utf-8
+            headers:
+              CF-Cache-Status: MISS
+              CF-RAY: 8d67d252d9e9a3be-BTS
+              Connection: keep-alive
+              Content-Encoding: gzip
+              Content-Type: application/json
+              Date: Fri, 01 Nov 2019 13-36-03 GMT
+              NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+              Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=xl7gu9rsMe8TsRETWKUp3qWp54AJi%2BbsI4l2VGkbQUk%2Bp5OiOjw5RToGX5aWqtk1OYn5%2FhlTiAw7GU0VYYswET0Hiht5LW%2BB%2BRD0XmoRFIRuXbiZYZvmBEUrxkw%3D"}],"group":"cf-nel","max_age":604800}'
+              Server: cloudflare
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-security-policy: default-src 'none'
+              etag: W/"e7e266f41c8fcdc321f34e7eb850424f"
+              gitlab-lb: haproxy-main-44-lb-gprd
+              gitlab-sv: api-gke-us-east1-d
+              link: <https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions?id=14233409&noteable_id=11b37d913374b14f8519d16c2a2cca3ebc14ac64&page=1&per_page=20>;
+                rel="prev", <https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions?id=14233409&noteable_id=11b37d913374b14f8519d16c2a2cca3ebc14ac64&page=1&per_page=20>;
+                rel="first", <https://gitlab.com/api/v4/projects/14233409/repository/commits/11b37d913374b14f8519d16c2a2cca3ebc14ac64/discussions?id=14233409&noteable_id=11b37d913374b14f8519d16c2a2cca3ebc14ac64&page=2&per_page=20>;
+                rel="last"
+              referrer-policy: strict-origin-when-cross-origin
+              strict-transport-security: max-age=31536000
+              vary: Origin, Accept-Encoding
+              x-content-type-options: nosniff
+              x-frame-options: SAMEORIGIN
+              x-gitlab-meta: '{"correlation_id":"cd8c8334d8399249f3ab986db4ac5964","version":"1"}'
+              x-next-page: ''
+              x-page: '2'
+              x-per-page: '20'
+              x-prev-page: '1'
+              x-request-id: cd8c8334d8399249f3ab986db4ac5964
+              x-runtime: '0.558160'
+              x-total: '24'
+              x-total-pages: '2'
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.4097590446472168
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - gitlab.v4.objects.projects
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              cluster_agents: https://gitlab.com/api/v4/projects/14233409/cluster_agents
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_allow_fork_pipelines_to_run_in_parent_project: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_forward_deployment_enabled: null
+            ci_forward_deployment_rollback_allowed: true
+            ci_id_token_sub_claim_components:
+            - project_path
+            - ref_type
+            - ref
+            ci_job_token_scope_enabled: false
+            ci_pipeline_variables_minimum_override_role: maintainer
+            ci_push_repository_for_job_token_allowed: false
+            ci_separated_caches: true
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            description_html: <p data-sourcepos="1:1-1:84" dir="auto">Testing repository
+              for python-ogr package.  |  <a href="https://github.com/packit-service/ogr"
+              rel="nofollow noreferrer noopener" target="_blank">https://github.com/packit-service/ogr</a></p>
+            emails_disabled: false
+            emails_enabled: true
+            empty_repo: false
+            enforce_auth_checks_on_uploads: true
+            environments_access_level: enabled
+            external_authorization_classification_label: ''
+            feature_flags_access_level: enabled
+            forking_access_level: enabled
+            forks_count: 5
+            group_runners_enabled: true
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_error: null
+            import_status: none
+            import_type: null
+            import_url: null
+            infrastructure_access_level: enabled
+            issue_branch_template: null
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2023-12-02T18:37:49.862Z'
+            lfs_enabled: true
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            model_experiments_access_level: enabled
+            model_registry_access_level: enabled
+            monitor_access_level: enabled
+            name: ogr-tests
+            name_with_namespace: Packit / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: Packit
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 77
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access:
+                access_level: 50
+                notification_level: 3
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            releases_access_level: enabled
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            repository_object_format: sha1
+            request_access_enabled: false
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            restrict_user_defined_variables: false
+            runner_token_expiration_interval: null
+            runners_token: null
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+packit-service-ogr-tests-14233409-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            updated_at: '2024-01-09T09:25:04.219Z'
+            visibility: public
+            warn_about_potentially_unwanted_characters: true
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 8d67d249ad45a3be-BTS
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=KXXOeGfkCWhB8YxJQZt6EkewOksALFQV%2FgTzlIMoJ7mH1SYnciyglKyGrlJk7xrdUGefVM706zAAWiDSJQDsMp%2F8uf2rwfgy0txaahzJ6%2FZfdlICezZzUgLeT9U%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"3276b5a7b24f45d76cb8b8583c5b0708"
+            gitlab-lb: haproxy-main-13-lb-gprd
+            gitlab-sv: api-gke-us-east1-c
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"79adc31eb3eb9adc32a1cf74cbb600cc","version":"1"}'
+            x-request-id: 79adc31eb3eb9adc32a1cf74cbb600cc
+            x-runtime: '0.157962'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.41553807258605957
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_generic_commands
+          - ogr.abstract
+          - ogr.services.gitlab.project
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.v4.objects.users
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://secure.gravatar.com/avatar/7eaddaccb0af615d1017591ff12acf8566265d393e05dfb853ee08108951e0f7?s=80&d=identicon
+            bio: ''
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 1
+            commit_email: laura.barcziova@gmail.com
+            confirmed_at: '2019-09-10T13:30:57.928Z'
+            created_at: '2019-09-10T13:30:57.989Z'
+            current_sign_in_at: '2024-10-18T06:55:40.099Z'
+            discord: ''
+            email: laura.barcziova@gmail.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            id: 4594931
+            identities:
+            - extern_uid: '49026743'
+              provider: github
+              saml_provider_id: null
+            job_title: ''
+            last_activity_on: '2024-10-22'
+            last_sign_in_at: '2024-10-09T09:46:27.532Z'
+            linkedin: ''
+            local_time: 7:37 AM
+            location: ''
+            locked: false
+            name: "Laura Barcziov\xE1"
+            organization: ''
+            private_profile: false
+            projects_limit: 100000
+            pronouns: null
+            public_email: ''
+            scim_identities: []
+            shared_runners_minutes_limit: null
+            skype: ''
+            state: active
+            theme_id: 1
+            twitter: ''
+            two_factor_enabled: true
+            username: lbarcziova
+            web_url: https://gitlab.com/lbarcziova
+            website_url: ''
+            work_information: null
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: MISS
+            CF-RAY: 8d67d24719e0a3be-BTS
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            NEL: '{"success_fraction":0.01,"report_to":"cf-nel","max_age":604800}'
+            Report-To: '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=wl1wcuwCxx%2BqXyyjwJf14N4qhrJK60qbAgBycKsLDek%2BFf1S80UNeCclm9oyW2aLuu1XKJflxDXsrUp3Duv%2BN3HApAw2iM%2BpMzFrBZj7vb3ZDMahigE%2Bhktjf%2BU%3D"}],"group":"cf-nel","max_age":604800}'
+            Server: cloudflare
+            Set-Cookie: _cfuvid=OQjgf9kpM5Fkc_wFvocKjXHBiNe1lJPJAl_4Bi0AtAs-1729582639497-0.0.1.1-604800000;
+              path=/; domain=.gitlab.com; HttpOnly; Secure; SameSite=None
+            Transfer-Encoding: chunked
+            cache-control: max-age=0, private, must-revalidate
+            content-security-policy: default-src 'none'
+            etag: W/"19cad17fe1a3acfc8caf17ae998b0e07"
+            gitlab-lb: haproxy-main-46-lb-gprd
+            gitlab-sv: api-gke-us-east1-c
+            referrer-policy: strict-origin-when-cross-origin
+            strict-transport-security: max-age=31536000
+            vary: Origin, Accept-Encoding
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"3f662291cf80d8f94f3ef54fa30ccc34","version":"1"}'
+            x-request-id: 3f662291cf80d8f94f3ef54fa30ccc34
+            x-runtime: '0.053154'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_generic_commands.py
+++ b/tests/integration/gitlab/test_generic_commands.py
@@ -210,6 +210,16 @@ class GenericCommands(GitlabTests):
         assert comments[0].sha == "11b37d913374b14f8519d16c2a2cca3ebc14ac64"
         assert comments[0].body == "Comment to line 3"
 
+    def test_get_commit_comment(self):
+        comment = self.project.get_commit_comment(
+            "11b37d913374b14f8519d16c2a2cca3ebc14ac64",
+            1619912175,
+        )
+        assert comment
+        assert comment.sha == "11b37d913374b14f8519d16c2a2cca3ebc14ac64"
+        assert comment.body == "Comment to line 3"
+        assert comment.author == "mfocko"
+
     def test_get_web_url(self):
         url = self.project.get_web_url()
         assert url == "https://gitlab.com/packit-service/ogr-tests"


### PR DESCRIPTION
Make the CommitComment inherit from Comment directly to share the common functionality (e.g. adding emojis).

Needed for packit/packit-service#2589


RELEASE NOTES BEGIN

There is a new method for getting a single commit comment, supporting also retrieval and adding reactions in GitHub.

RELEASE NOTES END
