### PR TITLE
docs: mark implemented Forgejo APIs in COMPATIBILITY.md

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -9,24 +9,24 @@ In case you find any error, please [create a new issue](https://github.com/packi
 
 | | GitHub | GitLab | Pagure | Forgejo |
 | ---------------- | :----: | :----: | :----: | :-----: |
-| `body` (get/set) | ✔/✔ | ✔/✔ | ✔/✘ | ✘/✘ |
-| `add_reaction` | ✔ | ✔ | ✘ | ✘ |
-| `get_reactions` | ✔ | ✔ | ✘ | ✘ |
+| `body` (get/set) | ✔/✔ | ✔/✔ | ✔/✘ | ✔/✔ |
+| `add_reaction` | ✔ | ✔ | ✘ | ✔ |
+| `get_reactions` | ✔ | ✔ | ✘ | ✔ |
 
 ### `PRComment`
 
 | | GitHub | GitLab | Pagure | Forgejo |
 | ---------------- | :----: | :----: | :----: | :-----: |
-| `body` (get/set) | ✔/✔ | ✔/✔ | ✔/✘ | ✘ |
-| `add_reaction` | ✔ | ✔ | ✘ | ✘ |
-| `get_reactions` | ✔ | ✔ | ✘ | ✘ |
+| `body` (get/set) | ✔/✔ | ✔/✔ | ✔/✘ | ✔/✔ |
+| `add_reaction` | ✔ | ✔ | ✘ | ✔ |
+| `get_reactions` | ✔ | ✔ | ✘ | ✔ |
 | `closed_by` | ✘ | ✘ | ✔ | ✘ |
 
 ## Issue
 
 | | GitHub | GitLab | Pagure | Forgejo |
 | ----------- | :----: | :----: | :----: | :-----: |
-| `add_label` | ✔ | ✔ | ✘ | ✘ |
+| `add_label` | ✔ | ✔ | ✘ | ✔ |
 
 ## Pull request
 
@@ -53,9 +53,9 @@ In case you find any error, please [create a new issue](https://github.com/packi
 | | GitHub | GitLab | Pagure | Forgejo |
 | ----------------------------- | :----: | :----: | :---------------------: | :-----: |
 | `change_token` | ✘ | ✔ | ✔ | ✘ |
-| `get_release` | ✔ | ✔ | ✘ | ✘ |
+| `get_release` | ✔ | ✔ | ✘ | ✔ |
 | `get_commits` | ✔ | ✔ | ✘ | ✔ |
-| `get_latest_release` | ✔ | ✔ | ✘ | ✘ |
+| `get_latest_release` | ✔ | ✔ | ✘ | ✔ |
 | `is_private` | ✔ | ✔ | ✘ (may not be accurate) | ✔ |
 | `remove_user` | ✘ | ✘ | ✔ | ✔ |
 | `add_group` | ✘ | ✘ | ✔ | ✘ |
@@ -76,7 +76,7 @@ In case you find any error, please [create a new issue](https://github.com/packi
 
 | | GitHub | GitLab | Pagure | Forgejo |
 | -------- | :----: | :----: | :----: | :-----: |
-| `delete` | ✔ | ✔ | ✘ | ✘ |
+| `delete` | ✔ | ✔ | ✘ | ✔ |
 
 ## Service
 


### PR DESCRIPTION
## Summary
`COMPATIBILITY.md` still marked several Forgejo methods as unimplemented (including reaction `delete`) even though the Forgejo service implements them.

## Changes
Verified against `ogr/services/forgejo/` and updated the table for:
- IssueComment / PRComment: `body` get/set, `add_reaction`, `get_reactions`
- Issue: `add_label`
- Reaction: `delete`
- Project: `get_release`, `get_latest_release`

Closes #1002