### PR TITLE
Pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   check_release_notes:
     name: Notes are either written, or there are none
-    uses: packit/.github/.github/workflows/check-release-notes.yml@main
+    uses: packit/.github/.github/workflows/check-release-notes.yml@2837c96caf71966609451ad0323552ef4be11a23
     with:
       description: ${{ github.event.pull_request.body }}

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') && github.repository_owner == 'packit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Create GitHub release
         run: |
           VERSION=$(grep -oP '^# \K[0-9.]*' CHANGELOG.md | head -n 1)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Build and push docs
         run: |
           git config user.name Packit

--- a/.github/workflows/opened-prs-to-the-board.yml
+++ b/.github/workflows/opened-prs-to-the-board.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
         with:
           project-url: https://github.com/orgs/packit/projects/14
           github-token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -16,16 +16,16 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - name: Prepare release content
-        uses: packit/prepare-release@v1
+        uses: packit/prepare-release@3b7d729bf7a233a9696171d06abf9b8ef31e6e94 # v1
         with:
           version: ${{ inputs.version }}
           specfiles: fedora/python-ogr.spec
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           labels: release
           commit-message: Release ${{ inputs.version }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
 
       - name: Get history and tags for SCM versioning to work
         run: |
@@ -34,7 +34,7 @@ jobs:
           python -m build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-package-distributions
           path: dist/
@@ -52,13 +52,13 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Publish 📦 to PyPI
         # https://github.com/pypa/gh-action-pypi-publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           verbose: true


### PR DESCRIPTION
Pin all actions to specific commit SHAs to prevent supply chain attacks and ensure reproducible builds.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>