### PR TITLE
Remove outdated EPEL 9 workaround

### DIFF
--- a/fedora/python-ogr.spec
+++ b/fedora/python-ogr.spec
@@ -26,8 +26,7 @@ One Git library to Rule!
 
 
 %generate_buildrequires
-# The -w flag is required for EPEL 9's older hatchling
-%pyproject_buildrequires %{?el9:-w}
+%pyproject_buildrequires
 
 
 %build

--- a/plans/packit-integration.fmf
+++ b/plans/packit-integration.fmf
@@ -21,7 +21,7 @@ adjust:
 
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
     because: "build and deepdiff are not in EPEL 9"
-    prepare:
+    prepare+:
       - how: install
         package: python3-pip
       - how: shell


### PR DESCRIPTION
Sync of downstream change: https://src.fedoraproject.org/rpms/python-ogr/pull-request/688