### PR TITLE
pre-commit: replace archived mirrors-prettier with mdformat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,10 @@ repos:
     rev: 25.9.0
     hooks:
       - id: black
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
     hooks:
-      - id: prettier
+      - id: mdformat
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -499,8 +499,6 @@
 - Tests were removed from the zuul gating pipeline. (@lbarcziova)
 - We now use [rpmautospec] for generating changelogs in Fedora. (@TomasTomecek)
 
-[rpmautospec]: https://pagure.io/Fedora-Infra/rpmautospec
-
 # 0.11.1
 
 ## New Features
@@ -549,10 +547,10 @@
 - General restructure of the classes thanks to the
   [Red Hat Open Source Contest](https://research.redhat.com/red-hat-open-source-contest/)
   project done by @mfocko.
-  _ Classes are better linked together.
-  _ Functionality is moved to the classes from the `GitProject` classes.
-  _ You can now use the properties (setters) to modify objects.
-  _ Old behaviour should work as before, but will raise deprecation warnings.
+  \_ Classes are better linked together.
+  \_ Functionality is moved to the classes from the `GitProject` classes.
+  \_ You can now use the properties (setters) to modify objects.
+  \_ Old behaviour should work as before, but will raise deprecation warnings.
 
 ## Fixes
 
@@ -722,3 +720,5 @@
 ## Fixes
 
 - Object representation of the pull-request and pull-request commend.
+
+[rpmautospec]: https://pagure.io/Fedora-Infra/rpmautospec

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,79 +7,79 @@ In case you find any error, please [create a new issue](https://github.com/packi
 
 ### `IssueComment`
 
-|                  | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | ---------------- | :----: | :----: | :----: | :-----: |
-| `body` (get/set) |  ✔/✔   |  ✔/✔   |  ✔/✘   |   ✘/✘   |
-| `add_reaction`   |   ✔    |   ✔    |   ✘    |    ✘    |
-| `get_reactions`  |   ✔    |   ✔    |   ✘    |    ✘    |
+| `body` (get/set) | ✔/✔ | ✔/✔ | ✔/✘ | ✘/✘ |
+| `add_reaction` | ✔ | ✔ | ✘ | ✘ |
+| `get_reactions` | ✔ | ✔ | ✘ | ✘ |
 
 ### `PRComment`
 
-|                  | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | ---------------- | :----: | :----: | :----: | :-----: |
-| `body` (get/set) |  ✔/✔   |  ✔/✔   |  ✔/✘   |    ✘    |
-| `add_reaction`   |   ✔    |   ✔    |   ✘    |    ✘    |
-| `get_reactions`  |   ✔    |   ✔    |   ✘    |    ✘    |
-| `closed_by`      |   ✘    |   ✘    |   ✔    |    ✘    |
+| `body` (get/set) | ✔/✔ | ✔/✔ | ✔/✘ | ✘ |
+| `add_reaction` | ✔ | ✔ | ✘ | ✘ |
+| `get_reactions` | ✔ | ✔ | ✘ | ✘ |
+| `closed_by` | ✘ | ✘ | ✔ | ✘ |
 
 ## Issue
 
-|             | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | ----------- | :----: | :----: | :----: | :-----: |
-| `add_label` |   ✔    |   ✔    |   ✘    |    ✘    |
+| `add_label` | ✔ | ✔ | ✘ | ✘ |
 
 ## Pull request
 
-|                   | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | ----------------- | :----: | :----: | :----: | :-----: |
-| `add_label`       |   ✔    |   ✔    |   ✘    |    ✔    |
-| `get_all_commits` |   ✔    |   ✔    |   ✘    |    ✔    |
+| `add_label` | ✔ | ✔ | ✘ | ✔ |
+| `get_all_commits` | ✔ | ✔ | ✘ | ✔ |
 
 ## Release
 
-|                   | GitHub | GitLab |          Pagure          | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | ----------------- | :----: | :----: | :----------------------: | :-----: |
-| `edit_release`    |   ✔    |   ✘    |            ✘             |    ✔    |
-| `body` (only get) |   ✔    |   ✔    | ✘ (returns empty string) |    ✔    |
+| `edit_release` | ✔ | ✘ | ✘ | ✔ |
+| `body` (only get) | ✔ | ✔ | ✘ (returns empty string) | ✔ |
 
 ## Commit flag
 
-|          | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | -------- | :----: | :----: | :----: | :-----: |
-| `edited` |   ✔    |   ✘    |   ✔    |    ✘    |
+| `edited` | ✔ | ✘ | ✔ | ✘ |
 
 ## Project
 
-|                               | GitHub | GitLab |         Pagure          | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | ----------------------------- | :----: | :----: | :---------------------: | :-----: |
-| `change_token`                |   ✘    |   ✔    |            ✔            |    ✘    |
-| `get_release`                 |   ✔    |   ✔    |            ✘            |    ✘    |
-| `get_commits`                 |   ✔    |   ✔    |            ✘            |    ✔    |
-| `get_latest_release`          |   ✔    |   ✔    |            ✘            |    ✘    |
-| `is_private`                  |   ✔    |   ✔    | ✘ (may not be accurate) |    ✔    |
-| `remove_user`                 |   ✘    |   ✘    |            ✔            |    ✔    |
-| `add_group`                   |   ✘    |   ✘    |            ✔            |    ✘    |
-| `remove_group`                |   ✘    |   ✘    |            ✔            |    ✘    |
-| `which_groups_can_merge_pr`   |   ✘    |   ✘    |            ✔            |    ✘    |
-| `get_pr_files_diff`           |   ✘    |   ✘    |            ✔            |    ✘    |
-| `get_users_with_given_access` |   ✘    |   ✘    |            ✔            |    ✔    |
+| `change_token` | ✘ | ✔ | ✔ | ✘ |
+| `get_release` | ✔ | ✔ | ✘ | ✘ |
+| `get_commits` | ✔ | ✔ | ✘ | ✔ |
+| `get_latest_release` | ✔ | ✔ | ✘ | ✘ |
+| `is_private` | ✔ | ✔ | ✘ (may not be accurate) | ✔ |
+| `remove_user` | ✘ | ✘ | ✔ | ✔ |
+| `add_group` | ✘ | ✘ | ✔ | ✘ |
+| `remove_group` | ✘ | ✘ | ✔ | ✘ |
+| `which_groups_can_merge_pr` | ✘ | ✘ | ✔ | ✘ |
+| `get_pr_files_diff` | ✘ | ✘ | ✔ | ✘ |
+| `get_users_with_given_access` | ✘ | ✘ | ✔ | ✔ |
 
 ## User
 
-|                | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | -------------- | :----: | :----: | :----: | :-----: |
-| `get_projects` |   ✔    |   ✘    |   ✔    |    ✔    |
-| `get_forks`    |   ✔    |   ✘    |   ✔    |    ✔    |
-| `get_email`    |   ✔    |   ✔    |   ✘    |    ✔    |
+| `get_projects` | ✔ | ✘ | ✔ | ✔ |
+| `get_forks` | ✔ | ✘ | ✔ | ✔ |
+| `get_email` | ✔ | ✔ | ✘ | ✔ |
 
 ## Reaction
 
-|          | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | -------- | :----: | :----: | :----: | :-----: |
-| `delete` |   ✔    |   ✔    |   ✘    |    ✘    |
+| `delete` | ✔ | ✔ | ✘ | ✘ |
 
 ## Service
 
-|             | GitHub | GitLab | Pagure | Forgejo |
+| | GitHub | GitLab | Pagure | Forgejo |
 | ----------- | :----: | :----: | :----: | :-----: |
-| `get_group` |   ✘    |   ✘    |   ✔    |    ✘    |
+| `get_group` | ✘ | ✘ | ✔ | ✘ |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,11 +53,15 @@ We recommend running tests in a container. You need to have `podman` or
 
 To build the test image run:
 
-    make build-test-image
+```
+make build-test-image
+```
 
 You can run the test now with:
 
-    make check-in-container
+```
+make check-in-container
+```
 
 The 'make build-test-image' command builds a local image with all the dependencies using
 [ansible-bender](https://github.com/ansible-community/ansible-bender);
@@ -131,6 +135,6 @@ Run tests locally:
 make check
 ```
 
----
+______________________________________________________________________
 
 Thank you for your interest!

--- a/plans/README.md
+++ b/plans/README.md
@@ -9,7 +9,9 @@
 
 Run:
 
-    $ tmt -v run -a provision -h local
+```
+$ tmt -v run -a provision -h local
+```
 
 > [!WARNING]
 >
@@ -20,17 +22,23 @@ Run:
 
 It may be needed to install the `container` provisioning plugin:
 
-    $ sudo dnf install tmt-provision-container
+```
+$ sudo dnf install tmt-provision-container
+```
 
 Afterwards you can run the tests via:
 
-    $ tmt -v run -a provision -h container
+```
+$ tmt -v run -a provision -h container
+```
 
 Additionally you can also limit what tests are being run by setting the
 `TEST_TARGET` environment variable:
 
-    # For example this limits to only Forgejo tests
-    $ tmt -v run -e TEST_TARGET=integration/forgejo/ -a provision -h container
+```
+# For example this limits to only Forgejo tests
+$ tmt -v run -e TEST_TARGET=integration/forgejo/ -a provision -h container
+```
 
 ## Regenerating requre responses via `tmt`
 
@@ -47,13 +55,15 @@ clean up.
 This can be avoided by instructing tmt to keep the work directory after the test
 execution is finished:
 
-    # For example to generate Forgejo responses
-    $ tmt -vv \
-        run -a -k \
-        -e FORGEJO_TOKEN=$FORGEJO_TOKEN -e TEST_TARGET=integration/forgejo/ \
-          provision -h container \
-          plan -n full \
-          report -h display
+```
+# For example to generate Forgejo responses
+$ tmt -vv \
+    run -a -k \
+    -e FORGEJO_TOKEN=$FORGEJO_TOKEN -e TEST_TARGET=integration/forgejo/ \
+      provision -h container \
+      plan -n full \
+      report -h display
+```
 
 Explanation of the `tmt` command:
 
@@ -74,8 +84,9 @@ Explanation of the `tmt` command:
 >    cp .env.template .env
 >    ```
 >
-> 2. Populate `.env` with tokens
-> 3. Adjust the tmt command:
+> 1. Populate `.env` with tokens
+>
+> 1. Adjust the tmt command:
 >
 >    ```
 >    tmt -vv \
@@ -91,7 +102,9 @@ Explanation of the `tmt` command:
 Afterwards the generated responses can be found in the test directory
 (`<ID>` varies):
 
-    /var/tmp/tmt/<ID>/plans/full/discover/default-0/tests/
+```
+/var/tmp/tmt/<ID>/plans/full/discover/default-0/tests/
+```
 
 > [!WARNING]
 >


### PR DESCRIPTION
Replaces the archived `mirrors-prettier` hook with `mdformat` for Markdown formatting, as suggested in #983.

- `mirrors-prettier` is archived and has been making conflicting changes.
- `mdformat` now handles Markdown formatting via the plain `mdformat` hook id (no plugins).
- YAML/JSON formatting previously covered by prettier is dropped; YAML validity is still checked by the existing `check-yaml` hook. Maintainers can add a dedicated YAML formatter later if wanted.
- The second commit (`Reformat Markdown with mdformat`) is the mechanical output of `pre-commit run mdformat --all-files`.

Closes #983

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.
