### PR TITLE
ci(tmt): run only full test suite for rev-dep

### DIFF
--- a/plans/packit-integration.fmf
+++ b/plans/packit-integration.fmf
@@ -1,7 +1,7 @@
 discover:
     how: fmf
     url: https://github.com/packit/packit
-    filter: tier:0 | tier:1
+    filter: tag:full
 
 prepare:
   - how: install


### PR DESCRIPTION
Discovered by @nforro that we do not run ‹session-recording› tests during the reverse-dependency testing in ogr. However when I tried to enable it, I hit other issues that stem from pulling in additional dependencies for the ‹full› test suite when running together with ‹session-recording›.

Since my changes in Packit involve changes of tiers of tests, we need to explicitly specify that we want to run only the ‹tag:full›, so skip the ‹session-recording› for now anyways as running everything breaks…

I will try to set up importing of the plans which could resolve this… If you do not see the commit that resolves this via importing of plans, my plan has failed :)

---

Fixes CI in #918