### PR TITLE
Update dist-git domain names mapping to support Forgejo dist-git

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,10 @@ Here are some links to the documentation that could be helpful when contributing
   - for details also see [official GitLab API docs](https://docs.gitlab.com/ee/api/)
 - Pagure (through `requests`) - API is dependent on deployed version of Pagure service;
   `ogr` is majorly used on (links lead directly to API docs)
-  - [src.fedoraproject.org](https://src.fedoraproject.org/api/0/)
   - [pagure.io](https://pagure.io/api/0/)
   - [git.stg.centos.org](https://git.stg.centos.org/api/0/)
+- Forgejo
+  - [src.fedoraproject.org](https://src.fedoraproject.org/api/v1/)
 
 ## Making raw HTTP requests
 

--- a/ogr/factory.py
+++ b/ogr/factory.py
@@ -29,7 +29,7 @@ def use_for_service(service: str, _func=None):
         pass
 
     @use_for_service("pagure.io")
-    @use_for_service("src.fedoraproject.org")
+    @use_for_service("git.centos.org")
     class PagureService(BaseGitService):
         pass
     ```
@@ -178,13 +178,13 @@ def get_instances_from_dict(instances: dict) -> set[GitService]:
     ```py
     get_instances_from_dict({
         "github.com": {"token": "abcd"},
-        "pagure": {
+        "forgejo": {
             "token": "abcd",
             "instance_url": "https://src.fedoraproject.org",
         },
     }) == {
         GithubService(token="abcd"),
-        PagureService(token="abcd", instance_url="https://src.fedoraproject.org")
+        ForgejoService(token="abcd", instance_url="https://src.fedoraproject.org")
     }
     ```
 

--- a/ogr/services/forgejo/service.py
+++ b/ogr/services/forgejo/service.py
@@ -17,6 +17,10 @@ from ogr.services.forgejo.user import ForgejoUser
 
 @use_for_service("forgejo")
 @use_for_service("codeberg.org")
+@use_for_service("src.fedoraproject.org")
+@use_for_service("src.stg.fedoraproject.org")
+@use_for_service("pkgs.fedoraproject.org")
+@use_for_service("pkgs.stg.fedoraproject.org")
 class ForgejoService(BaseGitService):
     version = "/api/v1"
 

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -382,8 +382,6 @@ class PagureProject(BaseGitProject):
             "git.centos.org",
             "git.stg.centos.org",
             "pagure.io",
-            "src.fedoraproject.org",
-            "src.stg.fedoraproject.org",
         ]:
             # private repositories are not allowed on generally used pagure instances
             return False

--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -26,10 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 @use_for_service("pagure")
-@use_for_service("src.fedoraproject.org")
-@use_for_service("src.stg.fedoraproject.org")
-@use_for_service("pkgs.fedoraproject.org")
-@use_for_service("pkgs.stg.fedoraproject.org")
 @use_for_service("git.centos.org")
 @use_for_service("git.stg.centos.org")
 class PagureService(BaseGitService):

--- a/ogr/services/pagure/service.py
+++ b/ogr/services/pagure/service.py
@@ -32,7 +32,7 @@ class PagureService(BaseGitService):
     def __init__(
         self,
         token: Optional[str] = None,
-        instance_url: str = "https://src.fedoraproject.org",
+        instance_url: str = "https://pagure.io",
         read_only: bool = False,
         insecure: bool = False,
         max_retries: Union[int, urllib3.util.Retry] = 3,

--- a/tests/integration/factory/test_factory.py
+++ b/tests/integration/factory/test_factory.py
@@ -48,7 +48,10 @@ class FactoryTests(unittest.TestCase):
     @property
     def pagure_service(self):
         if not self._pagure_service:
-            self._pagure_service = PagureService(token=self.pagure_token)
+            self._pagure_service = PagureService(
+                token=self.pagure_token,
+                instance_url="https://src.fedoraproject.org",
+            )
         return self._pagure_service
 
     @property

--- a/tests/integration/pagure/test_data/test_project_token/PagureProjectTokenCommands.test_is_private.yaml
+++ b/tests/integration/pagure/test_data/test_project_token/PagureProjectTokenCommands.test_is_private.yaml
@@ -5,7 +5,7 @@ _requre:
 requests.sessions:
   send:
     POST:
-      https://src.fedoraproject.org/api/0/-/whoami:
+      https://pagure.io/api/0/-/whoami:
       - metadata:
           latency: 0.7874109745025635
           module_call_list:

--- a/tests/integration/pagure/test_project_token.py
+++ b/tests/integration/pagure/test_project_token.py
@@ -195,7 +195,7 @@ class PagureProjectTokenCommands(PagureTests):
         )
 
     def test_is_private(self):
-        self.service.instance_url = "https://src.fedoraproject.org"
+        self.service.instance_url = "https://pagure.io"
         assert not self.ogr_project.is_private()
 
     def test_token_is_none_then_set(self):

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -36,7 +36,7 @@ from ogr.services.pagure import PagureProject
             {"github.com": PagureService},
             PagureService,
         ),
-        ("https://src.fedoraproject.org/rpms/python-ogr", None, PagureService),
+        ("https://src.fedoraproject.org/rpms/python-ogr", None, ForgejoService),
         ("https://pagure.io/ogr", None, PagureService),
         ("https://pagure.something.com/ogr", None, PagureService),
         ("https://gitlab.com/someone/project", None, GitlabService),
@@ -56,18 +56,18 @@ from ogr.services.pagure import PagureProject
         (
             "https://src.fedoraproject.org/rpms/golang-gitlab-flimzy-testy",
             None,
-            PagureService,
+            ForgejoService,
         ),
         (
             "https://src.stg.fedoraproject.org/rpms/golang-gitlab-flimzy-testy",
             None,
-            PagureService,
+            ForgejoService,
         ),
-        ("https://src.fedoraproject.org/rpms/python-gitlab", None, PagureService),
+        ("https://src.fedoraproject.org/rpms/python-gitlab", None, ForgejoService),
         (
             "https://src.fedoraproject.org/rpms/golang-gitlab-yawning-utls",
             None,
-            PagureService,
+            ForgejoService,
         ),
     ],
 )
@@ -166,10 +166,10 @@ def test_get_service_class_not_found(url, mapping):
             None,
             None,
             True,
-            PagureProject(
+            ForgejoProject(
                 namespace="rpms",
                 repo="python-ogr",
-                service=PagureService(instance_url="https://src.fedoraproject.org"),
+                service=ForgejoService(instance_url="https://src.fedoraproject.org"),
             ),
         ),
         (
@@ -378,6 +378,7 @@ def test_get_project_not_found(url, mapping, instances, exc_str):
         ({"github.com": {"token": "abcd"}}, {GithubService(token="abcd")}),
         ({"gitlab": {"token": "abcd"}}, {GitlabService(token="abcd")}),
         ({"pagure": {"token": "abcd"}}, {PagureService(token="abcd")}),
+        ({"forgejo": {"token": "abcd"}}, {ForgejoService(token="abcd")}),
         (
             {
                 "pagure": {
@@ -386,6 +387,20 @@ def test_get_project_not_found(url, mapping, instances, exc_str):
                 },
             },
             {PagureService(token="abcd", instance_url="https://src.fedoraproject.org")},
+        ),
+        (
+            {
+                "forgejo": {
+                    "token": "abcd",
+                    "instance_url": "https://src.fedoraproject.org",
+                },
+            },
+            {
+                ForgejoService(
+                    token="abcd",
+                    instance_url="https://src.fedoraproject.org",
+                ),
+            },
         ),
         (
             {"github.com": {"token": "abcd"}, "gitlab": {"token": "abcd"}},

--- a/tests/unit/test_pagure.py
+++ b/tests/unit/test_pagure.py
@@ -8,5 +8,8 @@ from ogr import PagureService
 
 class TestPagureService(TestCase):
     def test_hostname(self):
-        assert PagureService().hostname == "src.fedoraproject.org"
-        assert PagureService(instance_url="https://pagure.io").hostname == "pagure.io"
+        assert PagureService().hostname == "pagure.io"
+        assert (
+            PagureService(instance_url="https://git.centos.org").hostname
+            == "git.centos.org"
+        )


### PR DESCRIPTION
Fixes https://github.com/packit/ogr/issues/997

Merge after the migration of dist-git.


RELEASE NOTES BEGIN

`ogr` now maps the dist-git domain names to the Forgejo classes instead of Pagure. Accordingly, the default value of `PagureService.instance_url` has changed from the dist-git domain to `pagure.io`, and `PagureProject.is_private()` no longer considers the dist-git domains.

RELEASE NOTES END
