### PR TITLE
Count requests per namespace

### DIFF
--- a/ogr/metrics.py
+++ b/ogr/metrics.py
@@ -1,0 +1,132 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""
+Metrics tracking for OGR API calls.
+
+This module provides a lightweight metrics tracking system to count
+API calls per service type and namespace. Metrics are stored in-memory
+and are NOT thread-safe or process-synchronized.
+
+The track_ogr_request decorator can be applied to GitProject methods
+to automatically track API calls.
+"""
+
+import functools
+import logging
+from collections import defaultdict
+from typing import Callable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+F = TypeVar("F", bound=Callable)
+
+
+class RequestMetricsTracker:
+    """
+    Tracker for counting API calls per namespace and service type.
+
+    Note: This class is NOT thread-safe and does NOT synchronize across processes.
+    In a multi-worker environment, each worker maintains its own metrics, and some
+    request counts may be lost. This is acceptable for approximate metrics tracking.
+    The aggregation of data from multiple workers can be done in grafana dashboard.
+    """
+
+    def __init__(self):
+        """Initialize the metrics tracker."""
+        self._counts: dict[tuple[str, str], int] = defaultdict(int)
+
+    def record_request(
+        self,
+        service_type: str,
+        namespace: str,
+    ) -> None:
+        """
+        Record an API request for a given service type and namespace.
+
+        Args:
+            service_type: The service type (e.g., "github", "gitlab", "pagure")
+            namespace: The namespace (e.g., "packit", "rpms")
+        """
+        key = (service_type, namespace)
+        self._counts[key] += 1
+
+    def get_all_counts(self) -> dict[tuple[str, str], int]:
+        """
+        Get all request counts.
+
+        Returns:
+            Dictionary mapping (service_type, namespace) tuples to counts.
+        """
+        return {key: count for key, count in self._counts.items() if count > 0}
+
+    def reset(self) -> None:
+        """
+        Reset all counters to zero.
+
+        This is typically called after metrics have been collected and pushed.
+        """
+        self._counts.clear()
+
+
+# Global instance
+_metrics_tracker = RequestMetricsTracker()
+
+
+def get_metrics_tracker() -> RequestMetricsTracker:
+    """Get the global metrics tracker instance."""
+    return _metrics_tracker
+
+
+def record_ogr_request(service_type: str, namespace: str) -> None:
+    """
+    Record an ogr API request.
+
+    This is a convenience function that uses the global metrics tracker.
+
+    Args:
+        service_type: The service type (e.g., "github", "gitlab", "pagure")
+        namespace: The namespace (e.g., "packit-service", "rpms")
+    """
+    _metrics_tracker.record_request(service_type, namespace)
+
+
+def track_ogr_request(service_type: str) -> Callable[[F], F]:
+    """
+    Decorator to track ogr API method calls.
+
+    The decorated method must be called on a GitProject instance
+    (which has `namespace` and `service` attributes).
+
+    Args:
+        service_type: The service type (e.g., "github", "gitlab", "pagure")
+
+    Example:
+        @track_ogr_request("github")
+        def get_issues(self):
+            ...
+    """
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            namespace = getattr(self, "namespace", None)
+            if namespace:
+                try:
+                    record_ogr_request(service_type, namespace)
+                except Exception as e:
+                    logger.debug(f"Failed to record metrics: {e}")
+
+            return func(self, *args, **kwargs)
+
+        return wrapper  # type: ignore
+
+    return decorator
+
+
+__all__ = [
+    "RequestMetricsTracker",
+    "get_metrics_tracker",
+    "record_ogr_request",
+    "track_ogr_request",
+]

--- a/ogr/metrics.py
+++ b/ogr/metrics.py
@@ -5,17 +5,23 @@
 Metrics tracking for OGR API calls.
 
 This module provides a lightweight metrics tracking system to count
-API calls per service type and namespace. Metrics are stored in-memory
+API calls per instance URL and namespace. Metrics are stored in-memory
 and are NOT thread-safe or process-synchronized.
 
 The track_ogr_request decorator can be applied to GitProject methods
-to automatically track API calls.
+to automatically track API calls. The instance URL uniquely identifies
+the service instance (e.g., github.com, gitlab.com, gitlab.example.com).
 """
+
+from __future__ import annotations
 
 import functools
 import logging
 from collections import defaultdict
-from typing import Any, Callable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
+
+if TYPE_CHECKING:
+    from ogr.abstract import GitProject
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +30,7 @@ F = TypeVar("F", bound=Callable)
 
 class RequestMetricsTracker:
     """
-    Tracker for counting API calls per namespace and service type.
+    Tracker for counting API calls per instance URL and namespace.
 
     Note: This class is NOT thread-safe and does NOT synchronize across processes.
     In a multi-worker environment, each worker maintains its own metrics, and some
@@ -38,17 +44,17 @@ class RequestMetricsTracker:
 
     def record_request(
         self,
-        service_type: str,
+        instance_url: str,
         namespace: str,
     ) -> None:
         """
-        Record an API request for a given service type and namespace.
+        Record an API request for a given instance URL and namespace.
 
         Args:
-            service_type: The service type (e.g., "github", "gitlab", "pagure")
+            instance_url: The service instance URL (e.g., "https://github.com", "https://gitlab.com")
             namespace: The namespace (e.g., "packit", "rpms")
         """
-        key = (service_type, namespace)
+        key = (instance_url, namespace)
         self._counts[key] += 1
 
     def get_all_counts(self) -> dict[tuple[str, str], int]:
@@ -56,7 +62,7 @@ class RequestMetricsTracker:
         Get all request counts.
 
         Returns:
-            Dictionary mapping (service_type, namespace) tuples to counts.
+            Dictionary mapping (instance_url, namespace) tuples to counts.
         """
         return {key: count for key, count in self._counts.items() if count > 0}
 
@@ -78,60 +84,58 @@ def get_metrics_tracker() -> RequestMetricsTracker:
     return _metrics_tracker
 
 
-def record_ogr_request(service_type: str, namespace: str) -> None:
+def record_ogr_request(instance_url: str, namespace: str) -> None:
     """
     Record an ogr API request.
 
     This is a convenience function that uses the global metrics tracker.
 
     Args:
-        service_type: The service type (e.g., "github", "gitlab", "pagure")
+        instance_url: The service instance URL (e.g., "https://github.com", "https://gitlab.com")
         namespace: The namespace (e.g., "packit-service", "rpms")
     """
-    _metrics_tracker.record_request(service_type, namespace)
+    _metrics_tracker.record_request(instance_url, namespace)
 
 
-def track_ogr_request(service_type: str) -> Callable[[F], F]:
+def track_ogr_request(func: F) -> F:
     """
     Decorator to track ogr API method calls.
 
     The decorated method must be called on a GitProject instance
-    (which has `namespace` and `service` attributes).
+    (which has `namespace`, `repo`, and `service` attributes).
 
     For Pagure projects, the namespace is combined with the repo name
     (e.g., "rpms/python-requests") to provide more granular metrics.
 
-    Args:
-        service_type: The service type (e.g., "github", "gitlab", "pagure")
+    The instance URL is extracted from the service to distinguish between
+    different instances (e.g., multiple GitLab or Forgejo instances).
 
     Example:
-        @track_ogr_request("github")
+        @track_ogr_request
         def get_issues(self):
             ...
     """
 
