### PR TITLE
Add retry responses for pyforgejo 2.0.7 in forgejo test cassette

### DIFF
--- a/tests/integration/forgejo/test_data/test_issues/Issues.test_issue_no_such_assignee.yaml
+++ b/tests/integration/forgejo/test_data/test_issues/Issues.test_issue_no_such_assignee.yaml
@@ -303,3 +303,69 @@ httpx._client:
             x-frame-options: SAMEORIGIN
           next_request: null
           status_code: 500
+      - metadata:
+          latency: 0.2674534320831299
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_issues
+          - ogr.abstract.exception
+          - ogr.services.forgejo.issue
+          - pyforgejo.issue.client
+          - pyforgejo.issue.raw_client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: ''
+            url: https://v10.next.forgejo.org/api/swagger
+          _elapsed: 0.267228
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '64'
+            content-type: application/json;charset=utf-8
+            date: Mon, 05 Jan 2026 11:20:35 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 500
+      - metadata:
+          latency: 0.2674534320831299
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.forgejo.test_issues
+          - ogr.abstract.exception
+          - ogr.services.forgejo.issue
+          - pyforgejo.issue.client
+          - pyforgejo.issue.raw_client
+          - pyforgejo.core.http_client
+          - httpx._client
+          - requre.objects
+          - requre.cassette
+          - httpx._client
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            message: ''
+            url: https://v10.next.forgejo.org/api/swagger
+          _elapsed: 0.267228
+          encoding: utf-8
+          headers:
+            cache-control: max-age=0, private, must-revalidate, no-transform
+            content-length: '64'
+            content-type: application/json;charset=utf-8
+            date: Mon, 05 Jan 2026 11:20:35 GMT
+            vary: Origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+          next_request: null
+          status_code: 500


### PR DESCRIPTION
pyforgejo changed its default retry behavior between versions 2.0.4 and 2.0.7:

- pyforgejo 2.0.4: max_retries defaults to 0 (no retries, 1 HTTP call)
- pyforgejo 2.0.7: max_retries defaults to 2 (2 retries, 3 HTTP calls total)

The test_issue_no_such_assignee test expects a 500 Internal Server Error response when attempting to add a non-existent user as an assignee. This is the actual behavior of the Forgejo API, and the test verifies that ogr properly converts this to a GitForgeInternalError.

Compatibility with both versions:
- pyforgejo 2.0.4 (F43): Uses first response, leaves 2 unused (safe)
- pyforgejo 2.0.7 (Rawhide): Consumes all 3 responses during retries

Fixes test failure in Fedora Rawhide with python3-pyforgejo-2.0.7.
