### PR TITLE
Fix `get_project_from_url` repo parsing in `ForgejoService`

### DIFF
--- a/ogr/services/forgejo/service.py
+++ b/ogr/services/forgejo/service.py
@@ -3,13 +3,13 @@
 
 from functools import cached_property
 from typing import Optional
-from urllib.parse import urlparse
 
 from pyforgejo import PyforgejoApi
 
 from ogr.abstract import GitUser
 from ogr.exceptions import OgrException
 from ogr.factory import use_for_service
+from ogr.parsing import parse_git_repo
 from ogr.services.base import BaseGitService
 from ogr.services.forgejo.project import ForgejoProject
 from ogr.services.forgejo.user import ForgejoUser
@@ -93,16 +93,11 @@ class ForgejoService(BaseGitService):
         )
 
     def get_project_from_url(self, url: str) -> "ForgejoProject":
-        parsed_url = urlparse(url)
-        path_parts = parsed_url.path.strip("/").split("/")
+        repo_url = parse_git_repo(potential_url=url)
+        if not repo_url:
+            raise OgrException(f"Invalid Forgejo URL: '{url}'")
 
-        if len(path_parts) < 2:
-            raise OgrException(f"Invalid Forgejo URL: {url}")
-
-        namespace = path_parts[0]
-        repo = path_parts[1]
-
-        return self.get_project(repo=repo, namespace=namespace)
+        return self.get_project(repo=repo_url.repo, namespace=repo_url.namespace)
 
     def get_rate_limit_remaining(
         self,

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -6,9 +6,10 @@ import pytest
 from flexmock import Mock, flexmock
 from urllib3.util import Retry
 
-from ogr import GithubService, GitlabService, PagureService
+from ogr import ForgejoService, GithubService, GitlabService, PagureService
 from ogr.exceptions import OgrException
 from ogr.factory import get_instances_from_dict, get_project, get_service_class
+from ogr.services.forgejo import ForgejoProject
 from ogr.services.github import GithubProject
 from ogr.services.gitlab import GitlabProject
 from ogr.services.pagure import PagureProject
@@ -222,6 +223,33 @@ def test_get_service_class_not_found(url, mapping):
                 repo="testing-ogr-repo",
                 namespace="lbarcziova",
                 service=GitlabService(instance_url="https://gitlab.gnome.org"),
+            ),
+        ),
+        (
+            "https://src.stg.fedoraproject.org/rpms/python-dockerpty.git",
+            None,
+            [ForgejoService(instance_url="https://src.stg.fedoraproject.org")],
+            True,
+            ForgejoProject(
+                repo="python-dockerpty",
+                namespace="rpms",
+                service=ForgejoService(
+                    instance_url="https://src.stg.fedoraproject.org",
+                ),
+            ),
+        ),
+        (
+            "https://src.fedoraproject.org/rpms/python-dockerpty.git",
+            None,
+            [
+                ForgejoService(instance_url="https://src.stg.fedoraproject.org"),
+                ForgejoService(instance_url="https://src.fedoraproject.org"),
+            ],
+            False,
+            ForgejoProject(
+                repo="python-dockerpty",
+                namespace="rpms",
+                service=ForgejoService(instance_url="https://src.fedoraproject.org"),
             ),
         ),
         (


### PR DESCRIPTION
The duplication of two existing test cases and editting them to test code in relation to `ForgejoService` revealed that the parsing of  repo from a given url was incomplete. The `get_project_from_url` method would extract `python-dockerpty.git` instead of the expected string `python-dockerpty`. That is because the stripping of the `.git` extension was omitted in the previous implementation. It is now fixed.

This bug was discovered in: [#996](https://github.com/packit/ogr/pull/996).

I've separated the fix to this separate PR as it's not directly related to [#996](https://github.com/packit/ogr/pull/996).

RELEASE NOTES BEGIN

The `ForgejoService.get_project_from_url()` method has been updated to ensure repository names are parsed accurately. It now correctly removes the `.git` extension from the repository name, addressing an issue where the extension was previously retained.

RELEASE NOTES END