-    def decorator(func: F) -> F:
-        @functools.wraps(func)
-        def wrapper(self: object, *args: Any, **kwargs: Any) -> Any:
-            namespace = getattr(self, "namespace", None)
-            if namespace:
-                try:
-                    # For Pagure, append the repo name to the namespace
-                    # to get more granular metrics (e.g., "rpms/python-requests")
-                    if service_type == "pagure":
-                        repo = getattr(self, "repo", None)
-                        if repo:
-                            namespace = f"{namespace}/{repo}"
+    @functools.wraps(func)
+    def wrapper(self: GitProject, *args: Any, **kwargs: Any) -> Any:
+        try:
+            from ogr.services.pagure import PagureService
 
-                    record_ogr_request(service_type, namespace)
-                except Exception as e:
-                    logger.debug(f"Failed to record metrics: {e}")
+            namespace = self.namespace
+            instance_url = self.service.instance_url
 
-            return func(self, *args, **kwargs)
+            # For Pagure, append the repo name to the namespace
+            # to get more granular metrics (e.g., "rpms/python-requests")
+            if isinstance(self.service, PagureService) and self.repo:
+                namespace = f"{namespace}/{self.repo}"
 
-        return cast(F, wrapper)
+            record_ogr_request(instance_url, namespace)
+        except Exception as e:
+            logger.debug(f"Failed to record metrics: {e}")
 
-    return decorator
+        return func(self, *args, **kwargs)
+
+    return cast(F, wrapper)
 
 
 __all__ = [

--- a/ogr/services/forgejo/project.py
+++ b/ogr/services/forgejo/project.py
@@ -25,6 +25,7 @@ from ogr.abstract import (
     Release,
 )
 from ogr.exceptions import OperationNotSupported
+from ogr.metrics import track_ogr_request
 from ogr.services import forgejo
 from ogr.services.base import BaseGitProject
 from ogr.utils import filter_paths, indirect
@@ -121,6 +122,7 @@ class ForgejoProject(BaseGitProject):
     def delete(self) -> None:
         self.partial_api(self.api.repo_delete)()
 
+    @track_ogr_request("forgejo")
     def exists(self) -> bool:
         try:
             _ = self.forgejo_repo
@@ -160,6 +162,7 @@ class ForgejoProject(BaseGitProject):
     def has_issues(self) -> bool:
         return self.forgejo_repo.has_issues
 
+    @track_ogr_request("forgejo")
     def get_branches(self) -> Iterable[str]:
         return (
             branch.name
@@ -172,6 +175,7 @@ class ForgejoProject(BaseGitProject):
     def default_branch(self) -> str:
         return self.forgejo_repo.default_branch
 
+    @track_ogr_request("forgejo")
     def get_commits(self, ref: Optional[str] = None) -> Iterable[str]:
         return (
             commit.sha
@@ -320,6 +324,7 @@ class ForgejoProject(BaseGitProject):
     def request_access(self) -> None:
         raise OperationNotSupported("Not possible on Forgejo")
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoIssue.get_list)
     def get_issue_list(
         self,
@@ -330,10 +335,12 @@ class ForgejoProject(BaseGitProject):
     ) -> list["Issue"]:
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoIssue.get)
     def get_issue(self, issue_id: int) -> "Issue":
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoIssue.create)
     def create_issue(
         self,
@@ -345,10 +352,12 @@ class ForgejoProject(BaseGitProject):
     ) -> Issue:
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoPullRequest.get_list)
     def get_pr_list(self, status: PRStatus = PRStatus.open) -> Iterable["PullRequest"]:
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoPullRequest.get)
     def get_pr(self, pr_id: int) -> "PullRequest":
         pass
@@ -372,6 +381,7 @@ class ForgejoProject(BaseGitProject):
         # https://github.com/packit/ogr/issues/895
         raise NotImplementedError()
 
+    @track_ogr_request("forgejo")
     def get_tags(self) -> Iterable["GitTag"]:
         return (
             GitTag(
@@ -381,12 +391,14 @@ class ForgejoProject(BaseGitProject):
             for tag in paginate(self.partial_api(self.api.repo_list_tags))
         )
 
+    @track_ogr_request("forgejo")
     def get_sha_from_tag(self, tag_name: str) -> str:
         return self.partial_api(
             self.api.repo_get_tag,
             tag=tag_name,
         )().commit.sha
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoRelease.get)
     def get_release(
         self,
@@ -396,14 +408,17 @@ class ForgejoProject(BaseGitProject):
     ) -> Release:
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoRelease.get_latest)
     def get_latest_release(self) -> Optional[Release]:
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoRelease.get_list)
     def get_releases(self) -> list[Release]:
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoRelease.create)
     def create_release(
         self,
@@ -414,6 +429,7 @@ class ForgejoProject(BaseGitProject):
     ) -> Release:
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoPullRequest.create)
     def create_pr(
         self,
@@ -440,6 +456,7 @@ class ForgejoProject(BaseGitProject):
     def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
         raise OperationNotSupported("Forgejo doesn't support commit comments")
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoCommitFlag.set)
     def set_commit_status(
         self,
@@ -452,6 +469,7 @@ class ForgejoProject(BaseGitProject):
     ) -> "CommitFlag":
         pass
 
+    @track_ogr_request("forgejo")
     @indirect(ForgejoCommitFlag.get)
     def get_commit_statuses(self, commit: str) -> Iterable["CommitFlag"]:
         pass
@@ -462,6 +480,7 @@ class ForgejoProject(BaseGitProject):
             "ssh": self.forgejo_repo.ssh_url,
         }
 
+    @track_ogr_request("forgejo")
     def fork_create(self, namespace: Optional[str] = None) -> "GitProject":
         if namespace:
             self.api.create_fork(
@@ -493,6 +512,7 @@ class ForgejoProject(BaseGitProject):
             "Not possible; requires recreation of the httpx client",
         )
 
