### PR TITLE
Forgejo permissions

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,79 +7,79 @@ In case you find any error, please [create a new issue](https://github.com/packi
 
 ### `IssueComment`
 
-|                  | GitHub | GitLab | Pagure |
-| ---------------- | :----: | :----: | :----: |
-| `body` (get/set) | ✔/✔  | ✔/✔  |  ✔/✘  |
-| `add_reaction`   |   ✔   |   ✔   |   ✘    |
-| `get_reactions`  |   ✔   |   ✔   |   ✘    |
+|                  | GitHub | GitLab | Pagure | Forgejo |
+| ---------------- | :----: | :----: | :----: | :-----: |
+| `body` (get/set) | ✔/✔  | ✔/✔  |  ✔/✘  |   ✘/✘   |
+| `add_reaction`   |   ✔   |   ✔   |   ✘    |    ✘    |
+| `get_reactions`  |   ✔   |   ✔   |   ✘    |    ✘    |
 
 ### `PRComment`
 
-|                  | GitHub | GitLab | Pagure |
-| ---------------- | :----: | :----: | :----: |
-| `body` (get/set) | ✔/✔  | ✔/✔  |  ✔/✘  |
-| `add_reaction`   |   ✔   |   ✔   |   ✘    |
-| `get_reactions`  |   ✔   |   ✔   |   ✘    |
-| `closed_by`      |   ✘    |   ✘    |   ✔   |
+|                  | GitHub | GitLab | Pagure | Forgejo |
+| ---------------- | :----: | :----: | :----: | :-----: |
+| `body` (get/set) | ✔/✔  | ✔/✔  |  ✔/✘  |    ✘    |
+| `add_reaction`   |   ✔   |   ✔   |   ✘    |    ✘    |
+| `get_reactions`  |   ✔   |   ✔   |   ✘    |    ✘    |
+| `closed_by`      |   ✘    |   ✘    |   ✔   |    ✘    |
 
 ## Issue
 
-|             | GitHub | GitLab | Pagure |
-| ----------- | :----: | :----: | :----: |
-| `add_label` |   ✔   |   ✔   |   ✘    |
+|             | GitHub | GitLab | Pagure | Forgejo |
+| ----------- | :----: | :----: | :----: | :-----: |
+| `add_label` |   ✔   |   ✔   |   ✘    |    ✘    |
 
 ## Pull request
 
-|                   | GitHub | GitLab | Pagure |
-| ----------------- | :----: | :----: | :----: |
-| `add_label`       |   ✔   |   ✔   |   ✘    |
-| `get_all_commits` |   ✔   |   ✔   |   ✘    |
+|                   | GitHub | GitLab | Pagure | Forgejo |
+| ----------------- | :----: | :----: | :----: | :-----: |
+| `add_label`       |   ✔   |   ✔   |   ✘    |    ✘    |
+| `get_all_commits` |   ✔   |   ✔   |   ✘    |    ✘    |
 
 ## Release
 
-|                   | GitHub | GitLab |          Pagure          |
-| ----------------- | :----: | :----: | :----------------------: |
-| `edit_release`    |   ✔   |   ✘    |            ✘             |
-| `body` (only get) |   ✔   |   ✔   | ✘ (returns empty string) |
+|                   | GitHub | GitLab |          Pagure          | Forgejo |
+| ----------------- | :----: | :----: | :----------------------: | :-----: |
+| `edit_release`    |   ✔   |   ✘    |            ✘             |    ✘    |
+| `body` (only get) |   ✔   |   ✔   | ✘ (returns empty string) |    ✘    |
 
 ## Commit flag
 
-|          | GitHub | GitLab | Pagure |
-| -------- | :----: | :----: | :----: |
-| `edited` |   ✔   |   ✘    |   ✔   |
+|          | GitHub | GitLab | Pagure | Forgejo |
+| -------- | :----: | :----: | :----: | :-----: |
+| `edited` |   ✔   |   ✘    |   ✔   |    ✘    |
 
 ## Project
 
-|                               | GitHub | GitLab |         Pagure          |
-| ----------------------------- | :----: | :----: | :---------------------: |
-| `change_token`                |   ✘    |   ✔   |           ✔            |
-| `get_release`                 |   ✔   |   ✔   |            ✘            |
-| `get_commits`                 |   ✔   |   ✔   |            ✘            |
-| `get_latest_release`          |   ✔   |   ✔   |            ✘            |
-| `is_private`                  |   ✔   |   ✔   | ✘ (may not be accurate) |
-| `remove_user`                 |   ✘    |   ✘    |           ✔            |
-| `add_group`                   |   ✘    |   ✘    |           ✔            |
-| `remove_group`                |   ✘    |   ✘    |           ✔            |
-| `which_groups_can_merge_pr`   |   ✘    |   ✘    |           ✔            |
-| `get_pr_files_diff`           |   ✘    |   ✘    |           ✔            |
-| `get_users_with_given_access` |   ✘    |   ✘    |           ✔            |
+|                               | GitHub | GitLab |         Pagure          | Forgejo |
+| ----------------------------- | :----: | :----: | :---------------------: | :-----: |
+| `change_token`                |   ✘    |   ✔   |           ✔            |    ✘    |
+| `get_release`                 |   ✔   |   ✔   |            ✘            |    ✘    |
+| `get_commits`                 |   ✔   |   ✔   |            ✘            |   ✔    |
+| `get_latest_release`          |   ✔   |   ✔   |            ✘            |    ✘    |
+| `is_private`                  |   ✔   |   ✔   | ✘ (may not be accurate) |   ✔    |
+| `remove_user`                 |   ✘    |   ✘    |           ✔            |   ✔    |
+| `add_group`                   |   ✘    |   ✘    |           ✔            |    ✘    |
+| `remove_group`                |   ✘    |   ✘    |           ✔            |    ✘    |
+| `which_groups_can_merge_pr`   |   ✘    |   ✘    |           ✔            |    ✘    |
+| `get_pr_files_diff`           |   ✘    |   ✘    |           ✔            |    ✘    |
+| `get_users_with_given_access` |   ✘    |   ✘    |           ✔            |   ✔    |
 
 ## User
 
-|                | GitHub | GitLab | Pagure |
-| -------------- | :----: | :----: | :----: |
-| `get_projects` |   ✔   |   ✘    |   ✔   |
-| `get_forks`    |   ✔   |   ✘    |   ✔   |
-| `get_email`    |   ✔   |   ✔   |   ✘    |
+|                | GitHub | GitLab | Pagure | Forgejo |
+| -------------- | :----: | :----: | :----: | :-----: |
+| `get_projects` |   ✔   |   ✘    |   ✔   |   ✔    |
+| `get_forks`    |   ✔   |   ✘    |   ✔   |   ✔    |
+| `get_email`    |   ✔   |   ✔   |   ✘    |   ✔    |
 
 ## Reaction
 
-|          | GitHub | GitLab | Pagure |
-| -------- | :----: | :----: | :----: |
-| `delete` |   ✔   |   ✔   |   ✘    |
+|          | GitHub | GitLab | Pagure | Forgejo |
+| -------- | :----: | :----: | :----: | :-----: |
+| `delete` |   ✔   |   ✔   |   ✘    |    ✘    |
 
 ## Service
 
-|             | GitHub | GitLab | Pagure |
-| ----------- | :----: | :----: | :----: |
-| `get_group` |   ✘    |   ✘    |   ✔   |
+|             | GitHub | GitLab | Pagure | Forgejo |
+| ----------- | :----: | :----: | :----: | :-----: |
+| `get_group` |   ✘    |   ✘    |   ✔   |    ✘    |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ As a CI we use [Zuul](https://softwarefactory-project.io/zuul/t/local/builds?pro
 If you want to re-run CI/tests in a pull request, just include `recheck` in a comment.
 
 When running the tests we use the pregenerated responses that are saved in ./tests/integration/test_data.
-If you need to generate a new file, just run the tests and provide environment variables for the service, e.g. `GITHUB_TOKEN`, `GITLAB_TOKEN`, `PAGURE_TOKEN`. Some API endpoints of Pagure require setting up token for a project: `PAGURE_OGR_TEST_TOKEN`.
+If you need to generate a new file, just run the tests and provide environment variables for the service, e.g. `GITHUB_TOKEN`, `GITLAB_TOKEN`, `PAGURE_TOKEN`, `FORGEJO_TOKEN`. Some API endpoints of Pagure require setting up token for a project: `PAGURE_OGR_TEST_TOKEN`.
 The missing file will be automatically generated from the real response. Do not forget to commit the file as well.
 
 If you need to regenerate a response file, just remove it and rerun the tests.

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ check-in-container:
 		--env COLOR \
 		--env COV_REPORT \
 		$(OGR_IMAGE) \
-		make -e GITHUB_TOKEN=$(GITHUB_TOKEN) GITLAB_TOKEN=$(GITLAB_TOKEN) check
+		make -e GITHUB_TOKEN=$(GITHUB_TOKEN) GITLAB_TOKEN=$(GITLAB_TOKEN) FORGEJO_TOKEN=$(FORGEJO_TOKEN) check
 
 shell:
 	podman run --rm -ti -v $(CURDIR):/src:Z -w /src $(OGR_IMAGE) bash

--- a/ogr/services/forgejo/project.py
+++ b/ogr/services/forgejo/project.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 from collections.abc import Iterable
 from functools import cached_property, partial
-from typing import Optional, Union
+from typing import ClassVar, Optional, Union
 
 from pyforgejo import NotFoundError, Repository, types
 from pyforgejo.repository.client import RepositoryClient
@@ -40,6 +40,14 @@ logger = logging.getLogger(__name__)
 
 class ForgejoProject(BaseGitProject):
     service: "forgejo.ForgejoService"
+    access_dict: ClassVar[dict] = {
+        AccessLevel.pull: "read",
+        AccessLevel.triage: "read",
+        AccessLevel.push: "write",
+        AccessLevel.admin: "admin",
+        AccessLevel.maintain: "owner",
+        None: "",
+    }
 
     def __init__(
         self,
@@ -214,97 +222,81 @@ class ForgejoProject(BaseGitProject):
         return None
 
     def get_owners(self) -> list[str]:
-        """
-        Returns:
-            List of usernames of project owners.
-        """
-        raise NotImplementedError("TBD")
+        return [self.forgejo_repo.owner.username]
+
+    def _get_collaborators(self) -> list[str]:
+        return [
+            c.username
+            for c in self.api.repo_list_collaborators(
+                owner=self.namespace,
+                repo=self.repo,
+            )
+        ] + self.get_owners()
+
+    def _get_collaborators_with_access(self) -> dict[str, str]:
+        return {
+            c: self.api.repo_get_repo_permissions(
+                owner=self.namespace,
+                repo=self.repo,
+                collaborator=c,
+            ).permission
+            for c in self._get_collaborators()
+        }
+
+    def get_contributors(self) -> set[str]:
+        return set(self._get_collaborators())
+
+    def users_with_write_access(self) -> set[str]:
+        return {
+            collaborator
+            for collaborator, access in self._get_collaborators_with_access().items()
+            if access in ("owner", "admin", "write")
+        }
 
     def who_can_close_issue(self) -> set[str]:
-        """
-        Returns:
-            Names of all users who have permission to modify an issue.
-        """
-        raise NotImplementedError("TBD")
+        return self.users_with_write_access()
 
     def who_can_merge_pr(self) -> set[str]:
-        """
-        Returns:
-            Names of all users who have permission to modify pull request.
-        """
-        raise NotImplementedError("TBD")
-
-    def which_groups_can_merge_pr(self) -> set[str]:
-        """
-        Returns:
-            Names of all groups that have permission to modify pull request.
-        """
-        raise NotImplementedError("TBD")
+        return self.users_with_write_access()
 
     def can_merge_pr(self, username: str) -> bool:
-        """
-        Args:
-            username: Username.
-
-        Returns:
-            `True` if user merge pull request, `False` otherwise.
-        """
-        raise NotImplementedError("TBD")
+        return self.api.repo_get_repo_permissions(
+            owner=self.namespace,
+            repo=self.repo,
+            collaborator=username,
+        ).permission in ("owner", "admin", "write")
 
     def get_users_with_given_access(self, access_levels: list[AccessLevel]) -> set[str]:
-        """
-        Args:
-            access_levels: list of access levels
+        access_levels_forgejo = [
+            self.access_dict[access_level] for access_level in access_levels
+        ]
 
-        Returns:
-            set of users with given access levels
-        """
-        raise NotImplementedError("TBD")
+        return {
+            user
+            for user, permission in self._get_collaborators_with_access().items()
+            if permission in access_levels_forgejo
+        }
 
     def add_user(self, user: str, access_level: AccessLevel) -> None:
-        """
-        Add user to project.
+        if access_level == AccessLevel.maintain:
+            raise OperationNotSupported("Not possible to add a user as `owner`.")
 
-        Args:
-            user: Username of the user.
-            access_level: Permissions for the user.
-        """
-        raise NotImplementedError()
+        self.api.repo_add_collaborator(
+            owner=self.namespace,
+            repo=self.repo,
+            collaborator=user,
+            permission=self.access_dict[access_level],
+        )
 
     def remove_user(self, user: str) -> None:
-        """
-        Remove user from project.
-
-        Args:
-            user: Username of the user.
-        """
-        raise NotImplementedError()
+        self.api.repo_delete_collaborator(
+            owner=self.namespace,
+            repo=self.repo,
+            collaborator=user,
+        )
 
     def request_access(self) -> None:
-        """
-        Request an access to the project (cannot specify access level to be granted;
-        needs to be approved and specified by the user with maintainer/admin rights).
-        """
-        raise NotImplementedError()
-
-    def add_group(self, group: str, access_level: AccessLevel) -> None:
-        """
-        Add group to project.
-
-        Args:
-            group: Name of the group.
-            access_level: Permissions for the group.
-        """
-        raise NotImplementedError()
-
-    def remove_group(self, group: str) -> None:
-        """
-        Remove group from project.
-
-        Args:
-            group: Name of the group.
-        """
-        raise NotImplementedError()
+        raise OperationNotSupported("Not possible on Forgejo")
 
     @indirect(ForgejoIssue.get_list)
     def get_issue_list(
@@ -575,17 +567,3 @@ class ForgejoProject(BaseGitProject):
             return branch_info.commit.id
         except NotFoundError:
             return None
-
-    def get_contributors(self) -> set[str]:
-        """
-        Returns:
-            Set of all contributors to the given project.
-        """
-        raise NotImplementedError("TBD")
-
-    def users_with_write_access(self) -> set[str]:
-        """
-        Returns:
-            List of users who have write access to the project
-        """
-        raise NotImplementedError("TBD")

--- a/tests/integration/forgejo/test_data/test_project/test_add_remove_user.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_add_remove_user.yaml
@@ -1,0 +1,64 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+httpx._client:
+  send:
+    DELETE:
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/lbarcziova:
+      - metadata:
+          latency: 0.40206241607666016
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 1
+          _content: ''
+          _elapsed: 0.401719
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            date: Tue, 08 Apr 2025 18:42:25 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 204
+    PUT:
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/lbarcziova:
+      - metadata:
+          latency: 0.831289529800415
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 1
+          _content: ''
+          _elapsed: 0.831017
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            date: Tue, 08 Apr 2025 18:42:25 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 204

--- a/tests/integration/forgejo/test_data/test_project/test_get_contributors.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_get_contributors.yaml
@@ -7,10 +7,12 @@ httpx._client:
     GET:
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
       - metadata:
-          latency: 0.22250580787658691
+          latency: 0.2857069969177246
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -120,12 +122,12 @@ httpx._client:
             watchers_count: 1
             website: ''
             wiki_branch: master
-          _elapsed: 0.22227
+          _elapsed: 0.285493
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 19:01:50 GMT
+            date: Fri, 11 Apr 2025 13:34:00 GMT
             transfer-encoding: chunked
             vary: Origin
             x-content-type-options: nosniff
@@ -134,7 +136,7 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
       - metadata:
-          latency: 0.4366331100463867
+          latency: 0.4319467544555664
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
@@ -176,17 +178,53 @@ httpx._client:
             username: mfocko
             visibility: public
             website: ''
-          _elapsed: 0.436326
+          _elapsed: 0.431688
           encoding: utf-8
           headers:
             access-control-expose-headers: X-Total-Count
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '576'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 19:01:50 GMT
+            date: Fri, 11 Apr 2025 13:33:59 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
             x-total-count: '1'
           next_request: null
           status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/teams:
+      - metadata:
+          latency: 0.22438693046569824
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: repo is not owned by an organization
+            url: https://v10.next.forgejo.org/api/swagger
+          _elapsed: 0.224212
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '100'
+            content-type: application/json;charset=utf-8
+            date: Fri, 11 Apr 2025 13:34:00 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 405

--- a/tests/integration/forgejo/test_data/test_project/test_get_contributors.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_get_contributors.yaml
@@ -1,0 +1,192 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+httpx._client:
+  send:
+    GET:
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
+      - metadata:
+          latency: 0.22250580787658691
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - functools
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_fast_forward_only_merge: true
+            allow_merge_commits: true
+            allow_rebase: true
+            allow_rebase_explicit: true
+            allow_rebase_update: true
+            allow_squash_merge: true
+            archived: false
+            archived_at: '1970-01-01T00:00:00Z'
+            avatar_url: ''
+            clone_url: https://v10.next.forgejo.org/packit-validator/ogr-tests.git
+            created_at: '2025-03-20T21:40:15Z'
+            default_allow_maintainer_edit: false
+            default_branch: master
+            default_delete_branch_after_merge: false
+            default_merge_style: merge
+            default_update_style: merge
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            empty: false
+            fork: false
+            forks_count: 1
+            full_name: packit-validator/ogr-tests
+            globally_editable_wiki: false
+            has_actions: true
+            has_issues: true
+            has_packages: true
+            has_projects: true
+            has_pull_requests: true
+            has_releases: true
+            has_wiki: true
+            html_url: https://v10.next.forgejo.org/packit-validator/ogr-tests
+            id: 531
+            ignore_whitespace_conflicts: false
+            internal: false
+            internal_tracker:
+              allow_only_contributors_to_track_time: true
+              enable_issue_dependencies: true
+              enable_time_tracker: true
+            language: ''
+            languages_url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/languages
+            link: ''
+            mirror: false
+            mirror_interval: ''
+            mirror_updated: '0001-01-01T00:00:00Z'
+            name: ogr-tests
+            object_format_name: sha1
+            open_issues_count: 92
+            open_pr_counter: 7
+            original_url: https://gitlab.com/packit-service/ogr-tests.git
+            owner:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: packit-validator@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+            parent: null
+            permissions:
+              admin: true
+              pull: true
+              push: true
+            private: false
+            release_counter: 12
+            repo_transfer: null
+            size: 65
+            ssh_url: ssh://git@v10.next.forgejo.org:2100/packit-validator/ogr-tests.git
+            stars_count: 0
+            template: false
+            topics: null
+            updated_at: '2025-03-21T10:30:54Z'
+            url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests
+            watchers_count: 1
+            website: ''
+            wiki_branch: master
+          _elapsed: 0.22227
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 19:01:50 GMT
+            transfer-encoding: chunked
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
+      - metadata:
+          latency: 0.4366331100463867
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - active: false
+            avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+            created: '2025-02-12T13:52:32Z'
+            description: ''
+            email: mfocko@noreply.v10.next.forgejo.org
+            followers_count: 0
+            following_count: 0
+            full_name: ''
+            html_url: https://v10.next.forgejo.org/mfocko
+            id: 601
+            is_admin: false
+            language: ''
+            last_login: '0001-01-01T00:00:00Z'
+            location: ''
+            login: mfocko
+            login_name: ''
+            prohibit_login: false
+            pronouns: ''
+            restricted: false
+            source_id: 0
+            starred_repos_count: 0
+            username: mfocko
+            visibility: public
+            website: ''
+          _elapsed: 0.436326
+          encoding: utf-8
+          headers:
+            access-control-expose-headers: X-Total-Count
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '576'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 19:01:50 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-total-count: '1'
+          next_request: null
+          status_code: 200

--- a/tests/integration/forgejo/test_data/test_project/test_get_owners.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_get_owners.yaml
@@ -1,0 +1,130 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+httpx._client:
+  send:
+    GET:
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
+      - metadata:
+          latency: 0.3934040069580078
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - functools
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_fast_forward_only_merge: true
+            allow_merge_commits: true
+            allow_rebase: true
+            allow_rebase_explicit: true
+            allow_rebase_update: true
+            allow_squash_merge: true
+            archived: false
+            archived_at: '1970-01-01T00:00:00Z'
+            avatar_url: ''
+            clone_url: https://v10.next.forgejo.org/packit-validator/ogr-tests.git
+            created_at: '2025-03-20T21:40:15Z'
+            default_allow_maintainer_edit: false
+            default_branch: master
+            default_delete_branch_after_merge: false
+            default_merge_style: merge
+            default_update_style: merge
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            empty: false
+            fork: false
+            forks_count: 1
+            full_name: packit-validator/ogr-tests
+            globally_editable_wiki: false
+            has_actions: true
+            has_issues: true
+            has_packages: true
+            has_projects: true
+            has_pull_requests: true
+            has_releases: true
+            has_wiki: true
+            html_url: https://v10.next.forgejo.org/packit-validator/ogr-tests
+            id: 531
+            ignore_whitespace_conflicts: false
+            internal: false
+            internal_tracker:
+              allow_only_contributors_to_track_time: true
+              enable_issue_dependencies: true
+              enable_time_tracker: true
+            language: ''
+            languages_url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/languages
+            link: ''
+            mirror: false
+            mirror_interval: ''
+            mirror_updated: '0001-01-01T00:00:00Z'
+            name: ogr-tests
+            object_format_name: sha1
+            open_issues_count: 92
+            open_pr_counter: 7
+            original_url: https://gitlab.com/packit-service/ogr-tests.git
+            owner:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: packit-validator@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+            parent: null
+            permissions:
+              admin: true
+              pull: true
+              push: true
+            private: false
+            release_counter: 12
+            repo_transfer: null
+            size: 65
+            ssh_url: ssh://git@v10.next.forgejo.org:2100/packit-validator/ogr-tests.git
+            stars_count: 0
+            template: false
+            topics: null
+            updated_at: '2025-03-21T10:30:54Z'
+            url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests
+            watchers_count: 1
+            website: ''
+            wiki_branch: master
+          _elapsed: 0.393143
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:24:56 GMT
+            transfer-encoding: chunked
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200

--- a/tests/integration/forgejo/test_data/test_project/test_get_users_with_given_access.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_get_users_with_given_access.yaml
@@ -1,0 +1,483 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+httpx._client:
+  send:
+    GET:
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
+      - metadata:
+          latency: 0.21732878684997559
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - functools
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_fast_forward_only_merge: true
+            allow_merge_commits: true
+            allow_rebase: true
+            allow_rebase_explicit: true
+            allow_rebase_update: true
+            allow_squash_merge: true
+            archived: false
+            archived_at: '1970-01-01T00:00:00Z'
+            avatar_url: ''
+            clone_url: https://v10.next.forgejo.org/packit-validator/ogr-tests.git
+            created_at: '2025-03-20T21:40:15Z'
+            default_allow_maintainer_edit: false
+            default_branch: master
+            default_delete_branch_after_merge: false
+            default_merge_style: merge
+            default_update_style: merge
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            empty: false
+            fork: false
+            forks_count: 1
+            full_name: packit-validator/ogr-tests
+            globally_editable_wiki: false
+            has_actions: true
+            has_issues: true
+            has_packages: true
+            has_projects: true
+            has_pull_requests: true
+            has_releases: true
+            has_wiki: true
+            html_url: https://v10.next.forgejo.org/packit-validator/ogr-tests
+            id: 531
+            ignore_whitespace_conflicts: false
+            internal: false
+            internal_tracker:
+              allow_only_contributors_to_track_time: true
+              enable_issue_dependencies: true
+              enable_time_tracker: true
+            language: ''
+            languages_url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/languages
+            link: ''
+            mirror: false
+            mirror_interval: ''
+            mirror_updated: '0001-01-01T00:00:00Z'
+            name: ogr-tests
+            object_format_name: sha1
+            open_issues_count: 92
+            open_pr_counter: 7
+            original_url: https://gitlab.com/packit-service/ogr-tests.git
+            owner:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: packit-validator@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+            parent: null
+            permissions:
+              admin: true
+              pull: true
+              push: true
+            private: false
+            release_counter: 12
+            repo_transfer: null
+            size: 65
+            ssh_url: ssh://git@v10.next.forgejo.org:2100/packit-validator/ogr-tests.git
+            stars_count: 0
+            template: false
+            topics: null
+            updated_at: '2025-03-21T10:30:54Z'
+            url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests
+            watchers_count: 1
+            website: ''
+            wiki_branch: master
+          _elapsed: 0.217088
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:42:45 GMT
+            transfer-encoding: chunked
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
+      - metadata:
+          latency: 0.3804049491882324
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - active: false
+            avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+            created: '2025-02-12T13:52:32Z'
+            description: ''
+            email: mfocko@noreply.v10.next.forgejo.org
+            followers_count: 0
+            following_count: 0
+            full_name: ''
+            html_url: https://v10.next.forgejo.org/mfocko
+            id: 601
+            is_admin: false
+            language: ''
+            last_login: '0001-01-01T00:00:00Z'
+            location: ''
+            login: mfocko
+            login_name: ''
+            prohibit_login: false
+            pronouns: ''
+            restricted: false
+            source_id: 0
+            starred_repos_count: 0
+            username: mfocko
+            visibility: public
+            website: ''
+          _elapsed: 0.380136
+          encoding: utf-8
+          headers:
+            access-control-expose-headers: X-Total-Count
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '576'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:42:45 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-total-count: '1'
+          next_request: null
+          status_code: 200
+      - metadata:
+          latency: 0.4032602310180664
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - active: false
+            avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+            created: '2025-02-12T13:52:32Z'
+            description: ''
+            email: mfocko@noreply.v10.next.forgejo.org
+            followers_count: 0
+            following_count: 0
+            full_name: ''
+            html_url: https://v10.next.forgejo.org/mfocko
+            id: 601
+            is_admin: false
+            language: ''
+            last_login: '0001-01-01T00:00:00Z'
+            location: ''
+            login: mfocko
+            login_name: ''
+            prohibit_login: false
+            pronouns: ''
+            restricted: false
+            source_id: 0
+            starred_repos_count: 0
+            username: mfocko
+            visibility: public
+            website: ''
+          _elapsed: 0.403041
+          encoding: utf-8
+          headers:
+            access-control-expose-headers: X-Total-Count
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '576'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:42:46 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-total-count: '1'
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/mfocko/permission:
+      - metadata:
+          latency: 0.3633108139038086
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: admin
+            role_name: admin
+            user:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+              created: '2025-02-12T13:52:32Z'
+              description: ''
+              email: mfocko@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/mfocko
+              id: 601
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: mfocko
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: mfocko
+              visibility: public
+              website: ''
+          _elapsed: 0.363128
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '624'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:42:46 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      - metadata:
+          latency: 0.28839874267578125
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: admin
+            role_name: admin
+            user:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+              created: '2025-02-12T13:52:32Z'
+              description: ''
+              email: mfocko@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/mfocko
+              id: 601
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: mfocko
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: mfocko
+              visibility: public
+              website: ''
+          _elapsed: 0.288131
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '624'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:42:47 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/packit-validator/permission:
+      - metadata:
+          latency: 0.40218043327331543
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: owner
+            role_name: owner
+            user:
+              active: true
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: public-repos-bot@packit.dev
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: en-US
+              last_login: '2025-03-21T09:34:45Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+          _elapsed: 0.40197
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '650'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:42:46 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      - metadata:
+          latency: 0.22763395309448242
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: owner
+            role_name: owner
+            user:
+              active: true
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: public-repos-bot@packit.dev
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: en-US
+              last_login: '2025-03-21T09:34:45Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+          _elapsed: 0.227418
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '650'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:42:47 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200

--- a/tests/integration/forgejo/test_data/test_project/test_get_users_with_given_access.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_get_users_with_given_access.yaml
@@ -7,10 +7,14 @@ httpx._client:
     GET:
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
       - metadata:
-          latency: 0.21732878684997559
+          latency: 0.2304246425628662
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -120,12 +124,12 @@ httpx._client:
             watchers_count: 1
             website: ''
             wiki_branch: master
-          _elapsed: 0.217088
+          _elapsed: 0.230236
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:42:45 GMT
+            date: Fri, 11 Apr 2025 13:37:55 GMT
             transfer-encoding: chunked
             vary: Origin
             x-content-type-options: nosniff
@@ -134,10 +138,12 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
       - metadata:
-          latency: 0.3804049491882324
+          latency: 0.3457448482513428
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -176,14 +182,14 @@ httpx._client:
             username: mfocko
             visibility: public
             website: ''
-          _elapsed: 0.380136
+          _elapsed: 0.345593
           encoding: utf-8
           headers:
             access-control-expose-headers: X-Total-Count
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '576'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:42:45 GMT
+            date: Fri, 11 Apr 2025 13:37:54 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -191,10 +197,12 @@ httpx._client:
           next_request: null
           status_code: 200
       - metadata:
-          latency: 0.4032602310180664
+          latency: 0.24201083183288574
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -233,14 +241,14 @@ httpx._client:
             username: mfocko
             visibility: public
             website: ''
-          _elapsed: 0.403041
+          _elapsed: 0.241749
           encoding: utf-8
           headers:
             access-control-expose-headers: X-Total-Count
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '576'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:42:46 GMT
+            date: Fri, 11 Apr 2025 13:37:56 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -249,7 +257,7 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/mfocko/permission:
       - metadata:
-          latency: 0.3633108139038086
+          latency: 0.31940531730651855
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
@@ -294,20 +302,20 @@ httpx._client:
               username: mfocko
               visibility: public
               website: ''
-          _elapsed: 0.363128
+          _elapsed: 0.319141
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '624'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:42:46 GMT
+            date: Fri, 11 Apr 2025 13:37:55 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
           next_request: null
           status_code: 200
       - metadata:
-          latency: 0.28839874267578125
+          latency: 0.32514214515686035
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
@@ -352,13 +360,13 @@ httpx._client:
               username: mfocko
               visibility: public
               website: ''
-          _elapsed: 0.288131
+          _elapsed: 0.324902
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '624'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:42:47 GMT
+            date: Fri, 11 Apr 2025 13:37:56 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -366,7 +374,7 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/packit-validator/permission:
       - metadata:
-          latency: 0.40218043327331543
+          latency: 0.22773528099060059
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
@@ -411,20 +419,20 @@ httpx._client:
               username: packit-validator
               visibility: public
               website: ''
-          _elapsed: 0.40197
+          _elapsed: 0.227479
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '650'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:42:46 GMT
+            date: Fri, 11 Apr 2025 13:37:56 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
           next_request: null
           status_code: 200
       - metadata:
-          latency: 0.22763395309448242
+          latency: 0.3734431266784668
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
@@ -469,15 +477,90 @@ httpx._client:
               username: packit-validator
               visibility: public
               website: ''
-          _elapsed: 0.227418
+          _elapsed: 0.373234
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '650'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:42:47 GMT
+            date: Fri, 11 Apr 2025 13:37:57 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
           next_request: null
           status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/teams:
+      - metadata:
+          latency: 0.22866058349609375
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: repo is not owned by an organization
+            url: https://v10.next.forgejo.org/api/swagger
+          _elapsed: 0.228404
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '100'
+            content-type: application/json;charset=utf-8
+            date: Fri, 11 Apr 2025 13:37:55 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 405
+      - metadata:
+          latency: 0.22675275802612305
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: repo is not owned by an organization
+            url: https://v10.next.forgejo.org/api/swagger
+          _elapsed: 0.226551
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '100'
+            content-type: application/json;charset=utf-8
+            date: Fri, 11 Apr 2025 13:37:56 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 405

--- a/tests/integration/forgejo/test_data/test_project/test_issue_permissions.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_issue_permissions.yaml
@@ -7,10 +7,16 @@ httpx._client:
     GET:
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
       - metadata:
-          latency: 0.23102498054504395
+          latency: 0.393721342086792
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -120,12 +126,12 @@ httpx._client:
             watchers_count: 1
             website: ''
             wiki_branch: master
-          _elapsed: 0.230716
+          _elapsed: 0.393435
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:24:56 GMT
+            date: Fri, 11 Apr 2025 13:37:51 GMT
             transfer-encoding: chunked
             vary: Origin
             x-content-type-options: nosniff
@@ -134,10 +140,14 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
       - metadata:
-          latency: 0.31401848793029785
+          latency: 0.5264222621917725
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -176,14 +186,14 @@ httpx._client:
             username: mfocko
             visibility: public
             website: ''
-          _elapsed: 0.313761
+          _elapsed: 0.526169
           encoding: utf-8
           headers:
             access-control-expose-headers: X-Total-Count
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '576'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:24:56 GMT
+            date: Fri, 11 Apr 2025 13:37:51 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -192,10 +202,12 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/mfocko/permission:
       - metadata:
-          latency: 0.3810129165649414
+          latency: 0.2216343879699707
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -237,13 +249,13 @@ httpx._client:
               username: mfocko
               visibility: public
               website: ''
-          _elapsed: 0.380734
+          _elapsed: 0.221391
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '624'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:24:57 GMT
+            date: Fri, 11 Apr 2025 13:37:52 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -251,10 +263,12 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/packit-validator/permission:
       - metadata:
-          latency: 0.23930954933166504
+          latency: 0.31739068031311035
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -296,15 +310,55 @@ httpx._client:
               username: packit-validator
               visibility: public
               website: ''
-          _elapsed: 0.239038
+          _elapsed: 0.317195
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '650'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:24:57 GMT
+            date: Fri, 11 Apr 2025 13:37:52 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
           next_request: null
           status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/teams:
+      - metadata:
+          latency: 0.24696755409240723
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: repo is not owned by an organization
+            url: https://v10.next.forgejo.org/api/swagger
+          _elapsed: 0.246732
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '100'
+            content-type: application/json;charset=utf-8
+            date: Fri, 11 Apr 2025 13:37:52 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 405

--- a/tests/integration/forgejo/test_data/test_project/test_issue_permissions.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_issue_permissions.yaml
@@ -1,0 +1,310 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+httpx._client:
+  send:
+    GET:
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
+      - metadata:
+          latency: 0.23102498054504395
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - functools
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_fast_forward_only_merge: true
+            allow_merge_commits: true
+            allow_rebase: true
+            allow_rebase_explicit: true
+            allow_rebase_update: true
+            allow_squash_merge: true
+            archived: false
+            archived_at: '1970-01-01T00:00:00Z'
+            avatar_url: ''
+            clone_url: https://v10.next.forgejo.org/packit-validator/ogr-tests.git
+            created_at: '2025-03-20T21:40:15Z'
+            default_allow_maintainer_edit: false
+            default_branch: master
+            default_delete_branch_after_merge: false
+            default_merge_style: merge
+            default_update_style: merge
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            empty: false
+            fork: false
+            forks_count: 1
+            full_name: packit-validator/ogr-tests
+            globally_editable_wiki: false
+            has_actions: true
+            has_issues: true
+            has_packages: true
+            has_projects: true
+            has_pull_requests: true
+            has_releases: true
+            has_wiki: true
+            html_url: https://v10.next.forgejo.org/packit-validator/ogr-tests
+            id: 531
+            ignore_whitespace_conflicts: false
+            internal: false
+            internal_tracker:
+              allow_only_contributors_to_track_time: true
+              enable_issue_dependencies: true
+              enable_time_tracker: true
+            language: ''
+            languages_url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/languages
+            link: ''
+            mirror: false
+            mirror_interval: ''
+            mirror_updated: '0001-01-01T00:00:00Z'
+            name: ogr-tests
+            object_format_name: sha1
+            open_issues_count: 92
+            open_pr_counter: 7
+            original_url: https://gitlab.com/packit-service/ogr-tests.git
+            owner:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: packit-validator@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+            parent: null
+            permissions:
+              admin: true
+              pull: true
+              push: true
+            private: false
+            release_counter: 12
+            repo_transfer: null
+            size: 65
+            ssh_url: ssh://git@v10.next.forgejo.org:2100/packit-validator/ogr-tests.git
+            stars_count: 0
+            template: false
+            topics: null
+            updated_at: '2025-03-21T10:30:54Z'
+            url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests
+            watchers_count: 1
+            website: ''
+            wiki_branch: master
+          _elapsed: 0.230716
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:24:56 GMT
+            transfer-encoding: chunked
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
+      - metadata:
+          latency: 0.31401848793029785
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - active: false
+            avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+            created: '2025-02-12T13:52:32Z'
+            description: ''
+            email: mfocko@noreply.v10.next.forgejo.org
+            followers_count: 0
+            following_count: 0
+            full_name: ''
+            html_url: https://v10.next.forgejo.org/mfocko
+            id: 601
+            is_admin: false
+            language: ''
+            last_login: '0001-01-01T00:00:00Z'
+            location: ''
+            login: mfocko
+            login_name: ''
+            prohibit_login: false
+            pronouns: ''
+            restricted: false
+            source_id: 0
+            starred_repos_count: 0
+            username: mfocko
+            visibility: public
+            website: ''
+          _elapsed: 0.313761
+          encoding: utf-8
+          headers:
+            access-control-expose-headers: X-Total-Count
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '576'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:24:56 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-total-count: '1'
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/mfocko/permission:
+      - metadata:
+          latency: 0.3810129165649414
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: admin
+            role_name: admin
+            user:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+              created: '2025-02-12T13:52:32Z'
+              description: ''
+              email: mfocko@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/mfocko
+              id: 601
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: mfocko
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: mfocko
+              visibility: public
+              website: ''
+          _elapsed: 0.380734
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '624'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:24:57 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/packit-validator/permission:
+      - metadata:
+          latency: 0.23930954933166504
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: owner
+            role_name: owner
+            user:
+              active: true
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: public-repos-bot@packit.dev
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: en-US
+              last_login: '2025-03-21T09:34:45Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+          _elapsed: 0.239038
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '650'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:24:57 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200

--- a/tests/integration/forgejo/test_data/test_project/test_pr_permissions.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_pr_permissions.yaml
@@ -1,0 +1,540 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+httpx._client:
+  send:
+    GET:
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
+      - metadata:
+          latency: 0.5910086631774902
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - functools
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_fast_forward_only_merge: true
+            allow_merge_commits: true
+            allow_rebase: true
+            allow_rebase_explicit: true
+            allow_rebase_update: true
+            allow_squash_merge: true
+            archived: false
+            archived_at: '1970-01-01T00:00:00Z'
+            avatar_url: ''
+            clone_url: https://v10.next.forgejo.org/packit-validator/ogr-tests.git
+            created_at: '2025-03-20T21:40:15Z'
+            default_allow_maintainer_edit: false
+            default_branch: master
+            default_delete_branch_after_merge: false
+            default_merge_style: merge
+            default_update_style: merge
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            empty: false
+            fork: false
+            forks_count: 1
+            full_name: packit-validator/ogr-tests
+            globally_editable_wiki: false
+            has_actions: true
+            has_issues: true
+            has_packages: true
+            has_projects: true
+            has_pull_requests: true
+            has_releases: true
+            has_wiki: true
+            html_url: https://v10.next.forgejo.org/packit-validator/ogr-tests
+            id: 531
+            ignore_whitespace_conflicts: false
+            internal: false
+            internal_tracker:
+              allow_only_contributors_to_track_time: true
+              enable_issue_dependencies: true
+              enable_time_tracker: true
+            language: ''
+            languages_url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/languages
+            link: ''
+            mirror: false
+            mirror_interval: ''
+            mirror_updated: '0001-01-01T00:00:00Z'
+            name: ogr-tests
+            object_format_name: sha1
+            open_issues_count: 92
+            open_pr_counter: 7
+            original_url: https://gitlab.com/packit-service/ogr-tests.git
+            owner:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: packit-validator@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+            parent: null
+            permissions:
+              admin: true
+              pull: true
+              push: true
+            private: false
+            release_counter: 12
+            repo_transfer: null
+            size: 65
+            ssh_url: ssh://git@v10.next.forgejo.org:2100/packit-validator/ogr-tests.git
+            stars_count: 0
+            template: false
+            topics: null
+            updated_at: '2025-03-21T10:30:54Z'
+            url: https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests
+            watchers_count: 1
+            website: ''
+            wiki_branch: master
+          _elapsed: 0.590794
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:16 GMT
+            transfer-encoding: chunked
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
+      - metadata:
+          latency: 0.8629000186920166
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - active: false
+            avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+            created: '2025-02-12T13:52:32Z'
+            description: ''
+            email: mfocko@noreply.v10.next.forgejo.org
+            followers_count: 0
+            following_count: 0
+            full_name: ''
+            html_url: https://v10.next.forgejo.org/mfocko
+            id: 601
+            is_admin: false
+            language: ''
+            last_login: '0001-01-01T00:00:00Z'
+            location: ''
+            login: mfocko
+            login_name: ''
+            prohibit_login: false
+            pronouns: ''
+            restricted: false
+            source_id: 0
+            starred_repos_count: 0
+            username: mfocko
+            visibility: public
+            website: ''
+          _elapsed: 0.862625
+          encoding: utf-8
+          headers:
+            access-control-expose-headers: X-Total-Count
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '576'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:15 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-total-count: '1'
+          next_request: null
+          status_code: 200
+      - metadata:
+          latency: 0.21556496620178223
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+          - active: false
+            avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+            created: '2025-02-12T13:52:32Z'
+            description: ''
+            email: mfocko@noreply.v10.next.forgejo.org
+            followers_count: 0
+            following_count: 0
+            full_name: ''
+            html_url: https://v10.next.forgejo.org/mfocko
+            id: 601
+            is_admin: false
+            language: ''
+            last_login: '0001-01-01T00:00:00Z'
+            location: ''
+            login: mfocko
+            login_name: ''
+            prohibit_login: false
+            pronouns: ''
+            restricted: false
+            source_id: 0
+            starred_repos_count: 0
+            username: mfocko
+            visibility: public
+            website: ''
+          _elapsed: 0.215351
+          encoding: utf-8
+          headers:
+            access-control-expose-headers: X-Total-Count
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '576'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:16 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-total-count: '1'
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/lbarcziova/permission:
+      - metadata:
+          latency: 0.2788980007171631
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: read
+            role_name: read
+            user:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/9c8d9a288151a8e563547e082c591f2a
+              created: '2025-04-08T18:33:00Z'
+              description: ''
+              email: lbarcziova@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/lbarcziova
+              id: 1214
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: lbarcziova
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: lbarcziova
+              visibility: public
+              website: ''
+          _elapsed: 0.278694
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '639'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:17 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/mfocko/permission:
+      - metadata:
+          latency: 0.2217271327972412
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: admin
+            role_name: admin
+            user:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+              created: '2025-02-12T13:52:32Z'
+              description: ''
+              email: mfocko@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/mfocko
+              id: 601
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: mfocko
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: mfocko
+              visibility: public
+              website: ''
+          _elapsed: 0.221444
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '624'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:16 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      - metadata:
+          latency: 0.33124780654907227
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: admin
+            role_name: admin
+            user:
+              active: false
+              avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
+              created: '2025-02-12T13:52:32Z'
+              description: ''
+              email: mfocko@noreply.v10.next.forgejo.org
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/mfocko
+              id: 601
+              is_admin: false
+              language: ''
+              last_login: '0001-01-01T00:00:00Z'
+              location: ''
+              login: mfocko
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: mfocko
+              visibility: public
+              website: ''
+          _elapsed: 0.331036
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '624'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:17 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/packit-validator/permission:
+      - metadata:
+          latency: 0.2156696319580078
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: owner
+            role_name: owner
+            user:
+              active: true
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: public-repos-bot@packit.dev
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: en-US
+              last_login: '2025-03-21T09:34:45Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+          _elapsed: 0.215362
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '650'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:16 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200
+      - metadata:
+          latency: 0.2792482376098633
+          module_call_list:
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - pyforgejo.repository.client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            permission: owner
+            role_name: owner
+            user:
+              active: true
+              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
+              created: '2025-02-14T09:34:00Z'
+              description: ''
+              email: public-repos-bot@packit.dev
+              followers_count: 0
+              following_count: 0
+              full_name: ''
+              html_url: https://v10.next.forgejo.org/packit-validator
+              id: 618
+              is_admin: false
+              language: en-US
+              last_login: '2025-03-21T09:34:45Z'
+              location: ''
+              login: packit-validator
+              login_name: ''
+              prohibit_login: false
+              pronouns: ''
+              restricted: false
+              source_id: 0
+              starred_repos_count: 0
+              username: packit-validator
+              visibility: public
+              website: ''
+          _elapsed: 0.27898
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '650'
+            content-type: application/json;charset=utf-8
+            date: Tue, 08 Apr 2025 18:41:17 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 200

--- a/tests/integration/forgejo/test_data/test_project/test_pr_permissions.yaml
+++ b/tests/integration/forgejo/test_data/test_project/test_pr_permissions.yaml
@@ -7,10 +7,16 @@ httpx._client:
     GET:
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests:
       - metadata:
-          latency: 0.5910086631774902
+          latency: 0.29625797271728516
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -120,12 +126,12 @@ httpx._client:
             watchers_count: 1
             website: ''
             wiki_branch: master
-          _elapsed: 0.590794
+          _elapsed: 0.296022
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:16 GMT
+            date: Fri, 11 Apr 2025 13:37:53 GMT
             transfer-encoding: chunked
             vary: Origin
             x-content-type-options: nosniff
@@ -134,10 +140,14 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators:
       - metadata:
-          latency: 0.8629000186920166
+          latency: 0.38154172897338867
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -176,71 +186,14 @@ httpx._client:
             username: mfocko
             visibility: public
             website: ''
-          _elapsed: 0.862625
+          _elapsed: 0.381324
           encoding: utf-8
           headers:
             access-control-expose-headers: X-Total-Count
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '576'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:15 GMT
-            vary: Origin
-            x-content-type-options: nosniff
-            x-frame-options: SAMEORIGIN
-            x-total-count: '1'
-          next_request: null
-          status_code: 200
-      - metadata:
-          latency: 0.21556496620178223
-          module_call_list:
-          - requre.record_and_replace
-          - tests.integration.forgejo.test_project
-          - ogr.abstract
-          - ogr.services.forgejo.project
-          - ogr.abstract
-          - ogr.services.forgejo.project
-          - pyforgejo.repository.client
-          - pyforgejo.core.http_client
-          - httpx._client
-          - requre.objects
-          - requre.cassette
-          - httpx._client
-          - send
-        output:
-          __store_indicator: 2
-          _content:
-          - active: false
-            avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
-            created: '2025-02-12T13:52:32Z'
-            description: ''
-            email: mfocko@noreply.v10.next.forgejo.org
-            followers_count: 0
-            following_count: 0
-            full_name: ''
-            html_url: https://v10.next.forgejo.org/mfocko
-            id: 601
-            is_admin: false
-            language: ''
-            last_login: '0001-01-01T00:00:00Z'
-            location: ''
-            login: mfocko
-            login_name: ''
-            prohibit_login: false
-            pronouns: ''
-            restricted: false
-            source_id: 0
-            starred_repos_count: 0
-            username: mfocko
-            visibility: public
-            website: ''
-          _elapsed: 0.215351
-          encoding: utf-8
-          headers:
-            access-control-expose-headers: X-Total-Count
-            cache-control: max-age=0, private, must-revalidate, no-transform
-            content-length: '576'
-            content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:16 GMT
+            date: Fri, 11 Apr 2025 13:37:53 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -249,7 +202,7 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/lbarcziova/permission:
       - metadata:
-          latency: 0.2788980007171631
+          latency: 0.38231325149536133
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
@@ -292,13 +245,13 @@ httpx._client:
               username: lbarcziova
               visibility: public
               website: ''
-          _elapsed: 0.278694
+          _elapsed: 0.382053
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '639'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:17 GMT
+            date: Fri, 11 Apr 2025 13:37:54 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -306,10 +259,12 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/mfocko/permission:
       - metadata:
-          latency: 0.2217271327972412
+          latency: 0.2321181297302246
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -351,71 +306,13 @@ httpx._client:
               username: mfocko
               visibility: public
               website: ''
-          _elapsed: 0.221444
+          _elapsed: 0.231876
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '624'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:16 GMT
-            vary: Origin
-            x-content-type-options: nosniff
-            x-frame-options: SAMEORIGIN
-          next_request: null
-          status_code: 200
-      - metadata:
-          latency: 0.33124780654907227
-          module_call_list:
-          - requre.record_and_replace
-          - tests.integration.forgejo.test_project
-          - ogr.abstract
-          - ogr.services.forgejo.project
-          - ogr.abstract
-          - ogr.services.forgejo.project
-          - pyforgejo.repository.client
-          - pyforgejo.core.http_client
-          - httpx._client
-          - requre.objects
-          - requre.cassette
-          - httpx._client
-          - send
-        output:
-          __store_indicator: 2
-          _content:
-            permission: admin
-            role_name: admin
-            user:
-              active: false
-              avatar_url: https://v10.next.forgejo.org/avatars/ee44221e4bd2b983751872d3cde92cf4
-              created: '2025-02-12T13:52:32Z'
-              description: ''
-              email: mfocko@noreply.v10.next.forgejo.org
-              followers_count: 0
-              following_count: 0
-              full_name: ''
-              html_url: https://v10.next.forgejo.org/mfocko
-              id: 601
-              is_admin: false
-              language: ''
-              last_login: '0001-01-01T00:00:00Z'
-              location: ''
-              login: mfocko
-              login_name: ''
-              prohibit_login: false
-              pronouns: ''
-              restricted: false
-              source_id: 0
-              starred_repos_count: 0
-              username: mfocko
-              visibility: public
-              website: ''
-          _elapsed: 0.331036
-          encoding: utf-8
-          headers:
-            cache-control: max-age=0, private, must-revalidate, no-transform
-            content-length: '624'
-            content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:17 GMT
+            date: Fri, 11 Apr 2025 13:37:53 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
@@ -423,10 +320,12 @@ httpx._client:
           status_code: 200
       https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/collaborators/packit-validator/permission:
       - metadata:
-          latency: 0.2156696319580078
+          latency: 0.2905290126800537
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -468,23 +367,30 @@ httpx._client:
               username: packit-validator
               visibility: public
               website: ''
-          _elapsed: 0.215362
+          _elapsed: 0.290273
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
             content-length: '650'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:16 GMT
+            date: Fri, 11 Apr 2025 13:37:54 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
           next_request: null
           status_code: 200
+      https://v10.next.forgejo.org/api/v1/repos/packit-validator/ogr-tests/teams:
       - metadata:
-          latency: 0.2792482376098633
+          latency: 0.2859930992126465
           module_call_list:
           - requre.record_and_replace
           - tests.integration.forgejo.test_project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
+          - ogr.abstract
+          - ogr.services.forgejo.project
           - ogr.abstract
           - ogr.services.forgejo.project
           - ogr.abstract
@@ -499,42 +405,17 @@ httpx._client:
         output:
           __store_indicator: 2
           _content:
-            permission: owner
-            role_name: owner
-            user:
-              active: true
-              avatar_url: https://v10.next.forgejo.org/avatars/9c4cb263b7809b180c92b4970f7d0847
-              created: '2025-02-14T09:34:00Z'
-              description: ''
-              email: public-repos-bot@packit.dev
-              followers_count: 0
-              following_count: 0
-              full_name: ''
-              html_url: https://v10.next.forgejo.org/packit-validator
-              id: 618
-              is_admin: false
-              language: en-US
-              last_login: '2025-03-21T09:34:45Z'
-              location: ''
-              login: packit-validator
-              login_name: ''
-              prohibit_login: false
-              pronouns: ''
-              restricted: false
-              source_id: 0
-              starred_repos_count: 0
-              username: packit-validator
-              visibility: public
-              website: ''
-          _elapsed: 0.27898
+            message: repo is not owned by an organization
+            url: https://v10.next.forgejo.org/api/swagger
+          _elapsed: 0.285719
           encoding: utf-8
           headers:
             cache-control: max-age=0, private, must-revalidate, no-transform
-            content-length: '650'
+            content-length: '100'
             content-type: application/json;charset=utf-8
-            date: Tue, 08 Apr 2025 18:41:17 GMT
+            date: Fri, 11 Apr 2025 13:37:53 GMT
             vary: Origin
             x-content-type-options: nosniff
             x-frame-options: SAMEORIGIN
           next_request: null
-          status_code: 200
+          status_code: 405

--- a/tests/integration/forgejo/test_project.py
+++ b/tests/integration/forgejo/test_project.py
@@ -4,6 +4,7 @@
 import pytest
 from requre.helpers import record_httpx
 
+from ogr.abstract import AccessLevel
 from ogr.exceptions import ForgejoAPIException
 
 
@@ -211,3 +212,43 @@ def test_has_issues(service, project):
         namespace="packit-validator",
         repo="test",
     ).has_issues
+
+
+@record_httpx()
+def test_get_owners(project):
+    owners = project.get_owners()
+    assert owners == ["packit-validator"]
+
+
+@record_httpx()
+def test_get_contributors(project):
+    users = project.get_contributors()
+    assert users == {"mfocko", "packit-validator"}
+
+
+@record_httpx()
+def test_issue_permissions(project):
+    users = project.who_can_close_issue()
+    assert "mfocko" in users
+
+
+@record_httpx()
+def test_pr_permissions(project):
+    users = project.who_can_merge_pr()
+    assert "mfocko" in users
+    assert not project.can_merge_pr("lbarcziova")
+
+
+@record_httpx()
+def test_get_users_with_given_access(project):
+    maintainers = project.get_users_with_given_access([AccessLevel.maintain])
+    assert "packit-validator" in maintainers
+
+    admins = project.get_users_with_given_access([AccessLevel.admin])
+    assert "mfocko" in admins
+
+
+@record_httpx()
+def test_add_remove_user(project):
+    project.add_user("lbarcziova", AccessLevel.push)
+    project.remove_user("lbarcziova")


### PR DESCRIPTION
TODO:
- [x] There are also [teams](https://forgejo.org/docs/v1.19/user/repo-permissions/#teams) and orgs, I will have a look into how it makes sense to integrate with the current `group`-related methods.

Fixes #878

RELEASE NOTES BEGIN

We have added support for Forgejo methods related to permissions.

RELEASE NOTES END
