### PR TITLE
chore(pyproject): bump python versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "One API for multiple git forges."
 readme = "README.md"
 license = "MIT"
 license-files = { paths = ["LICENSE"] }
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -20,9 +20,9 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
Trying to run it locally I get yelled at because pyforgejo doesn't support Python 3.9.

Looking at the current Python in CentOS 10 (where we still release updates into EPEL10), the version is 3.12.

As for the current Fedora, it's 3.14, therefore add all these versions to classifiers and bump the minimal requirement from 3.9 to 3.12 as right now it is the minimal version we actively maintain.