### PR TITLE
implement methods for the classes inheriting from Comment and Reaction https://github.com/packit/ogr/issues/883

### DIFF
--- a/ogr/abstract.py
+++ b/ogr/abstract.py
@@ -168,15 +168,34 @@ class OgrAbstractClass(metaclass=CatchCommonErrors):
 
 
 class Reaction(OgrAbstractClass):
-    def __init__(self, raw_reaction: Any) -> None:
+    def __init__(
+        self,
+        raw_reaction: Any,
+        reaction_id: Optional[int] = None,
+        parent: Optional[Any] = None,
+    ) -> None:
         self._raw_reaction = raw_reaction
+        self._id = reaction_id
+        self._parent = parent
 
     def __str__(self):
         return f"Reaction(raw_reaction={self._raw_reaction})"
 
     def delete(self) -> None:
         """Delete a reaction."""
-        raise NotImplementedError()
+        if not self._id:
+            raise ValueError("Cannot delete a reaction without an ID.")
+        if not self._parent:
+            raise ValueError("Cannot delete a reaction without a parent object.")
+        if not self._raw_reaction or "content" not in self._raw_reaction:
+            raise ValueError("Invalid raw reaction data.")
+
+        self._parent.client.issue.delete_comment_reaction(
+            owner=self._parent.repo_namespace,
+            repo=self._parent.repo_name,
+            id=self._id,
+            content=self._raw_reaction["content"],
+        )
 
 
 class Comment(OgrAbstractClass):
@@ -215,7 +234,11 @@ class Comment(OgrAbstractClass):
 
     def _from_raw_comment(self, raw_comment: Any) -> None:
         """Constructs Comment object from raw_comment given from API."""
-        raise NotImplementedError()
+        self._id = raw_comment["id"]
+        self._body = raw_comment["body"]
+        self._author = raw_comment["user"]["login"]
+        self._created = raw_comment["created_at"]
+        self._edited = raw_comment.get("updated_at")
 
     @property
     def body(self) -> str:
@@ -247,7 +270,15 @@ class Comment(OgrAbstractClass):
 
     def get_reactions(self) -> list[Reaction]:
         """Returns list of reactions."""
-        raise NotImplementedError()
+        if not self._id or not self._parent:
+            raise ValueError("Cannot fetch reactions without a comment ID and parent.")
+
+        reactions_data = self._parent.client.issue.get_comment_reactions(
+            owner=self._parent.repo_namespace,
+            repo=self._parent.repo_name,
+            id=self._id,
+        )
+        return [Reaction(raw_reaction=react) for react in reactions_data]
 
     def add_reaction(self, reaction: str) -> Reaction:
         """
@@ -261,7 +292,16 @@ class Comment(OgrAbstractClass):
         Returns:
             Object representing newly added reaction.
         """
-        raise NotImplementedError()
+        if not self._id or not self._parent:
+            raise ValueError("Cannot add reaction without a comment ID and parent.")
+
+        reaction_data = self._parent.client.issue.add_comment_reaction(
+            owner=self._parent.repo_namespace,
+            repo=self._parent.repo_name,
+            id=self._id,
+            content=reaction,
+        )
+        return Reaction(raw_reaction=reaction_data)
 
 
 class IssueComment(Comment):

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -27,6 +27,7 @@
         name:
           - twine # we need newest twine, b/c of the check command
           - readme_renderer[md]
+          - pytest-cov
         state: latest
       become: true
     - name: Install requre


### PR DESCRIPTION
### implement methods for the classes inheriting from Comment and Reaction https://github.com/packit/ogr/issues/883

This PR implements support for Forgejo comments and reactions in the OGR library. It adds the necessary methods to the [Comment](https://github.com/packit/ogr/blob/31f2ff50bfa4583ffe108640666f8470c692bef0/ogr/abstract.py#L171) and [Reaction](https://github.com/packit/ogr/blob/31f2ff50bfa4583ffe108640666f8470c692bef0/ogr/abstract.py#L159) classes to interact with the Forgejo API using the pyforgejo client.

**Changes Included**

1. Added methods to the Comment class:

-    get_reactions(): Fetches reactions for a comment.
-    add_reaction(): Adds a reaction to a comment.
-    delete(): Deletes a comment.


2.  Added methods to the Reaction class:

- delete(): Deletes a reaction.

3.  Integrated the pyforgejo client to interact with the Forgejo API.

**Related Issues**
[Closes #883: Implement support for Forgejo comments and reactions.](https://github.com/packit/ogr/issues/866)