### PR TITLE
fix(forgejo): import ApiError from top-level

### DIFF
--- a/ogr/abstract/exception.py
+++ b/ogr/abstract/exception.py
@@ -39,7 +39,7 @@ def __wrap_exception(
     ex: Union[
         github.GithubException,
         gitlab.GitlabError,
-        pyforgejo.core.api_error.ApiError,  # type: ignore
+        pyforgejo.ApiError,  # type: ignore
     ],
 ) -> APIException:
     """
@@ -57,7 +57,7 @@ def __wrap_exception(
     MAPPING = {
         github.GithubException: GithubAPIException,
         gitlab.GitlabError: GitlabAPIException,
-        pyforgejo.core.api_error.ApiError: ForgejoAPIException,  # type: ignore
+        pyforgejo.ApiError: ForgejoAPIException,  # type: ignore
     }
 
     for caught_exception, ogr_exception in MAPPING.items():
@@ -99,7 +99,7 @@ def catch_common_exceptions(function: Callable) -> Any:
         except (
             github.GithubException,
             gitlab.GitlabError,
-            pyforgejo.core.api_error.ApiError,  # type: ignore
+            pyforgejo.ApiError,  # type: ignore
         ) as ex:
             __check_for_internal_failure(__wrap_exception(ex))
 

--- a/ogr/exceptions.py
+++ b/ogr/exceptions.py
@@ -74,7 +74,7 @@ class ForgejoAPIException(APIException):
     def response_code(self):
         if self.__cause__ is None or not isinstance(
             self.__cause__,
-            pyforgejo.core.api_error.ApiError,
+            pyforgejo.ApiError,
         ):
             return None
         return self.__cause__.status_code

--- a/tests/integration/forgejo/test_service.py
+++ b/tests/integration/forgejo/test_service.py
@@ -31,7 +31,7 @@ def test_project_create(service, kwargs_):
 
     # Check that project doesn't exist
     project = service.get_project(**kwargs_fetch)
-    with pytest.raises(pyforgejo.core.api_error.ApiError):
+    with pytest.raises(pyforgejo.ApiError):
         _ = project.forgejo_repo
 
     # Create new project


### PR DESCRIPTION
As it has been discovered by @betulependule, the latest release of pyforgejo overrides `__getattr__` on the top-level module, therefore it's no longer possible to import the ApiError using the fully-qualified path.

This causes issues when running CI on our PRs, therefore switch to the import from the top-level.

Raised the issue with the upstream, for more details see: https://codeberg.org/harabat/pyforgejo/issues/38

Blocked on:
- [ ] https://codeberg.org/harabat/pyforgejo/issues/38