+    @track_ogr_request("forgejo")
     def get_file_content(
         self,
         path: str,
@@ -551,6 +571,7 @@ class ForgejoProject(BaseGitProject):
 
                     yield file.path
 
+    @track_ogr_request("forgejo")
     def get_files(
         self,
         ref: Optional[str] = None,
@@ -570,6 +591,7 @@ class ForgejoProject(BaseGitProject):
 
         return paths
 
+    @track_ogr_request("forgejo")
     def get_forks(self) -> Iterable["ForgejoProject"]:
         return (
             ForgejoProject(
@@ -585,6 +607,7 @@ class ForgejoProject(BaseGitProject):
     def get_web_url(self) -> str:
         return self.forgejo_repo.html_url
 
+    @track_ogr_request("forgejo")
     def get_sha_from_branch(self, branch: str) -> Optional[str]:
         try:
             branch_info = self.partial_api(

--- a/ogr/services/forgejo/project.py
+++ b/ogr/services/forgejo/project.py
@@ -122,7 +122,7 @@ class ForgejoProject(BaseGitProject):
     def delete(self) -> None:
         self.partial_api(self.api.repo_delete)()
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def exists(self) -> bool:
         try:
             _ = self.forgejo_repo
@@ -162,7 +162,7 @@ class ForgejoProject(BaseGitProject):
     def has_issues(self) -> bool:
         return self.forgejo_repo.has_issues
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_branches(self) -> Iterable[str]:
         return (
             branch.name
@@ -175,7 +175,7 @@ class ForgejoProject(BaseGitProject):
     def default_branch(self) -> str:
         return self.forgejo_repo.default_branch
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_commits(self, ref: Optional[str] = None) -> Iterable[str]:
         return (
             commit.sha
@@ -324,7 +324,7 @@ class ForgejoProject(BaseGitProject):
     def request_access(self) -> None:
         raise OperationNotSupported("Not possible on Forgejo")
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoIssue.get_list)
     def get_issue_list(
         self,
@@ -335,12 +335,12 @@ class ForgejoProject(BaseGitProject):
     ) -> list["Issue"]:
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoIssue.get)
     def get_issue(self, issue_id: int) -> "Issue":
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoIssue.create)
     def create_issue(
         self,
@@ -352,12 +352,12 @@ class ForgejoProject(BaseGitProject):
     ) -> Issue:
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoPullRequest.get_list)
     def get_pr_list(self, status: PRStatus = PRStatus.open) -> Iterable["PullRequest"]:
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoPullRequest.get)
     def get_pr(self, pr_id: int) -> "PullRequest":
         pass
@@ -381,7 +381,7 @@ class ForgejoProject(BaseGitProject):
         # https://github.com/packit/ogr/issues/895
         raise NotImplementedError()
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_tags(self) -> Iterable["GitTag"]:
         return (
             GitTag(
@@ -391,14 +391,14 @@ class ForgejoProject(BaseGitProject):
             for tag in paginate(self.partial_api(self.api.repo_list_tags))
         )
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_sha_from_tag(self, tag_name: str) -> str:
         return self.partial_api(
             self.api.repo_get_tag,
             tag=tag_name,
         )().commit.sha
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoRelease.get)
     def get_release(
         self,
@@ -408,17 +408,17 @@ class ForgejoProject(BaseGitProject):
     ) -> Release:
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoRelease.get_latest)
     def get_latest_release(self) -> Optional[Release]:
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoRelease.get_list)
     def get_releases(self) -> list[Release]:
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoRelease.create)
     def create_release(
         self,
@@ -429,7 +429,7 @@ class ForgejoProject(BaseGitProject):
     ) -> Release:
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoPullRequest.create)
     def create_pr(
         self,
@@ -456,7 +456,7 @@ class ForgejoProject(BaseGitProject):
     def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
         raise OperationNotSupported("Forgejo doesn't support commit comments")
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoCommitFlag.set)
     def set_commit_status(
         self,
@@ -469,7 +469,7 @@ class ForgejoProject(BaseGitProject):
     ) -> "CommitFlag":
         pass
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     @indirect(ForgejoCommitFlag.get)
     def get_commit_statuses(self, commit: str) -> Iterable["CommitFlag"]:
         pass
