### PR TITLE
Fix the value of `_self.token` in `ForgejoService`

### DIFF
--- a/ogr/services/forgejo/service.py
+++ b/ogr/services/forgejo/service.py
@@ -28,12 +28,14 @@ class ForgejoService(BaseGitService):
     ):
         super().__init__()
         self.instance_url = instance_url + self.version
-        self._token = f"token {token}"
+        self._token = token
         self._api = None
 
     @cached_property
     def api(self) -> PyforgejoApi:
-        return PyforgejoApi(base_url=self.instance_url, api_key=self._token)
+        # pyforgejo doesn't add the "token " prefix by default
+        api_key = f"token {self._token}"
+        return PyforgejoApi(base_url=self.instance_url, api_key=api_key)
 
     def get_project(  # type: ignore[override]
         self,


### PR DESCRIPTION
The value was previously set to f"token {token}", so when `token` was `None`, `self._token` would be set to "token None", which could lead to confusing behavior. `self._token` should be set to match `token` (to match the implementation of other forges). When instantiating `PyforgejoApi`, `api_key` needs to be set to an arbitrary string when making an unauthenticated request, otherwise a `ValueError` would be raised.

This issues was discovered when working on [#996](https://github.com/packit/ogr/pull/996).

RELEASE NOTES BEGIN

A bug has been fixed in relation to `ForgejoService` where `self._token` would be set to "token None" when it should be set to `None` instead.

RELEASE NOTES END