### PR TITLE
Fix a bug in relation to the Forgejo "error" commit flag

### DIFF
--- a/ogr/services/forgejo/flag.py
+++ b/ogr/services/forgejo/flag.py
@@ -24,7 +24,7 @@ class ForgejoCommitFlag(BaseCommitFlag):
         "pending": CommitStatus.pending,
         "success": CommitStatus.success,
         "failure": CommitStatus.failure,
-        "canceled": CommitStatus.error,
+        "error": CommitStatus.error,
         "warning": CommitStatus.warning,
     }
 


### PR DESCRIPTION
The internal `_states` dictionary contained improper mapping of the "canceled" state to `CommitStatus.error`. Forgejo doesn't support the "canceled" state, so the mapping was never used. The supported "error" state would then not be recognized and a `ValueError` would be raised when attempting to map it. This has been fixed so that the "error" state is properly mapped.

RELEASE NOTES BEGIN

The `ogr` library now correctly handles the Forgejo 'error' commit flag, resolving an issue that previously caused it to fail during internal mapping.

RELEASE NOTES END