@@ -480,7 +480,7 @@ class ForgejoProject(BaseGitProject):
             "ssh": self.forgejo_repo.ssh_url,
         }
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def fork_create(self, namespace: Optional[str] = None) -> "GitProject":
         if namespace:
             self.api.create_fork(
@@ -512,7 +512,7 @@ class ForgejoProject(BaseGitProject):
             "Not possible; requires recreation of the httpx client",
         )
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_file_content(
         self,
         path: str,
@@ -571,7 +571,7 @@ class ForgejoProject(BaseGitProject):
 
                     yield file.path
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_files(
         self,
         ref: Optional[str] = None,
@@ -591,7 +591,7 @@ class ForgejoProject(BaseGitProject):
 
         return paths
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_forks(self) -> Iterable["ForgejoProject"]:
         return (
             ForgejoProject(
@@ -607,7 +607,7 @@ class ForgejoProject(BaseGitProject):
     def get_web_url(self) -> str:
         return self.forgejo_repo.html_url
 
-    @track_ogr_request("forgejo")
+    @track_ogr_request
     def get_sha_from_branch(self, branch: str) -> Optional[str]:
         try:
             branch_info = self.partial_api(

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -141,7 +141,7 @@ class GithubProject(BaseGitProject):
             logger.debug(f"Project {user_login}/{self.repo} does not exist: {ex}")
             return None
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def exists(self) -> bool:
         try:
             _ = self.github_repo
@@ -173,11 +173,11 @@ class GithubProject(BaseGitProject):
     def default_branch(self):
         return self.github_repo.default_branch
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_branches(self) -> list[str]:
         return [branch.name for branch in self.github_repo.get_branches()]
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_commits(self, ref: Optional[str] = None) -> list[str]:
         ref = ref or self.github_repo.default_branch
         return [commit.sha for commit in self.github_repo.get_commits(sha=ref)]
@@ -269,7 +269,7 @@ class GithubProject(BaseGitProject):
             collaborators[user.login] = permission
         return collaborators
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubIssue.get_list)
     def get_issue_list(
         self,
@@ -280,12 +280,12 @@ class GithubProject(BaseGitProject):
     ) -> list[Issue]:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubIssue.get)
     def get_issue(self, issue_id: int) -> Issue:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubIssue.create)
     def create_issue(
         self,
@@ -300,17 +300,17 @@ class GithubProject(BaseGitProject):
     def delete(self) -> None:
         self.github_repo.delete()
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubPullRequest.get_list)
     def get_pr_list(self, status: PRStatus = PRStatus.open) -> list[PullRequest]:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubPullRequest.get)
     def get_pr(self, pr_id: int) -> PullRequest:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_sha_from_tag(self, tag_name: str) -> str:
         # TODO: This is ugly. Can we do it better?
         all_tags = self.github_repo.get_tags()
@@ -335,7 +335,7 @@ class GithubProject(BaseGitProject):
                 return GitTag(name=tag.name, commit_sha=tag.commit.sha)
         return None
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @if_readonly(return_function=GitProjectReadOnly.create_pr)
     @indirect(GithubPullRequest.create)
     def create_pr(
@@ -348,7 +348,7 @@ class GithubProject(BaseGitProject):
     ) -> PullRequest:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @if_readonly(
         return_function=GitProjectReadOnly.commit_comment,
         log_message="Create Comment to commit",
@@ -380,7 +380,7 @@ class GithubProject(BaseGitProject):
             sha=raw_commit_coment.commit_id,
         )
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_commit_comments(self, commit: str) -> list[CommitComment]:
         github_commit: Commit = self.github_repo.get_commit(commit)
         return [
@@ -388,13 +388,13 @@ class GithubProject(BaseGitProject):
             for comment in github_commit.get_comments()
         ]
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
         return self._commit_comment_from_github_object(
             self.github_repo.get_comment(comment_id),
         )
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @if_readonly(
         return_function=GitProjectReadOnly.set_commit_status,
         log_message="Create a status on a commit",
@@ -411,12 +411,12 @@ class GithubProject(BaseGitProject):
     ):
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubCommitFlag.get)
     def get_commit_statuses(self, commit: str) -> list[CommitFlag]:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubCheckRun.get)
     def get_check_run(
         self,
@@ -425,7 +425,7 @@ class GithubProject(BaseGitProject):
     ) -> Optional["GithubCheckRun"]:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubCheckRun.create)
     def create_check_run(
         self,
@@ -442,7 +442,7 @@ class GithubProject(BaseGitProject):
     ) -> "GithubCheckRun":
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubCheckRun.get_list)
     def get_check_runs(
         self,
@@ -455,7 +455,7 @@ class GithubProject(BaseGitProject):
     def get_git_urls(self) -> dict[str, str]:
         return {"git": self.github_repo.clone_url, "ssh": self.github_repo.ssh_url}
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @if_readonly(return_function=GitProjectReadOnly.fork_create)
     def fork_create(self, namespace: Optional[str] = None) -> "GithubProject":
         fork_repo = (
@@ -471,7 +471,7 @@ class GithubProject(BaseGitProject):
     def change_token(self, new_token: str):
         raise OperationNotSupported
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_file_content(
         self,
         path: str,
@@ -489,7 +489,7 @@ class GithubProject(BaseGitProject):
                 raise FileNotFoundError(f"File '{path}' on {ref} not found") from ex
             raise GithubAPIException() from ex
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_files(
         self,
         ref: Optional[str] = None,
@@ -561,27 +561,27 @@ class GithubProject(BaseGitProject):
             return color[1:]
         return color
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubRelease.get)
     def get_release(self, identifier=None, name=None, tag_name=None) -> GithubRelease:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubRelease.get_latest)
     def get_latest_release(self) -> Optional[GithubRelease]:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubRelease.get_list)
     def get_releases(self) -> list[Release]:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     @indirect(GithubRelease.create)
     def create_release(self, tag: str, name: str, message: str) -> GithubRelease:
         pass
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_forks(self) -> list["GithubProject"]:
         return [
             self.service.get_project_from_github_repository(fork)
@@ -592,11 +592,11 @@ class GithubProject(BaseGitProject):
     def get_web_url(self) -> str:
         return self.github_repo.html_url
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_tags(self) -> list["GitTag"]:
         return [GitTag(tag.name, tag.commit.sha) for tag in self.github_repo.get_tags()]
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_sha_from_branch(self, branch: str) -> Optional[str]:
         try:
             return self.github_repo.get_branch(branch).commit.sha
@@ -605,7 +605,7 @@ class GithubProject(BaseGitProject):
                 return None
             raise GithubAPIException from ex
 
-    @track_ogr_request("github")
+    @track_ogr_request
     def get_contributors(self) -> set[str]:
         """
         Returns:

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -114,7 +114,7 @@ class GitlabProject(BaseGitProject):
             logger.debug(f"Project {user_login}/{self.repo} does not exist: {ex}")
         return None
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def exists(self) -> bool:
         try:
             _ = self.gitlab_repo
@@ -258,12 +258,12 @@ class GitlabProject(BaseGitProject):
         except gitlab.exceptions.GitlabCreateError as e:
             raise GitlabAPIException("Unable to request access") from e
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabPullRequest.get_list)
     def get_pr_list(self, status: PRStatus = PRStatus.open) -> list["PullRequest"]:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_sha_from_tag(self, tag_name: str) -> str:
         try:
             tag = self.gitlab_repo.tags.get(tag_name)
@@ -272,7 +272,7 @@ class GitlabProject(BaseGitProject):
             logger.error(f"Tag {tag_name} was not found.")
             raise GitlabAPIException(f"Tag {tag_name} was not found.") from ex
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabPullRequest.create)
     def create_pr(
         self,
@@ -284,7 +284,7 @@ class GitlabProject(BaseGitProject):
     ) -> "PullRequest":
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def commit_comment(
         self,
         commit: str,
@@ -313,7 +313,7 @@ class GitlabProject(BaseGitProject):
             sha=commit,
         )
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_commit_comments(self, commit: str) -> list[CommitComment]:
         try:
             commit_object: ProjectCommit = self.gitlab_repo.commits.get(commit)
@@ -358,7 +358,7 @@ class GitlabProject(BaseGitProject):
 
         return self._commit_comment_from_gitlab_object(comment, commit_sha)
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabCommitFlag.set)
     def set_commit_status(
         self,
@@ -371,7 +371,7 @@ class GitlabProject(BaseGitProject):
     ) -> "CommitFlag":
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabCommitFlag.get)
     def get_commit_statuses(self, commit: str) -> list[CommitFlag]:
         pass
@@ -382,7 +382,7 @@ class GitlabProject(BaseGitProject):
             "ssh": self.gitlab_repo.attributes["ssh_url_to_repo"],
         }
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def fork_create(self, namespace: Optional[str] = None) -> "GitlabProject":
         data = {}
         if namespace:
@@ -405,11 +405,11 @@ class GitlabProject(BaseGitProject):
     def change_token(self, new_token: str):
         self.service.change_token(new_token)
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_branches(self) -> list[str]:
         return [branch.name for branch in self.gitlab_repo.branches.list(all=True)]
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_commits(self, ref: Optional[str] = None) -> list[str]:
         ref = ref or self.default_branch
         return [
@@ -417,7 +417,7 @@ class GitlabProject(BaseGitProject):
             for commit in self.gitlab_repo.commits.list(ref_name=ref, all=True)
         ]
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_file_content(
         self,
         path: str,
@@ -435,7 +435,7 @@ class GitlabProject(BaseGitProject):
                 raise FileNotFoundError(f"File '{path}' on {ref} not found") from ex
             raise GitlabAPIException() from ex
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_files(
         self,
         ref: Optional[str] = None,
@@ -457,7 +457,7 @@ class GitlabProject(BaseGitProject):
 
         return paths
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabIssue.get_list)
     def get_issue_list(
         self,
@@ -468,12 +468,12 @@ class GitlabProject(BaseGitProject):
     ) -> list[Issue]:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabIssue.get)
     def get_issue(self, issue_id: int) -> Issue:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabIssue.create)
     def create_issue(
         self,
@@ -485,12 +485,12 @@ class GitlabProject(BaseGitProject):
     ) -> Issue:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabPullRequest.get)
     def get_pr(self, pr_id: int) -> PullRequest:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_tags(self) -> list["GitTag"]:
         tags = self.gitlab_repo.tags.list()
         return [GitTag(tag.name, tag.commit["id"]) for tag in tags]
@@ -499,17 +499,17 @@ class GitlabProject(BaseGitProject):
         git_tag = self.gitlab_repo.tags.get(tag_name)
         return GitTag(name=git_tag.name, commit_sha=git_tag.commit["id"])
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabRelease.get_list)
     def get_releases(self) -> list[Release]:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabRelease.get)
     def get_release(self, identifier=None, name=None, tag_name=None) -> GitlabRelease:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabRelease.create)
     def create_release(
         self,
@@ -520,7 +520,7 @@ class GitlabProject(BaseGitProject):
     ) -> GitlabRelease:
         pass
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     @indirect(GitlabRelease.get_latest)
     def get_latest_release(self) -> Optional[GitlabRelease]:
         pass
@@ -534,7 +534,7 @@ class GitlabProject(BaseGitProject):
         """
         return list(self.gitlab_repo.labels.list())
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_forks(self) -> list["GitlabProject"]:
         try:
             forks = self.gitlab_repo.forks.list()
@@ -589,7 +589,7 @@ class GitlabProject(BaseGitProject):
     def get_web_url(self) -> str:
         return self.gitlab_repo.web_url
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_sha_from_branch(self, branch: str) -> Optional[str]:
         try:
             return self.gitlab_repo.branches.get(branch).attributes["commit"]["id"]
@@ -598,7 +598,7 @@ class GitlabProject(BaseGitProject):
                 return None
             raise GitlabAPIException from ex
 
-    @track_ogr_request("gitlab")
+    @track_ogr_request
     def get_contributors(self) -> set[str]:
         """
         Returns:

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -24,6 +24,7 @@ from ogr.exceptions import (
     OperationNotSupported,
     PagureAPIException,
 )
+from ogr.metrics import track_ogr_request
 from ogr.read_only import GitProjectReadOnly, if_readonly
 from ogr.services import pagure as ogr_pagure
 from ogr.services.base import BaseGitProject
@@ -184,9 +185,11 @@ class PagureProject(BaseGitProject):
             add_api_endpoint_part=add_api_endpoint_part,
         )
 
+    @track_ogr_request("pagure")
     def get_project_info(self):
         return self._call_project_api(method="GET")
 
+    @track_ogr_request("pagure")
     def get_branches(self) -> list[str]:
         return_value = self._call_project_api("git", "branches", method="GET")
         return return_value["branches"]
@@ -258,6 +261,7 @@ class PagureProject(BaseGitProject):
     def request_access(self):
         raise OperationNotSupported("Not possible on Pagure")
 
+    @track_ogr_request("pagure")
     @indirect(PagureIssue.get_list)
     def get_issue_list(
         self,
@@ -268,6 +272,7 @@ class PagureProject(BaseGitProject):
     ) -> list[Issue]:
         pass
 
+    @track_ogr_request("pagure")
     @indirect(PagureIssue.get)
     def get_issue(self, issue_id: int) -> Issue:
         pass
@@ -275,6 +280,7 @@ class PagureProject(BaseGitProject):
     def delete(self) -> None:
         self._call_project_api_raw("delete", method="POST")
 
+    @track_ogr_request("pagure")
     @indirect(PagureIssue.create)
     def create_issue(
         self,
@@ -286,6 +292,7 @@ class PagureProject(BaseGitProject):
     ) -> Issue:
         pass
 
+    @track_ogr_request("pagure")
     @indirect(PagurePullRequest.get_list)
     def get_pr_list(
         self,
@@ -295,6 +302,7 @@ class PagureProject(BaseGitProject):
     ) -> list[PullRequest]:
         pass
 
+    @track_ogr_request("pagure")
     @indirect(PagurePullRequest.get)
     def get_pr(self, pr_id: int) -> PullRequest:
         pass
@@ -308,6 +316,7 @@ class PagureProject(BaseGitProject):
     ) -> dict:
         pass
 
+    @track_ogr_request("pagure")
     @if_readonly(return_function=GitProjectReadOnly.create_pr)
     @indirect(PagurePullRequest.create)
     def create_pr(
@@ -320,6 +329,7 @@ class PagureProject(BaseGitProject):
     ) -> PullRequest:
         pass
 
+    @track_ogr_request("pagure")
     @if_readonly(return_function=GitProjectReadOnly.fork_create)
     def fork_create(self, namespace: Optional[str] = None) -> "PagureProject":
         if namespace is not None:
@@ -372,6 +382,7 @@ class PagureProject(BaseGitProject):
         )
         return None
 
+    @track_ogr_request("pagure")
     def exists(self) -> bool:
         response = self._call_project_api_raw()
         return response.ok
@@ -465,6 +476,7 @@ class PagureProject(BaseGitProject):
     def change_token(self, new_token: str) -> None:
         self.service.change_token(new_token)
 
+    @track_ogr_request("pagure")
     def get_file_content(
         self,
         path: str,
@@ -490,6 +502,7 @@ class PagureProject(BaseGitProject):
             )
         return result.content.decode()
 
+    @track_ogr_request("pagure")
     def get_sha_from_tag(self, tag_name: str) -> str:
         tags_dict = self.get_tags_dict()
         if tag_name not in tags_dict:
@@ -512,6 +525,7 @@ class PagureProject(BaseGitProject):
     def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
         raise OperationNotSupported("Commit comments are not supported on Pagure.")
 
+    @track_ogr_request("pagure")
     @if_readonly(return_function=GitProjectReadOnly.set_commit_status)
     @indirect(PagureCommitFlag.set)
     def set_commit_status(
@@ -527,10 +541,12 @@ class PagureProject(BaseGitProject):
     ) -> "CommitFlag":
         pass
 
+    @track_ogr_request("pagure")
     @indirect(PagureCommitFlag.get)
     def get_commit_statuses(self, commit: str) -> list[CommitFlag]:
         pass
 
+    @track_ogr_request("pagure")
     def get_tags(self) -> list[GitTag]:
         response = self._call_project_api("git", "tags", params={"with_commits": True})
         return [GitTag(name=n, commit_sha=c) for n, c in response["tags"].items()]
@@ -539,18 +555,22 @@ class PagureProject(BaseGitProject):
         response = self._call_project_api("git", "tags", params={"with_commits": True})
         return {n: GitTag(name=n, commit_sha=c) for n, c in response["tags"].items()}
 
+    @track_ogr_request("pagure")
     @indirect(PagureRelease.get_list)
     def get_releases(self) -> list[Release]:
         pass
 
+    @track_ogr_request("pagure")
     @indirect(PagureRelease.get)
     def get_release(self, identifier=None, name=None, tag_name=None) -> PagureRelease:
         pass
 
+    @track_ogr_request("pagure")
     @indirect(PagureRelease.get_latest)
     def get_latest_release(self) -> Optional[PagureRelease]:
         pass
 
+    @track_ogr_request("pagure")
     @indirect(PagureRelease.create)
     def create_release(
         self,
@@ -561,6 +581,7 @@ class PagureProject(BaseGitProject):
     ) -> Release:
         pass
 
+    @track_ogr_request("pagure")
     def get_forks(self) -> list["PagureProject"]:
         forks_url = self.service.get_api_url("projects")
         projects_response = self.service.call_api(
@@ -608,6 +629,7 @@ class PagureProject(BaseGitProject):
                 elif recursive and file["type"] == "folder":
                     subfolders.append(file["path"])
 
+    @track_ogr_request("pagure")
     def get_files(
         self,
         ref: Optional[str] = None,
@@ -621,6 +643,7 @@ class PagureProject(BaseGitProject):
 
         return paths
 
+    @track_ogr_request("pagure")
     def get_sha_from_branch(self, branch: str) -> Optional[str]:
         branches = self._call_project_api(
             "git",

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -185,11 +185,11 @@ class PagureProject(BaseGitProject):
             add_api_endpoint_part=add_api_endpoint_part,
         )
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_project_info(self):
         return self._call_project_api(method="GET")
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_branches(self) -> list[str]:
         return_value = self._call_project_api("git", "branches", method="GET")
         return return_value["branches"]
@@ -261,7 +261,7 @@ class PagureProject(BaseGitProject):
     def request_access(self):
         raise OperationNotSupported("Not possible on Pagure")
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureIssue.get_list)
     def get_issue_list(
         self,
@@ -272,7 +272,7 @@ class PagureProject(BaseGitProject):
     ) -> list[Issue]:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureIssue.get)
     def get_issue(self, issue_id: int) -> Issue:
         pass
@@ -280,7 +280,7 @@ class PagureProject(BaseGitProject):
     def delete(self) -> None:
         self._call_project_api_raw("delete", method="POST")
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureIssue.create)
     def create_issue(
         self,
@@ -292,7 +292,7 @@ class PagureProject(BaseGitProject):
     ) -> Issue:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagurePullRequest.get_list)
     def get_pr_list(
         self,
@@ -302,7 +302,7 @@ class PagureProject(BaseGitProject):
     ) -> list[PullRequest]:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagurePullRequest.get)
     def get_pr(self, pr_id: int) -> PullRequest:
         pass
@@ -316,7 +316,7 @@ class PagureProject(BaseGitProject):
     ) -> dict:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @if_readonly(return_function=GitProjectReadOnly.create_pr)
     @indirect(PagurePullRequest.create)
     def create_pr(
@@ -329,7 +329,7 @@ class PagureProject(BaseGitProject):
     ) -> PullRequest:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @if_readonly(return_function=GitProjectReadOnly.fork_create)
     def fork_create(self, namespace: Optional[str] = None) -> "PagureProject":
         if namespace is not None:
@@ -382,7 +382,7 @@ class PagureProject(BaseGitProject):
         )
         return None
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def exists(self) -> bool:
         response = self._call_project_api_raw()
         return response.ok
@@ -476,7 +476,7 @@ class PagureProject(BaseGitProject):
     def change_token(self, new_token: str) -> None:
         self.service.change_token(new_token)
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_file_content(
         self,
         path: str,
@@ -502,7 +502,7 @@ class PagureProject(BaseGitProject):
             )
         return result.content.decode()
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_sha_from_tag(self, tag_name: str) -> str:
         tags_dict = self.get_tags_dict()
         if tag_name not in tags_dict:
@@ -525,7 +525,7 @@ class PagureProject(BaseGitProject):
     def get_commit_comment(self, commit_sha: str, comment_id: int) -> CommitComment:
         raise OperationNotSupported("Commit comments are not supported on Pagure.")
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @if_readonly(return_function=GitProjectReadOnly.set_commit_status)
     @indirect(PagureCommitFlag.set)
     def set_commit_status(
@@ -541,12 +541,12 @@ class PagureProject(BaseGitProject):
     ) -> "CommitFlag":
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureCommitFlag.get)
     def get_commit_statuses(self, commit: str) -> list[CommitFlag]:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_tags(self) -> list[GitTag]:
         response = self._call_project_api("git", "tags", params={"with_commits": True})
         return [GitTag(name=n, commit_sha=c) for n, c in response["tags"].items()]
@@ -555,22 +555,22 @@ class PagureProject(BaseGitProject):
         response = self._call_project_api("git", "tags", params={"with_commits": True})
         return {n: GitTag(name=n, commit_sha=c) for n, c in response["tags"].items()}
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureRelease.get_list)
     def get_releases(self) -> list[Release]:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureRelease.get)
     def get_release(self, identifier=None, name=None, tag_name=None) -> PagureRelease:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureRelease.get_latest)
     def get_latest_release(self) -> Optional[PagureRelease]:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     @indirect(PagureRelease.create)
     def create_release(
         self,
@@ -581,7 +581,7 @@ class PagureProject(BaseGitProject):
     ) -> Release:
         pass
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_forks(self) -> list["PagureProject"]:
         forks_url = self.service.get_api_url("projects")
         projects_response = self.service.call_api(
@@ -629,7 +629,7 @@ class PagureProject(BaseGitProject):
                 elif recursive and file["type"] == "folder":
                     subfolders.append(file["path"])
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_files(
         self,
         ref: Optional[str] = None,
@@ -643,7 +643,7 @@ class PagureProject(BaseGitProject):
 
         return paths
 
-    @track_ogr_request("pagure")
+    @track_ogr_request
     def get_sha_from_branch(self, branch: str) -> Optional[str]:
         branches = self._call_project_api(
             "git",

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,267 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+import pytest
+from flexmock import flexmock
+
+import ogr.metrics
+from ogr.metrics import (
+    RequestMetricsTracker,
+    get_metrics_tracker,
+    record_ogr_request,
+    track_ogr_request,
+)
+
+
+class TestRequestMetricsTracker:
+    """Tests for RequestMetricsTracker class."""
+
+    def test_record_request_basic(self):
+        """Test basic request recording."""
+        tracker = RequestMetricsTracker()
+        tracker.record_request("github", "packit")
+
+        counts = tracker.get_all_counts()
+        assert counts == {("github", "packit"): 1}
+
+    def test_record_request_multiple(self):
+        """Test recording multiple requests."""
+        tracker = RequestMetricsTracker()
+        tracker.record_request("github", "packit")
+        tracker.record_request("github", "packit")
+        tracker.record_request("github", "rpms")
+        tracker.record_request("gitlab", "packit")
+
+        counts = tracker.get_all_counts()
+        assert counts == {
+            ("github", "packit"): 2,
+            ("github", "rpms"): 1,
+            ("gitlab", "packit"): 1,
+        }
+
+    def test_get_all_counts_empty(self):
+        """Test getting counts from empty tracker."""
+        tracker = RequestMetricsTracker()
+        counts = tracker.get_all_counts()
+        assert counts == {}
+
+    def test_reset(self):
+        """Test resetting counters."""
+        tracker = RequestMetricsTracker()
+        tracker.record_request("github", "packit")
+        tracker.record_request("gitlab", "rpms")
+
+        # Verify counts before reset
+        assert len(tracker.get_all_counts()) == 2
+
+        # Reset and verify
+        tracker.reset()
+        counts = tracker.get_all_counts()
+        assert counts == {}
+
+    @pytest.mark.parametrize(
+        ("service_type", "namespace", "count"),
+        [
+            ("github", "packit", 1),
+            ("gitlab", "rpms", 5),
+            ("pagure", "fedora-infrastructure", 10),
+            ("forgejo", "example-org", 3),
+        ],
+    )
+    def test_record_request_various_services(
+        self,
+        service_type: str,
+        namespace: str,
+        count: int,
+    ):
+        """Test recording requests for various service types."""
+        tracker = RequestMetricsTracker()
+        for _ in range(count):
+            tracker.record_request(service_type, namespace)
+
+        counts = tracker.get_all_counts()
+        assert counts == {(service_type, namespace): count}
+
+
+class TestGlobalFunctions:
+    """Tests for global convenience functions."""
+
+    def test_get_metrics_tracker(self):
+        """Test getting the global metrics tracker."""
+        tracker1 = get_metrics_tracker()
+        tracker2 = get_metrics_tracker()
+
+        assert tracker1 is tracker2
+        assert isinstance(tracker1, RequestMetricsTracker)
+
+    def test_record_ogr_request(self):
+        """Test the record_ogr_request convenience function."""
+        tracker = get_metrics_tracker()
+        tracker.reset()
+
+        record_ogr_request("github", "packit")
+        record_ogr_request("github", "packit")
+
+        counts = tracker.get_all_counts()
+        assert counts[("github", "packit")] == 2
+
+
+class TestTrackOgrRequestDecorator:
+    """Tests for track_ogr_request decorator."""
+
+    def test_decorator_tracks_request(self):
+        """Test that decorator tracks requests correctly."""
+        tracker = get_metrics_tracker()
+        tracker.reset()
+
+        mock_project = flexmock(namespace="packit")
+
+        @track_ogr_request("github")
+        def test_method(self):
+            return "success"
+
+        result = test_method(mock_project)
+
+        assert result == "success"
+
+        counts = tracker.get_all_counts()
+        assert counts == {("github", "packit"): 1}
+
+    def test_decorator_with_none_namespace(self):
+        """Test decorator when namespace is None (should not track)."""
+        tracker = get_metrics_tracker()
+        tracker.reset()
+
+        # Create a mock project without namespace
+        mock_project = flexmock(namespace=None)
+
+        @track_ogr_request("github")
+        def test_method(self):
+            return "success"
+
+        result = test_method(mock_project)
+
+        assert result == "success"
+
+        counts = tracker.get_all_counts()
+        assert counts == {}
+
+    def test_decorator_with_missing_namespace_attribute(self):
+        """Test decorator when object has no namespace attribute (should not track)."""
+        tracker = get_metrics_tracker()
+        tracker.reset()
+
+        mock_obj = flexmock()  # No namespace attribute
+
+        @track_ogr_request("github")
+        def test_method(self):
+            return "success"
+
+        result = test_method(mock_obj)
+
+        assert result == "success"
+
+        counts = tracker.get_all_counts()
+        assert counts == {}
+
+    def test_decorator_handles_exceptions_silently(self, caplog):
+        """Test that decorator catches exceptions during metric recording."""
+
+        mock_project = flexmock(namespace="test-namespace")
+
+        flexmock(ogr.metrics).should_receive("record_ogr_request").and_raise(
+            ValueError("Test exception"),
+        )
+
+        @track_ogr_request("github")
+        def test_method(self):
+            return "success"
+
+        with caplog.at_level(logging.DEBUG):
+            result = test_method(mock_project)
+
+        # Verify method still returns successfully
+        assert result == "success"
+
+        # Verify exception was logged
+        assert any(
+            "Failed to record metrics" in record.message for record in caplog.records
+        )
+
+    def test_decorator_preserves_function_metadata(self):
+        """Test that decorator preserves function name and docstring."""
+
+        @track_ogr_request("github")
+        def example_method(self):
+            """Example docstring."""
+            return "result"
+
+        assert example_method.__name__ == "example_method"
+        assert example_method.__doc__ == "Example docstring."
+
+    def test_decorator_with_multiple_calls(self):
+        """Test decorator with multiple calls to same method."""
+        tracker = get_metrics_tracker()
+        tracker.reset()
+
+        mock_project = flexmock(namespace="packit")
+
+        @track_ogr_request("github")
+        def test_method(self):
+            return "success"
+
+        # Call multiple times
+        for _ in range(5):
+            test_method(mock_project)
+
+        counts = tracker.get_all_counts()
+        assert counts == {("github", "packit"): 5}
+
+    def test_decorator_with_different_service_types(self):
+        """Test decorator with different service types."""
+        tracker = get_metrics_tracker()
+        tracker.reset()
+
+        mock_project = flexmock(namespace="packit")
+
+        @track_ogr_request("github")
+        def github_method(self):
+            return "github"
+
+        @track_ogr_request("gitlab")
+        def gitlab_method(self):
+            return "gitlab"
+
+        github_method(mock_project)
+        github_method(mock_project)
+        gitlab_method(mock_project)
+
+        counts = tracker.get_all_counts()
+        assert counts == {
+            ("github", "packit"): 2,
+            ("gitlab", "packit"): 1,
+        }
+
+    def test_integration_with_different_namespaces(self):
+        """Integration test with multiple namespaces."""
+        tracker = get_metrics_tracker()
+        tracker.reset()
+
+        @track_ogr_request("github")
+        def get_issues(self):
+            return []
+
+        project1 = flexmock(namespace="packit")
+        project2 = flexmock(namespace="rpms")
+
+        get_issues(project1)
+        get_issues(project1)
+        get_issues(project2)
+
+        counts = tracker.get_all_counts()
+        assert counts == {
+            ("github", "packit"): 2,
+            ("github", "rpms"): 1,
+        }

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -13,6 +13,7 @@ from ogr.metrics import (
     record_ogr_request,
     track_ogr_request,
 )
+from ogr.services.pagure import PagureService
 
 
 class TestRequestMetricsTracker:
@@ -21,24 +22,24 @@ class TestRequestMetricsTracker:
     def test_record_request_basic(self):
         """Test basic request recording."""
         tracker = RequestMetricsTracker()
-        tracker.record_request("github", "packit")
+        tracker.record_request("https://github.com", "packit")
 
         counts = tracker.get_all_counts()
-        assert counts == {("github", "packit"): 1}
+        assert counts == {("https://github.com", "packit"): 1}
 
     def test_record_request_multiple(self):
         """Test recording multiple requests."""
         tracker = RequestMetricsTracker()
-        tracker.record_request("github", "packit")
-        tracker.record_request("github", "packit")
-        tracker.record_request("github", "rpms")
-        tracker.record_request("gitlab", "packit")
+        tracker.record_request("https://github.com", "packit")
+        tracker.record_request("https://github.com", "packit")
+        tracker.record_request("https://github.com", "rpms")
+        tracker.record_request("https://gitlab.com", "packit")
 
         counts = tracker.get_all_counts()
         assert counts == {
-            ("github", "packit"): 2,
-            ("github", "rpms"): 1,
-            ("gitlab", "packit"): 1,
+            ("https://github.com", "packit"): 2,
+            ("https://github.com", "rpms"): 1,
+            ("https://gitlab.com", "packit"): 1,
         }
 
     def test_get_all_counts_empty(self):
@@ -50,8 +51,8 @@ class TestRequestMetricsTracker:
     def test_reset(self):
         """Test resetting counters."""
         tracker = RequestMetricsTracker()
-        tracker.record_request("github", "packit")
-        tracker.record_request("gitlab", "rpms")
+        tracker.record_request("https://github.com", "packit")
+        tracker.record_request("https://gitlab.com", "rpms")
 
         # Verify counts before reset
         assert len(tracker.get_all_counts()) == 2
@@ -62,27 +63,44 @@ class TestRequestMetricsTracker:
         assert counts == {}
 
     @pytest.mark.parametrize(
-        ("service_type", "namespace", "count"),
+        ("instance_url", "namespace", "count"),
         [
-            ("github", "packit", 1),
-            ("gitlab", "rpms", 5),
-            ("pagure", "fedora-infrastructure", 10),
-            ("forgejo", "example-org", 3),
+            ("https://github.com", "packit", 1),
+            ("https://gitlab.com", "rpms", 5),
+            ("https://pagure.io", "fedora-infrastructure", 10),
+            ("https://codeberg.org", "example-org", 3),
         ],
     )
     def test_record_request_various_services(
         self,
-        service_type: str,
+        instance_url: str,
         namespace: str,
         count: int,
     ):
         """Test recording requests for various service types."""
         tracker = RequestMetricsTracker()
         for _ in range(count):
-            tracker.record_request(service_type, namespace)
+            tracker.record_request(instance_url, namespace)
 
         counts = tracker.get_all_counts()
-        assert counts == {(service_type, namespace): count}
+        assert counts == {(instance_url, namespace): count}
+
+    def test_multiple_instances_same_service_type(self):
+        """Test that different instances of the same service type are tracked separately."""
+        tracker = RequestMetricsTracker()
+        tracker.record_request("https://gitlab.com", "packit")
+        tracker.record_request("https://gitlab.example.com", "packit")
+        tracker.record_request("https://gitlab.com", "packit")
+        tracker.record_request("https://codeberg.org", "myorg")
+        tracker.record_request("https://forgejo.example.com", "myorg")
+
+        counts = tracker.get_all_counts()
+        assert counts == {
+            ("https://gitlab.com", "packit"): 2,
+            ("https://gitlab.example.com", "packit"): 1,
+            ("https://codeberg.org", "myorg"): 1,
+            ("https://forgejo.example.com", "myorg"): 1,
+        }
 
 
 class TestGlobalFunctions:
@@ -101,11 +119,11 @@ class TestGlobalFunctions:
         tracker = get_metrics_tracker()
         tracker.reset()
 
-        record_ogr_request("github", "packit")
-        record_ogr_request("github", "packit")
+        record_ogr_request("https://github.com", "packit")
+        record_ogr_request("https://github.com", "packit")
 
         counts = tracker.get_all_counts()
-        assert counts[("github", "packit")] == 2
+        assert counts[("https://github.com", "packit")] == 2
 
 
 class TestTrackOgrRequestDecorator:
@@ -116,9 +134,10 @@ class TestTrackOgrRequestDecorator:
         tracker = get_metrics_tracker()
         tracker.reset()
 
-        mock_project = flexmock(namespace="packit")
+        mock_service = flexmock(instance_url="https://github.com")
+        mock_project = flexmock(namespace="packit", service=mock_service)
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def test_method(self):
             return "success"
 
@@ -127,7 +146,7 @@ class TestTrackOgrRequestDecorator:
         assert result == "success"
 
         counts = tracker.get_all_counts()
-        assert counts == {("github", "packit"): 1}
+        assert counts == {("https://github.com", "packit"): 1}
 
     def test_decorator_with_none_namespace(self):
         """Test decorator when namespace is None (should not track)."""
@@ -137,7 +156,7 @@ class TestTrackOgrRequestDecorator:
         # Create a mock project without namespace
         mock_project = flexmock(namespace=None)
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def test_method(self):
             return "success"
 
@@ -155,7 +174,7 @@ class TestTrackOgrRequestDecorator:
 
         mock_obj = flexmock()  # No namespace attribute
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def test_method(self):
             return "success"
 
@@ -175,7 +194,7 @@ class TestTrackOgrRequestDecorator:
             ValueError("Test exception"),
         )
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def test_method(self):
             return "success"
 
@@ -193,7 +212,7 @@ class TestTrackOgrRequestDecorator:
     def test_decorator_preserves_function_metadata(self):
         """Test that decorator preserves function name and docstring."""
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def example_method(self):
             """Example docstring."""
             return "result"
@@ -206,9 +225,10 @@ class TestTrackOgrRequestDecorator:
         tracker = get_metrics_tracker()
         tracker.reset()
 
-        mock_project = flexmock(namespace="packit")
+        mock_service = flexmock(instance_url="https://github.com")
+        mock_project = flexmock(namespace="packit", service=mock_service)
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def test_method(self):
             return "success"
 
@@ -217,31 +237,34 @@ class TestTrackOgrRequestDecorator:
             test_method(mock_project)
 
         counts = tracker.get_all_counts()
-        assert counts == {("github", "packit"): 5}
+        assert counts == {("https://github.com", "packit"): 5}
 
     def test_decorator_with_different_service_types(self):
         """Test decorator with different service types."""
         tracker = get_metrics_tracker()
         tracker.reset()
 
-        mock_project = flexmock(namespace="packit")
+        mock_github_service = flexmock(instance_url="https://github.com")
+        mock_gitlab_service = flexmock(instance_url="https://gitlab.com")
+        mock_github_project = flexmock(namespace="packit", service=mock_github_service)
+        mock_gitlab_project = flexmock(namespace="packit", service=mock_gitlab_service)
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def github_method(self):
             return "github"
 
-        @track_ogr_request("gitlab")
+        @track_ogr_request
         def gitlab_method(self):
             return "gitlab"
 
-        github_method(mock_project)
-        github_method(mock_project)
-        gitlab_method(mock_project)
+        github_method(mock_github_project)
+        github_method(mock_github_project)
+        gitlab_method(mock_gitlab_project)
 
         counts = tracker.get_all_counts()
         assert counts == {
-            ("github", "packit"): 2,
-            ("gitlab", "packit"): 1,
+            ("https://github.com", "packit"): 2,
+            ("https://gitlab.com", "packit"): 1,
         }
 
     def test_integration_with_different_namespaces(self):
@@ -249,12 +272,13 @@ class TestTrackOgrRequestDecorator:
         tracker = get_metrics_tracker()
         tracker.reset()
 
-        @track_ogr_request("github")
+        @track_ogr_request
         def get_issues(self):
             return []
 
-        project1 = flexmock(namespace="packit")
-        project2 = flexmock(namespace="rpms")
+        mock_service = flexmock(instance_url="https://github.com")
+        project1 = flexmock(namespace="packit", service=mock_service)
+        project2 = flexmock(namespace="rpms", service=mock_service)
 
         get_issues(project1)
         get_issues(project1)
@@ -262,8 +286,8 @@ class TestTrackOgrRequestDecorator:
 
         counts = tracker.get_all_counts()
         assert counts == {
-            ("github", "packit"): 2,
-            ("github", "rpms"): 1,
+            ("https://github.com", "packit"): 2,
+            ("https://github.com", "rpms"): 1,
         }
 
     def test_decorator_pagure_appends_repo_to_namespace(self):
@@ -271,10 +295,15 @@ class TestTrackOgrRequestDecorator:
         tracker = get_metrics_tracker()
         tracker.reset()
 
-        # Create mock Pagure project with namespace and repo
-        mock_project = flexmock(namespace="rpms", repo="python-requests")
+        # Create mock Pagure service - must be actual instance for isinstance() check
+        mock_service = flexmock(PagureService(instance_url="https://pagure.io"))
+        mock_project = flexmock(
+            namespace="rpms",
+            repo="python-requests",
+            service=mock_service,
+        )
 
-        @track_ogr_request("pagure")
+        @track_ogr_request
         def test_method(self):
             return "success"
 
@@ -283,17 +312,18 @@ class TestTrackOgrRequestDecorator:
         assert result == "success"
 
         counts = tracker.get_all_counts()
-        assert counts == {("pagure", "rpms/python-requests"): 1}
+        assert counts == {("https://pagure.io", "rpms/python-requests"): 1}
 
     def test_decorator_pagure_without_repo(self):
-        """Test Pagure decorator when repo attribute is missing."""
+        """Test Pagure decorator when repo is None or empty."""
         tracker = get_metrics_tracker()
         tracker.reset()
 
-        # Create mock Pagure project with only namespace
-        mock_project = flexmock(namespace="rpms")
+        # Create mock Pagure service - must be actual instance for isinstance() check
+        mock_service = flexmock(PagureService(instance_url="https://pagure.io"))
+        mock_project = flexmock(namespace="rpms", repo=None, service=mock_service)
 
-        @track_ogr_request("pagure")
+        @track_ogr_request
         def test_method(self):
             return "success"
 
@@ -301,26 +331,6 @@ class TestTrackOgrRequestDecorator:
 
         assert result == "success"
 
-        # Should fall back to just namespace when repo is missing
+        # Should fall back to just namespace when repo is None/empty
         counts = tracker.get_all_counts()
-        assert counts == {("pagure", "rpms"): 1}
-
-    def test_decorator_non_pagure_does_not_append_repo(self):
-        """Test that non-Pagure services don't append repo to namespace."""
-        tracker = get_metrics_tracker()
-        tracker.reset()
-
-        # Create mock project with both namespace and repo
-        mock_project = flexmock(namespace="packit", repo="some-repo")
-
-        @track_ogr_request("github")
-        def test_method(self):
-            return "success"
-
-        result = test_method(mock_project)
-
-        assert result == "success"
-
-        # For non-Pagure services, repo should be ignored
-        counts = tracker.get_all_counts()
-        assert counts == {("github", "packit"): 1}
+        assert counts == {("https://pagure.io", "rpms"): 1}


### PR DESCRIPTION
This implementation isn't thread safe. I don't think we need to risk a deadlock just for tracking the trend of requests in a namespace. We can lose some of them.
Also, the aggregation of counts across different workers needs to be done in Grafana.

Should fix https://github.com/packit/packit-service/issues/2912
Merge before https://github.com/packit/packit-service/pull/3026