### PR TITLE
Add support for allowing edits from maintainers on PRs/MRs

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -34,6 +34,7 @@ In case you find any error, please [create a new issue](https://github.com/packi
 | `add_label` | ✔ | ✔ | ✘ | ✔ |
 | `get_all_commits` | ✔ | ✔ | ✘ | ✔ |
 | `closed_by` | ✘ | ✘ | ✔ | ✔ |
+| `allow_maintainer_edit` | ✔ | ✔ | ✘ | ✔ |
 
 ## Release
 

--- a/ogr/abstract/git_project.py
+++ b/ogr/abstract/git_project.py
@@ -465,6 +465,7 @@ class GitProject(OgrAbstractClass):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "_abstract.PullRequest":
         """
         Create new pull request.
@@ -475,6 +476,9 @@ class GitProject(OgrAbstractClass):
             target_branch: Name of the branch where the changes are merged.
             source_branch: Name of the branch from which the changes are pulled.
             fork_username: The username of forked repository.
+
+                Defaults to `None`.
+            allow_maintainer_edit: Defines whether to allow maintainer edits.
 
                 Defaults to `None`.
 

--- a/ogr/abstract/pull_request.py
+++ b/ogr/abstract/pull_request.py
@@ -38,6 +38,11 @@ class PullRequest(OgrAbstractClass):
         raise NotImplementedError()
 
     @property
+    def allow_maintainer_edit(self) -> bool:
+        """Whether to allow maintainer edits."""
+        raise NotImplementedError()
+
+    @property
     def status(self) -> PRStatus:
         """Status of the pull request."""
         raise NotImplementedError()
@@ -163,6 +168,7 @@ class PullRequest(OgrAbstractClass):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         """
         Create new pull request.
@@ -175,6 +181,9 @@ class PullRequest(OgrAbstractClass):
                 merged.
             source_branch: Branch from which the changes are being pulled.
             fork_username: The username/namespace of the forked repository.
+            allow_maintainer_edit: Defines whether to allow maintainer edits.
+
+                Defaults to `None`, which means no explicit setting.
 
         Returns:
             Object that represents newly created pull request.
@@ -218,6 +227,7 @@ class PullRequest(OgrAbstractClass):
         self,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         """
         Update pull request information.
@@ -227,6 +237,9 @@ class PullRequest(OgrAbstractClass):
 
                 Defaults to `None`, which means no updating.
             description: The new description of the pull request.
+
+                Defaults to `None`, which means no updating.
+            allow_maintainer_edit: Defines whether to allow maintainer edits.
 
                 Defaults to `None`, which means no updating.
 

--- a/ogr/services/forgejo/project.py
+++ b/ogr/services/forgejo/project.py
@@ -422,6 +422,7 @@ class ForgejoProject(BaseGitProject):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         pass
 

--- a/ogr/services/forgejo/pull_request.py
+++ b/ogr/services/forgejo/pull_request.py
@@ -4,7 +4,7 @@ import datetime
 import logging
 from collections.abc import Iterable
 from functools import cached_property, partial
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import httpx
 from pyforgejo import NotFoundError
@@ -18,7 +18,7 @@ from ogr.abstract import (
     PRStatus,
     PullRequest,
 )
-from ogr.exceptions import ForgejoAPIException, OgrNetworkError
+from ogr.exceptions import ForgejoAPIException, OgrNetworkError, OperationNotSupported
 from ogr.services import forgejo
 from ogr.services.base import BasePullRequest
 from ogr.services.forgejo.comments import ForgejoPRComment
@@ -60,6 +60,10 @@ class ForgejoPullRequest(BasePullRequest):
     @property
     def id(self) -> int:
         return self._raw_pr.number
+
+    @property
+    def allow_maintainer_edit(self) -> bool:
+        return self._raw_pr.allow_maintainer_edit
 
     @property
     def status(self) -> PRStatus:
@@ -161,8 +165,17 @@ class ForgejoPullRequest(BasePullRequest):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         target_project = project
+
+        if allow_maintainer_edit is not None:
+            raise OperationNotSupported(
+                "Forgejo doesn't support setting allow_maintainer_edit"
+                " directly as part of the request for creating a PR."
+                " Create the PR first and then call update_info() to"
+                " set it.",
+            )
 
         if project.is_fork and fork_username is None:
             # handles fork -> upstream (called on fork)
@@ -233,12 +246,16 @@ class ForgejoPullRequest(BasePullRequest):
         self,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         try:
-            data = {"title": title if title else self.title}
+            data: dict[str, Any] = {"title": title if title else self.title}
 
             if description is not None:
                 data["body"] = description
+
+            if allow_maintainer_edit is not None:
+                data["allow_maintainer_edit"] = allow_maintainer_edit
 
             updated_pr = self._target_project.api.repo_edit_pull_request(
                 owner=self.target_project.namespace,

--- a/ogr/services/github/project.py
+++ b/ogr/services/github/project.py
@@ -334,6 +334,7 @@ class GithubProject(BaseGitProject):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> PullRequest:
         pass
 

--- a/ogr/services/github/pull_request.py
+++ b/ogr/services/github/pull_request.py
@@ -4,7 +4,7 @@
 import datetime
 import logging
 from collections.abc import Iterable
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import github
 import requests
@@ -221,7 +221,13 @@ class GithubPullRequest(BasePullRequest):
         description: Optional[str] = None,
     ) -> "PullRequest":
         try:
-            self._raw_pr.edit(title=title, body=description)
+            kwargs: dict[str, Any] = {}
+            if title is not None:
+                kwargs["title"] = title
+            if description is not None:
+                kwargs["body"] = description
+
+            self._raw_pr.edit(**kwargs)
             logger.info(f"PR updated: {self._raw_pr.url}")
             return self
         except Exception as ex:

--- a/ogr/services/github/pull_request.py
+++ b/ogr/services/github/pull_request.py
@@ -43,6 +43,10 @@ class GithubPullRequest(BasePullRequest):
         return self._raw_pr.number
 
     @property
+    def allow_maintainer_edit(self) -> bool:
+        return self._raw_pr.maintainer_can_modify
+
+    @property
     def status(self) -> PRStatus:
         return (
             PRStatus.merged
@@ -144,6 +148,7 @@ class GithubPullRequest(BasePullRequest):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         """
         The default behavior is the pull request is made to the immediate parent repository
@@ -167,11 +172,16 @@ class GithubPullRequest(BasePullRequest):
                     project.parent.github_repo,
                 )
 
+        kwargs: dict[str, Any] = {}
+        if allow_maintainer_edit is not None:
+            kwargs["maintainer_can_modify"] = allow_maintainer_edit
+
         created_pr = github_repo.create_pull(
             title=title,
             body=body,
             base=target_branch,
             head=source_branch,
+            **kwargs,
         )
         logger.info(f"PR {created_pr.id} created: {target_branch}<-{source_branch}")
         return GithubPullRequest(created_pr, target_project)
@@ -219,6 +229,7 @@ class GithubPullRequest(BasePullRequest):
         self,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         try:
             kwargs: dict[str, Any] = {}
@@ -226,6 +237,8 @@ class GithubPullRequest(BasePullRequest):
                 kwargs["title"] = title
             if description is not None:
                 kwargs["body"] = description
+            if allow_maintainer_edit is not None:
+                kwargs["maintainer_can_modify"] = allow_maintainer_edit
 
             self._raw_pr.edit(**kwargs)
             logger.info(f"PR updated: {self._raw_pr.url}")

--- a/ogr/services/gitlab/project.py
+++ b/ogr/services/gitlab/project.py
@@ -276,6 +276,7 @@ class GitlabProject(BaseGitProject):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         pass
 

--- a/ogr/services/gitlab/pull_request.py
+++ b/ogr/services/gitlab/pull_request.py
@@ -3,7 +3,7 @@
 
 import datetime
 from collections.abc import Iterable
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
 import gitlab
 import requests
@@ -42,6 +42,10 @@ class GitlabPullRequest(BasePullRequest):
     @property
     def id(self) -> int:
         return self._raw_pr.iid
+
+    @property
+    def allow_maintainer_edit(self) -> bool:
+        return self._raw_pr.allow_collaboration
 
     @property
     def status(self) -> PRStatus:
@@ -153,6 +157,7 @@ class GitlabPullRequest(BasePullRequest):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         """
         How to create PR:
@@ -163,7 +168,7 @@ class GitlabPullRequest(BasePullRequest):
         -  fork -> other_fork - call on fork, fork_username set to other_fork owner
         """
         repo = project.gitlab_repo
-        parameters = {
+        parameters: dict[str, Any] = {
             "source_branch": source_branch,
             "target_branch": target_branch,
             "title": title,
@@ -195,6 +200,9 @@ class GitlabPullRequest(BasePullRequest):
 
         if target_id is not None:
             parameters["target_project_id"] = target_id
+
+        if allow_maintainer_edit is not None:
+            parameters["allow_collaboration"] = allow_maintainer_edit
 
         mr = repo.mergerequests.create(parameters)
         return GitlabPullRequest(mr, target_project)
@@ -257,11 +265,14 @@ class GitlabPullRequest(BasePullRequest):
         self,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
         if title:
             self._raw_pr.title = title
         if description:
             self._raw_pr.description = description
+        if allow_maintainer_edit is not None:
+            self._raw_pr.allow_collaboration = allow_maintainer_edit
 
         self._raw_pr.save()
         return self

--- a/ogr/services/pagure/project.py
+++ b/ogr/services/pagure/project.py
@@ -317,6 +317,7 @@ class PagureProject(BaseGitProject):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> PullRequest:
         pass
 

--- a/ogr/services/pagure/pull_request.py
+++ b/ogr/services/pagure/pull_request.py
@@ -16,7 +16,7 @@ from ogr.abstract import (
     PRStatus,
     PullRequest,
 )
-from ogr.exceptions import PagureAPIException
+from ogr.exceptions import OperationNotSupported, PagureAPIException
 from ogr.services import pagure as ogr_pagure
 from ogr.services.base import BasePullRequest
 from ogr.services.pagure.comments import PagurePRComment
@@ -165,7 +165,14 @@ class PagurePullRequest(BasePullRequest):
         target_branch: str,
         source_branch: str,
         fork_username: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
+
+        if allow_maintainer_edit is not None:
+            raise OperationNotSupported(
+                "Pagure doesn't support allowing maintainer edits on PRs.",
+            )
+
         data = {
             "title": title,
             "branch_to": target_branch,
@@ -279,7 +286,13 @@ class PagurePullRequest(BasePullRequest):
         self,
         title: Optional[str] = None,
         description: Optional[str] = None,
+        allow_maintainer_edit: Optional[bool] = None,
     ) -> "PullRequest":
+        if allow_maintainer_edit is not None:
+            raise OperationNotSupported(
+                "Pagure doesn't support allowing maintainer edits on PRs.",
+            )
+
         try:
             data = {"title": title if title else self.title}
 

--- a/tests/integration/github/test_data/test_pull_requests/PullRequests.test_pr_create_upstream_fork_with_maintainer_edits.yaml
+++ b/tests/integration/github/test_data/test_pull_requests/PullRequests.test_pr_create_upstream_fork_with_maintainer_edits.yaml
@@ -1,0 +1,1854 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/betulependule/hello-world:
+      - metadata:
+          latency: 0.5400164127349854
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.github.project
+          - ogr.abstract.exception
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            allow_update_branch: false
+            archive_url: https://api.github.com/repos/betulependule/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/betulependule/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/betulependule/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/betulependule/hello-world/branches{/branch}
+            clone_url: https://github.com/betulependule/hello-world.git
+            collaborators_url: https://api.github.com/repos/betulependule/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/betulependule/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/betulependule/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/betulependule/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/betulependule/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/betulependule/hello-world/contributors
+            created_at: '2026-01-15T11:28:57Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/betulependule/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/betulependule/hello-world/downloads
+            events_url: https://api.github.com/repos/betulependule/hello-world/events
+            fork: true
+            forks: 0
+            forks_count: 0
+            forks_url: https://api.github.com/repos/betulependule/hello-world/forks
+            full_name: betulependule/hello-world
+            git_commits_url: https://api.github.com/repos/betulependule/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/betulependule/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/betulependule/hello-world/git/tags{/sha}
+            git_url: git://github.com/betulependule/hello-world.git
+            has_discussions: false
+            has_downloads: false
+            has_issues: false
+            has_pages: false
+            has_projects: true
+            has_pull_requests: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/betulependule/hello-world/hooks
+            html_url: https://github.com/betulependule/hello-world
+            id: 1134909479
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/betulependule/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/betulependule/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/betulependule/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/betulependule/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/betulependule/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/betulependule/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merge_commit_message: PR_TITLE
+            merge_commit_title: MERGE_MESSAGE
+            merges_url: https://api.github.com/repos/betulependule/hello-world/merges
+            milestones_url: https://api.github.com/repos/betulependule/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 25
+            node_id: R_kgDOQ6VYJw
+            notifications_url: https://api.github.com/repos/betulependule/hello-world/notifications{?since,all,participating}
+            open_issues: 1
+            open_issues_count: 1
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+              events_url: https://api.github.com/users/betulependule/events{/privacy}
+              followers_url: https://api.github.com/users/betulependule/followers
+              following_url: https://api.github.com/users/betulependule/following{/other_user}
+              gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/betulependule
+              id: 33840358
+              login: betulependule
+              node_id: MDQ6VXNlcjMzODQwMzU4
+              organizations_url: https://api.github.com/users/betulependule/orgs
+              received_events_url: https://api.github.com/users/betulependule/received_events
+              repos_url: https://api.github.com/users/betulependule/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+              type: User
+              url: https://api.github.com/users/betulependule
+              user_view_type: public
+            parent:
+              allow_forking: true
+              archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+              archived: false
+              assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+              blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+              branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+              clone_url: https://github.com/packit/hello-world.git
+              collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+              comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+              commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+              compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+              contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+              contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+              created_at: '2019-05-02T18:54:46Z'
+              default_branch: main
+              deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+              description: The most progresive command-line tool in the world.
+              disabled: false
+              downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+              events_url: https://api.github.com/repos/packit/hello-world/events
+              fork: false
+              forks: 25
+              forks_count: 25
+              forks_url: https://api.github.com/repos/packit/hello-world/forks
+              full_name: packit/hello-world
+              git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+              git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+              git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+              git_url: git://github.com/packit/hello-world.git
+              has_discussions: false
+              has_downloads: false
+              has_issues: true
+              has_pages: false
+              has_projects: true
+              has_pull_requests: true
+              has_wiki: true
+              homepage: null
+              hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+              html_url: https://github.com/packit/hello-world
+              id: 184635124
+              is_template: false
+              issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+              issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+              issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+              keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+              labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+              language: Python
+              languages_url: https://api.github.com/repos/packit/hello-world/languages
+              license:
+                key: mit
+                name: MIT License
+                node_id: MDc6TGljZW5zZTEz
+                spdx_id: MIT
+                url: https://api.github.com/licenses/mit
+              merges_url: https://api.github.com/repos/packit/hello-world/merges
+              milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+              mirror_url: null
+              name: hello-world
+              node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+              notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+              open_issues: 131
+              open_issues_count: 131
+              owner:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+                user_view_type: public
+              private: false
+              pull_request_creation_policy: all
+              pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+              pushed_at: '2026-08-26T04:13:08Z'
+              releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+              size: 325
+              ssh_url: git@github.com:packit/hello-world.git
+              stargazers_count: 4
+              stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+              statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+              subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+              subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+              svn_url: https://github.com/packit/hello-world
+              tags_url: https://api.github.com/repos/packit/hello-world/tags
+              teams_url: https://api.github.com/repos/packit/hello-world/teams
+              topics: []
+              trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+              updated_at: '2023-01-31T17:16:23Z'
+              url: https://api.github.com/repos/packit/hello-world
+              visibility: public
+              watchers: 4
+              watchers_count: 4
+              web_commit_signoff_required: false
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pull_request_creation_policy: all
+            pulls_url: https://api.github.com/repos/betulependule/hello-world/pulls{/number}
+            pushed_at: '2026-08-25T11:46:30Z'
+            releases_url: https://api.github.com/repos/betulependule/hello-world/releases{/id}
+            security_and_analysis:
+              dependabot_security_updates:
+                status: disabled
+              secret_scanning:
+                status: enabled
+              secret_scanning_non_provider_patterns:
+                status: disabled
+              secret_scanning_push_protection:
+                status: enabled
+              secret_scanning_validity_checks:
+                status: disabled
+            size: 35
+            source:
+              allow_forking: true
+              archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+              archived: false
+              assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+              blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+              branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+              clone_url: https://github.com/packit/hello-world.git
+              collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+              comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+              commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+              compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+              contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+              contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+              created_at: '2019-05-02T18:54:46Z'
+              default_branch: main
+              deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+              description: The most progresive command-line tool in the world.
+              disabled: false
+              downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+              events_url: https://api.github.com/repos/packit/hello-world/events
+              fork: false
+              forks: 25
+              forks_count: 25
+              forks_url: https://api.github.com/repos/packit/hello-world/forks
+              full_name: packit/hello-world
+              git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+              git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+              git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+              git_url: git://github.com/packit/hello-world.git
+              has_discussions: false
+              has_downloads: false
+              has_issues: true
+              has_pages: false
+              has_projects: true
+              has_pull_requests: true
+              has_wiki: true
+              homepage: null
+              hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+              html_url: https://github.com/packit/hello-world
+              id: 184635124
+              is_template: false
+              issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+              issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+              issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+              keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+              labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+              language: Python
+              languages_url: https://api.github.com/repos/packit/hello-world/languages
+              license:
+                key: mit
+                name: MIT License
+                node_id: MDc6TGljZW5zZTEz
+                spdx_id: MIT
+                url: https://api.github.com/licenses/mit
+              merges_url: https://api.github.com/repos/packit/hello-world/merges
+              milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+              mirror_url: null
+              name: hello-world
+              node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+              notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+              open_issues: 131
+              open_issues_count: 131
+              owner:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+                user_view_type: public
+              private: false
+              pull_request_creation_policy: all
+              pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+              pushed_at: '2026-08-26T04:13:08Z'
+              releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+              size: 325
+              ssh_url: git@github.com:packit/hello-world.git
+              stargazers_count: 4
+              stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+              statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+              subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+              subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+              svn_url: https://github.com/packit/hello-world
+              tags_url: https://api.github.com/repos/packit/hello-world/tags
+              teams_url: https://api.github.com/repos/packit/hello-world/teams
+              topics: []
+              trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+              updated_at: '2023-01-31T17:16:23Z'
+              url: https://api.github.com/repos/packit/hello-world
+              visibility: public
+              watchers: 4
+              watchers_count: 4
+              web_commit_signoff_required: false
+            squash_merge_commit_message: COMMIT_MESSAGES
+            squash_merge_commit_title: COMMIT_OR_PR_TITLE
+            ssh_url: git@github.com:betulependule/hello-world.git
+            stargazers_count: 0
+            stargazers_url: https://api.github.com/repos/betulependule/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/betulependule/hello-world/statuses/{sha}
+            subscribers_count: 0
+            subscribers_url: https://api.github.com/repos/betulependule/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/betulependule/hello-world/subscription
+            svn_url: https://github.com/betulependule/hello-world
+            tags_url: https://api.github.com/repos/betulependule/hello-world/tags
+            teams_url: https://api.github.com/repos/betulependule/hello-world/teams
+            temp_clone_token: ''
+            topics: []
+            trees_url: https://api.github.com/repos/betulependule/hello-world/git/trees{/sha}
+            updated_at: '2026-01-20T09:16:40Z'
+            url: https://api.github.com/repos/betulependule/hello-world
+            use_squash_pr_title_as_default: false
+            visibility: public
+            watchers: 0
+            watchers_count: 0
+            web_commit_signoff_required: false
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset, Warning
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Last-Modified: Tue, 20 Jan 2026 09:16:40 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '2'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2026-10-07 06:48:46 UTC
+            x-github-api-version-selected: '2022-11-28'
+            x-github-edge-region: fra
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/pulls/4166/merge:
+      - metadata:
+          latency: 0.36493825912475586
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.services.github.pull_request
+          - github.PullRequest
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            documentation_url: https://docs.github.com/rest/pulls/pulls#check-if-a-pull-request-has-been-merged
+            message: Not Found
+            status: '404'
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset, Warning
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept-Encoding, Accept, X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '2'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2026-10-07 06:48:46 UTC
+            x-github-api-version-selected: '2022-11-28'
+            x-github-edge-region: fra
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: Not Found
+          status_code: 404
+      - metadata:
+          latency: 0.3035242557525635
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.services.github.pull_request
+          - github.PullRequest
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            documentation_url: https://docs.github.com/rest/pulls/pulls#check-if-a-pull-request-has-been-merged
+            message: Not Found
+            status: '404'
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset, Warning
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept-Encoding, Accept, X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '5'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2026-10-07 06:48:46 UTC
+            x-github-api-version-selected: '2022-11-28'
+            x-github-edge-region: fra
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: Not Found
+          status_code: 404
+      https://api.github.com:443/user:
+      - metadata:
+          latency: 0.39365434646606445
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.github.project
+          - ogr.abstract.exception
+          - ogr.services.github.project
+          - github.AuthenticatedUser
+          - github.GithubObject
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+            bio: null
+            blog: ''
+            company: null
+            created_at: '2017-11-20T16:44:49Z'
+            email: null
+            events_url: https://api.github.com/users/betulependule/events{/privacy}
+            followers: 1
+            followers_url: https://api.github.com/users/betulependule/followers
+            following: 0
+            following_url: https://api.github.com/users/betulependule/following{/other_user}
+            gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+            gravatar_id: ''
+            hireable: null
+            html_url: https://github.com/betulependule
+            id: 33840358
+            location: null
+            login: betulependule
+            name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+            node_id: MDQ6VXNlcjMzODQwMzU4
+            notification_email: null
+            organizations_url: https://api.github.com/users/betulependule/orgs
+            public_gists: 0
+            public_repos: 18
+            received_events_url: https://api.github.com/users/betulependule/received_events
+            repos_url: https://api.github.com/users/betulependule/repos
+            site_admin: false
+            starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+            subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+            twitter_username: null
+            type: User
+            updated_at: '2026-08-25T11:45:02Z'
+            url: https://api.github.com/users/betulependule
+            user_view_type: public
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset, Warning
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Last-Modified: Tue, 25 Aug 2026 11:45:02 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '1'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2026-10-07 06:48:46 UTC
+            x-github-api-version-selected: '2022-11-28'
+            x-github-edge-region: fra
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+    PATCH:
+      https://api.github.com:443/repos/packit/hello-world/pulls/4166:
+      - metadata:
+          latency: 1.0249085426330566
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.github.pull_request
+          - github.PullRequest
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              comments:
+                href: https://api.github.com/repos/packit/hello-world/issues/4166/comments
+              commits:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166/commits
+              html:
+                href: https://github.com/packit/hello-world/pull/4166
+              issue:
+                href: https://api.github.com/repos/packit/hello-world/issues/4166
+              review_comment:
+                href: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+              review_comments:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166/comments
+              self:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166
+              statuses:
+                href: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            active_lock_reason: null
+            additions: 0
+            assignee: null
+            assignees: []
+            author_association: MEMBER
+            auto_merge: null
+            base:
+              label: packit:test_target
+              ref: test_target
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+                clone_url: https://github.com/packit/hello-world.git
+                collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+                created_at: '2019-05-02T18:54:46Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+                events_url: https://api.github.com/repos/packit/hello-world/events
+                fork: false
+                forks: 25
+                forks_count: 25
+                forks_url: https://api.github.com/repos/packit/hello-world/forks
+                full_name: packit/hello-world
+                git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+                git_url: git://github.com/packit/hello-world.git
+                has_discussions: false
+                has_downloads: false
+                has_issues: true
+                has_pages: false
+                has_projects: true
+                has_pull_requests: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+                html_url: https://github.com/packit/hello-world
+                id: 184635124
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/packit/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/packit/hello-world/merges
+                milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+                open_issues: 132
+                open_issues_count: 132
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                  events_url: https://api.github.com/users/packit/events{/privacy}
+                  followers_url: https://api.github.com/users/packit/followers
+                  following_url: https://api.github.com/users/packit/following{/other_user}
+                  gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/packit
+                  id: 46870917
+                  login: packit
+                  node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                  organizations_url: https://api.github.com/users/packit/orgs
+                  received_events_url: https://api.github.com/users/packit/received_events
+                  repos_url: https://api.github.com/users/packit/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/packit/subscriptions
+                  type: Organization
+                  url: https://api.github.com/users/packit
+                  user_view_type: public
+                private: false
+                pull_request_creation_policy: all
+                pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+                pushed_at: '2026-08-26T04:13:08Z'
+                releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+                size: 325
+                ssh_url: git@github.com:packit/hello-world.git
+                stargazers_count: 4
+                stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+                svn_url: https://github.com/packit/hello-world
+                tags_url: https://api.github.com/repos/packit/hello-world/tags
+                teams_url: https://api.github.com/repos/packit/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+                updated_at: '2023-01-31T17:16:23Z'
+                url: https://api.github.com/repos/packit/hello-world
+                visibility: public
+                watchers: 4
+                watchers_count: 4
+                web_commit_signoff_required: false
+              sha: 28d30dd1178b9983a0b717c809895500b2a3583b
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+                user_view_type: public
+            body: pull request body
+            changed_files: 1
+            closed_at: null
+            comments: 0
+            comments_url: https://api.github.com/repos/packit/hello-world/issues/4166/comments
+            commits: 3
+            commits_url: https://api.github.com/repos/packit/hello-world/pulls/4166/commits
+            created_at: '2026-08-26T12:56:02Z'
+            deletions: 26
+            diff_url: https://github.com/packit/hello-world/pull/4166.diff
+            draft: false
+            head:
+              label: betulependule:test_source
+              ref: test_source
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/betulependule/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/betulependule/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/betulependule/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/betulependule/hello-world/branches{/branch}
+                clone_url: https://github.com/betulependule/hello-world.git
+                collaborators_url: https://api.github.com/repos/betulependule/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/betulependule/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/betulependule/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/betulependule/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/betulependule/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/betulependule/hello-world/contributors
+                created_at: '2026-01-15T11:28:57Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/betulependule/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/betulependule/hello-world/downloads
+                events_url: https://api.github.com/repos/betulependule/hello-world/events
+                fork: true
+                forks: 0
+                forks_count: 0
+                forks_url: https://api.github.com/repos/betulependule/hello-world/forks
+                full_name: betulependule/hello-world
+                git_commits_url: https://api.github.com/repos/betulependule/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/betulependule/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/betulependule/hello-world/git/tags{/sha}
+                git_url: git://github.com/betulependule/hello-world.git
+                has_discussions: false
+                has_downloads: false
+                has_issues: false
+                has_pages: false
+                has_projects: true
+                has_pull_requests: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/betulependule/hello-world/hooks
+                html_url: https://github.com/betulependule/hello-world
+                id: 1134909479
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/betulependule/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/betulependule/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/betulependule/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/betulependule/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/betulependule/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/betulependule/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/betulependule/hello-world/merges
+                milestones_url: https://api.github.com/repos/betulependule/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: R_kgDOQ6VYJw
+                notifications_url: https://api.github.com/repos/betulependule/hello-world/notifications{?since,all,participating}
+                open_issues: 1
+                open_issues_count: 1
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+                  events_url: https://api.github.com/users/betulependule/events{/privacy}
+                  followers_url: https://api.github.com/users/betulependule/followers
+                  following_url: https://api.github.com/users/betulependule/following{/other_user}
+                  gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/betulependule
+                  id: 33840358
+                  login: betulependule
+                  node_id: MDQ6VXNlcjMzODQwMzU4
+                  organizations_url: https://api.github.com/users/betulependule/orgs
+                  received_events_url: https://api.github.com/users/betulependule/received_events
+                  repos_url: https://api.github.com/users/betulependule/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+                  type: User
+                  url: https://api.github.com/users/betulependule
+                  user_view_type: public
+                private: false
+                pull_request_creation_policy: all
+                pulls_url: https://api.github.com/repos/betulependule/hello-world/pulls{/number}
+                pushed_at: '2026-08-25T11:46:30Z'
+                releases_url: https://api.github.com/repos/betulependule/hello-world/releases{/id}
+                size: 35
+                ssh_url: git@github.com:betulependule/hello-world.git
+                stargazers_count: 0
+                stargazers_url: https://api.github.com/repos/betulependule/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/betulependule/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/betulependule/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/betulependule/hello-world/subscription
+                svn_url: https://github.com/betulependule/hello-world
+                tags_url: https://api.github.com/repos/betulependule/hello-world/tags
+                teams_url: https://api.github.com/repos/betulependule/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/betulependule/hello-world/git/trees{/sha}
+                updated_at: '2026-01-20T09:16:40Z'
+                url: https://api.github.com/repos/betulependule/hello-world
+                visibility: public
+                watchers: 0
+                watchers_count: 0
+                web_commit_signoff_required: false
+              sha: 7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+                events_url: https://api.github.com/users/betulependule/events{/privacy}
+                followers_url: https://api.github.com/users/betulependule/followers
+                following_url: https://api.github.com/users/betulependule/following{/other_user}
+                gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/betulependule
+                id: 33840358
+                login: betulependule
+                node_id: MDQ6VXNlcjMzODQwMzU4
+                organizations_url: https://api.github.com/users/betulependule/orgs
+                received_events_url: https://api.github.com/users/betulependule/received_events
+                repos_url: https://api.github.com/users/betulependule/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+                type: User
+                url: https://api.github.com/users/betulependule
+                user_view_type: public
+            html_url: https://github.com/packit/hello-world/pull/4166
+            id: 4367227567
+            issue_url: https://api.github.com/repos/packit/hello-world/issues/4166
+            labels: []
+            locked: false
+            maintainer_can_modify: false
+            merge_commit_sha: 19f716f97f53f548853d4cf0128739685e2654be
+            mergeable: true
+            mergeable_state: clean
+            merged: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            node_id: PR_kwDOCwFO9M8AAAABBE6arw
+            number: 4166
+            patch_url: https://github.com/packit/hello-world/pull/4166.patch
+            rebaseable: true
+            requested_reviewers: []
+            requested_teams: []
+            review_comment_url: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+            review_comments: 0
+            review_comments_url: https://api.github.com/repos/packit/hello-world/pulls/4166/comments
+            state: open
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            title: 'test: PR with maintainer edits enabled'
+            updated_at: '2026-08-26T12:56:04Z'
+            url: https://api.github.com/repos/packit/hello-world/pulls/4166
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+              events_url: https://api.github.com/users/betulependule/events{/privacy}
+              followers_url: https://api.github.com/users/betulependule/followers
+              following_url: https://api.github.com/users/betulependule/following{/other_user}
+              gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/betulependule
+              id: 33840358
+              login: betulependule
+              node_id: MDQ6VXNlcjMzODQwMzU4
+              organizations_url: https://api.github.com/users/betulependule/orgs
+              received_events_url: https://api.github.com/users/betulependule/received_events
+              repos_url: https://api.github.com/users/betulependule/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+              type: User
+              url: https://api.github.com/users/betulependule
+              user_view_type: public
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset, Warning
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '3'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2026-10-07 06:48:46 UTC
+            x-github-api-version-selected: '2022-11-28'
+            x-github-edge-region: fra
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.955111026763916
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.github.pull_request
+          - github.PullRequest
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              comments:
+                href: https://api.github.com/repos/packit/hello-world/issues/4166/comments
+              commits:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166/commits
+              html:
+                href: https://github.com/packit/hello-world/pull/4166
+              issue:
+                href: https://api.github.com/repos/packit/hello-world/issues/4166
+              review_comment:
+                href: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+              review_comments:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166/comments
+              self:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166
+              statuses:
+                href: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            active_lock_reason: null
+            additions: 0
+            assignee: null
+            assignees: []
+            author_association: MEMBER
+            auto_merge: null
+            base:
+              label: packit:test_target
+              ref: test_target
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+                clone_url: https://github.com/packit/hello-world.git
+                collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+                created_at: '2019-05-02T18:54:46Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+                events_url: https://api.github.com/repos/packit/hello-world/events
+                fork: false
+                forks: 25
+                forks_count: 25
+                forks_url: https://api.github.com/repos/packit/hello-world/forks
+                full_name: packit/hello-world
+                git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+                git_url: git://github.com/packit/hello-world.git
+                has_discussions: false
+                has_downloads: false
+                has_issues: true
+                has_pages: false
+                has_projects: true
+                has_pull_requests: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+                html_url: https://github.com/packit/hello-world
+                id: 184635124
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/packit/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/packit/hello-world/merges
+                milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+                open_issues: 131
+                open_issues_count: 131
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                  events_url: https://api.github.com/users/packit/events{/privacy}
+                  followers_url: https://api.github.com/users/packit/followers
+                  following_url: https://api.github.com/users/packit/following{/other_user}
+                  gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/packit
+                  id: 46870917
+                  login: packit
+                  node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                  organizations_url: https://api.github.com/users/packit/orgs
+                  received_events_url: https://api.github.com/users/packit/received_events
+                  repos_url: https://api.github.com/users/packit/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/packit/subscriptions
+                  type: Organization
+                  url: https://api.github.com/users/packit
+                  user_view_type: public
+                private: false
+                pull_request_creation_policy: all
+                pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+                pushed_at: '2026-08-26T04:13:08Z'
+                releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+                size: 325
+                ssh_url: git@github.com:packit/hello-world.git
+                stargazers_count: 4
+                stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+                svn_url: https://github.com/packit/hello-world
+                tags_url: https://api.github.com/repos/packit/hello-world/tags
+                teams_url: https://api.github.com/repos/packit/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+                updated_at: '2023-01-31T17:16:23Z'
+                url: https://api.github.com/repos/packit/hello-world
+                visibility: public
+                watchers: 4
+                watchers_count: 4
+                web_commit_signoff_required: false
+              sha: 28d30dd1178b9983a0b717c809895500b2a3583b
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+                user_view_type: public
+            body: pull request body
+            changed_files: 1
+            closed_at: '2026-08-26T12:56:06Z'
+            comments: 0
+            comments_url: https://api.github.com/repos/packit/hello-world/issues/4166/comments
+            commits: 3
+            commits_url: https://api.github.com/repos/packit/hello-world/pulls/4166/commits
+            created_at: '2026-08-26T12:56:02Z'
+            deletions: 26
+            diff_url: https://github.com/packit/hello-world/pull/4166.diff
+            draft: false
+            head:
+              label: betulependule:test_source
+              ref: test_source
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/betulependule/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/betulependule/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/betulependule/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/betulependule/hello-world/branches{/branch}
+                clone_url: https://github.com/betulependule/hello-world.git
+                collaborators_url: https://api.github.com/repos/betulependule/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/betulependule/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/betulependule/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/betulependule/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/betulependule/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/betulependule/hello-world/contributors
+                created_at: '2026-01-15T11:28:57Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/betulependule/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/betulependule/hello-world/downloads
+                events_url: https://api.github.com/repos/betulependule/hello-world/events
+                fork: true
+                forks: 0
+                forks_count: 0
+                forks_url: https://api.github.com/repos/betulependule/hello-world/forks
+                full_name: betulependule/hello-world
+                git_commits_url: https://api.github.com/repos/betulependule/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/betulependule/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/betulependule/hello-world/git/tags{/sha}
+                git_url: git://github.com/betulependule/hello-world.git
+                has_discussions: false
+                has_downloads: false
+                has_issues: false
+                has_pages: false
+                has_projects: true
+                has_pull_requests: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/betulependule/hello-world/hooks
+                html_url: https://github.com/betulependule/hello-world
+                id: 1134909479
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/betulependule/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/betulependule/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/betulependule/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/betulependule/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/betulependule/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/betulependule/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/betulependule/hello-world/merges
+                milestones_url: https://api.github.com/repos/betulependule/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: R_kgDOQ6VYJw
+                notifications_url: https://api.github.com/repos/betulependule/hello-world/notifications{?since,all,participating}
+                open_issues: 1
+                open_issues_count: 1
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+                  events_url: https://api.github.com/users/betulependule/events{/privacy}
+                  followers_url: https://api.github.com/users/betulependule/followers
+                  following_url: https://api.github.com/users/betulependule/following{/other_user}
+                  gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/betulependule
+                  id: 33840358
+                  login: betulependule
+                  node_id: MDQ6VXNlcjMzODQwMzU4
+                  organizations_url: https://api.github.com/users/betulependule/orgs
+                  received_events_url: https://api.github.com/users/betulependule/received_events
+                  repos_url: https://api.github.com/users/betulependule/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+                  type: User
+                  url: https://api.github.com/users/betulependule
+                  user_view_type: public
+                private: false
+                pull_request_creation_policy: all
+                pulls_url: https://api.github.com/repos/betulependule/hello-world/pulls{/number}
+                pushed_at: '2026-08-25T11:46:30Z'
+                releases_url: https://api.github.com/repos/betulependule/hello-world/releases{/id}
+                size: 35
+                ssh_url: git@github.com:betulependule/hello-world.git
+                stargazers_count: 0
+                stargazers_url: https://api.github.com/repos/betulependule/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/betulependule/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/betulependule/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/betulependule/hello-world/subscription
+                svn_url: https://github.com/betulependule/hello-world
+                tags_url: https://api.github.com/repos/betulependule/hello-world/tags
+                teams_url: https://api.github.com/repos/betulependule/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/betulependule/hello-world/git/trees{/sha}
+                updated_at: '2026-01-20T09:16:40Z'
+                url: https://api.github.com/repos/betulependule/hello-world
+                visibility: public
+                watchers: 0
+                watchers_count: 0
+                web_commit_signoff_required: false
+              sha: 7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+                events_url: https://api.github.com/users/betulependule/events{/privacy}
+                followers_url: https://api.github.com/users/betulependule/followers
+                following_url: https://api.github.com/users/betulependule/following{/other_user}
+                gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/betulependule
+                id: 33840358
+                login: betulependule
+                node_id: MDQ6VXNlcjMzODQwMzU4
+                organizations_url: https://api.github.com/users/betulependule/orgs
+                received_events_url: https://api.github.com/users/betulependule/received_events
+                repos_url: https://api.github.com/users/betulependule/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+                type: User
+                url: https://api.github.com/users/betulependule
+                user_view_type: public
+            html_url: https://github.com/packit/hello-world/pull/4166
+            id: 4367227567
+            issue_url: https://api.github.com/repos/packit/hello-world/issues/4166
+            labels: []
+            locked: false
+            maintainer_can_modify: false
+            merge_commit_sha: 19f716f97f53f548853d4cf0128739685e2654be
+            mergeable: true
+            mergeable_state: clean
+            merged: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            node_id: PR_kwDOCwFO9M8AAAABBE6arw
+            number: 4166
+            patch_url: https://github.com/packit/hello-world/pull/4166.patch
+            rebaseable: true
+            requested_reviewers: []
+            requested_teams: []
+            review_comment_url: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+            review_comments: 0
+            review_comments_url: https://api.github.com/repos/packit/hello-world/pulls/4166/comments
+            state: closed
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            title: 'test: PR with maintainer edits enabled'
+            updated_at: '2026-08-26T12:56:06Z'
+            url: https://api.github.com/repos/packit/hello-world/pulls/4166
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+              events_url: https://api.github.com/users/betulependule/events{/privacy}
+              followers_url: https://api.github.com/users/betulependule/followers
+              following_url: https://api.github.com/users/betulependule/following{/other_user}
+              gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/betulependule
+              id: 33840358
+              login: betulependule
+              node_id: MDQ6VXNlcjMzODQwMzU4
+              organizations_url: https://api.github.com/users/betulependule/orgs
+              received_events_url: https://api.github.com/users/betulependule/received_events
+              repos_url: https://api.github.com/users/betulependule/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+              type: User
+              url: https://api.github.com/users/betulependule
+              user_view_type: public
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset, Warning
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '4'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2026-10-07 06:48:46 UTC
+            x-github-api-version-selected: '2022-11-28'
+            x-github-edge-region: fra
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://api.github.com:443/repos/packit/hello-world/pulls:
+      - metadata:
+          latency: 1.778439998626709
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.github.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.read_only
+          - ogr.utils
+          - ogr.abstract.exception
+          - ogr.services.github.pull_request
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              comments:
+                href: https://api.github.com/repos/packit/hello-world/issues/4166/comments
+              commits:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166/commits
+              html:
+                href: https://github.com/packit/hello-world/pull/4166
+              issue:
+                href: https://api.github.com/repos/packit/hello-world/issues/4166
+              review_comment:
+                href: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+              review_comments:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166/comments
+              self:
+                href: https://api.github.com/repos/packit/hello-world/pulls/4166
+              statuses:
+                href: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            active_lock_reason: null
+            additions: 0
+            assignee: null
+            assignees: []
+            author_association: MEMBER
+            auto_merge: null
+            base:
+              label: packit:test_target
+              ref: test_target
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+                clone_url: https://github.com/packit/hello-world.git
+                collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+                created_at: '2019-05-02T18:54:46Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+                events_url: https://api.github.com/repos/packit/hello-world/events
+                fork: false
+                forks: 25
+                forks_count: 25
+                forks_url: https://api.github.com/repos/packit/hello-world/forks
+                full_name: packit/hello-world
+                git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+                git_url: git://github.com/packit/hello-world.git
+                has_discussions: false
+                has_downloads: false
+                has_issues: true
+                has_pages: false
+                has_projects: true
+                has_pull_requests: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+                html_url: https://github.com/packit/hello-world
+                id: 184635124
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/packit/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/packit/hello-world/merges
+                milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+                open_issues: 132
+                open_issues_count: 132
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                  events_url: https://api.github.com/users/packit/events{/privacy}
+                  followers_url: https://api.github.com/users/packit/followers
+                  following_url: https://api.github.com/users/packit/following{/other_user}
+                  gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/packit
+                  id: 46870917
+                  login: packit
+                  node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                  organizations_url: https://api.github.com/users/packit/orgs
+                  received_events_url: https://api.github.com/users/packit/received_events
+                  repos_url: https://api.github.com/users/packit/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/packit/subscriptions
+                  type: Organization
+                  url: https://api.github.com/users/packit
+                  user_view_type: public
+                private: false
+                pull_request_creation_policy: all
+                pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+                pushed_at: '2026-08-26T04:13:08Z'
+                releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+                size: 325
+                ssh_url: git@github.com:packit/hello-world.git
+                stargazers_count: 4
+                stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+                svn_url: https://github.com/packit/hello-world
+                tags_url: https://api.github.com/repos/packit/hello-world/tags
+                teams_url: https://api.github.com/repos/packit/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+                updated_at: '2023-01-31T17:16:23Z'
+                url: https://api.github.com/repos/packit/hello-world
+                visibility: public
+                watchers: 4
+                watchers_count: 4
+                web_commit_signoff_required: false
+              sha: 28d30dd1178b9983a0b717c809895500b2a3583b
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+                user_view_type: public
+            body: pull request body
+            changed_files: 1
+            closed_at: null
+            comments: 0
+            comments_url: https://api.github.com/repos/packit/hello-world/issues/4166/comments
+            commits: 3
+            commits_url: https://api.github.com/repos/packit/hello-world/pulls/4166/commits
+            created_at: '2026-08-26T12:56:02Z'
+            deletions: 26
+            diff_url: https://github.com/packit/hello-world/pull/4166.diff
+            draft: false
+            head:
+              label: betulependule:test_source
+              ref: test_source
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/betulependule/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/betulependule/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/betulependule/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/betulependule/hello-world/branches{/branch}
+                clone_url: https://github.com/betulependule/hello-world.git
+                collaborators_url: https://api.github.com/repos/betulependule/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/betulependule/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/betulependule/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/betulependule/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/betulependule/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/betulependule/hello-world/contributors
+                created_at: '2026-01-15T11:28:57Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/betulependule/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/betulependule/hello-world/downloads
+                events_url: https://api.github.com/repos/betulependule/hello-world/events
+                fork: true
+                forks: 0
+                forks_count: 0
+                forks_url: https://api.github.com/repos/betulependule/hello-world/forks
+                full_name: betulependule/hello-world
+                git_commits_url: https://api.github.com/repos/betulependule/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/betulependule/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/betulependule/hello-world/git/tags{/sha}
+                git_url: git://github.com/betulependule/hello-world.git
+                has_discussions: false
+                has_downloads: false
+                has_issues: false
+                has_pages: false
+                has_projects: true
+                has_pull_requests: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/betulependule/hello-world/hooks
+                html_url: https://github.com/betulependule/hello-world
+                id: 1134909479
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/betulependule/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/betulependule/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/betulependule/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/betulependule/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/betulependule/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/betulependule/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/betulependule/hello-world/merges
+                milestones_url: https://api.github.com/repos/betulependule/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: R_kgDOQ6VYJw
+                notifications_url: https://api.github.com/repos/betulependule/hello-world/notifications{?since,all,participating}
+                open_issues: 1
+                open_issues_count: 1
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+                  events_url: https://api.github.com/users/betulependule/events{/privacy}
+                  followers_url: https://api.github.com/users/betulependule/followers
+                  following_url: https://api.github.com/users/betulependule/following{/other_user}
+                  gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/betulependule
+                  id: 33840358
+                  login: betulependule
+                  node_id: MDQ6VXNlcjMzODQwMzU4
+                  organizations_url: https://api.github.com/users/betulependule/orgs
+                  received_events_url: https://api.github.com/users/betulependule/received_events
+                  repos_url: https://api.github.com/users/betulependule/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+                  type: User
+                  url: https://api.github.com/users/betulependule
+                  user_view_type: public
+                private: false
+                pull_request_creation_policy: all
+                pulls_url: https://api.github.com/repos/betulependule/hello-world/pulls{/number}
+                pushed_at: '2026-08-25T11:46:30Z'
+                releases_url: https://api.github.com/repos/betulependule/hello-world/releases{/id}
+                size: 35
+                ssh_url: git@github.com:betulependule/hello-world.git
+                stargazers_count: 0
+                stargazers_url: https://api.github.com/repos/betulependule/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/betulependule/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/betulependule/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/betulependule/hello-world/subscription
+                svn_url: https://github.com/betulependule/hello-world
+                tags_url: https://api.github.com/repos/betulependule/hello-world/tags
+                teams_url: https://api.github.com/repos/betulependule/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/betulependule/hello-world/git/trees{/sha}
+                updated_at: '2026-01-20T09:16:40Z'
+                url: https://api.github.com/repos/betulependule/hello-world
+                visibility: public
+                watchers: 0
+                watchers_count: 0
+                web_commit_signoff_required: false
+              sha: 7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+                events_url: https://api.github.com/users/betulependule/events{/privacy}
+                followers_url: https://api.github.com/users/betulependule/followers
+                following_url: https://api.github.com/users/betulependule/following{/other_user}
+                gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/betulependule
+                id: 33840358
+                login: betulependule
+                node_id: MDQ6VXNlcjMzODQwMzU4
+                organizations_url: https://api.github.com/users/betulependule/orgs
+                received_events_url: https://api.github.com/users/betulependule/received_events
+                repos_url: https://api.github.com/users/betulependule/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+                type: User
+                url: https://api.github.com/users/betulependule
+                user_view_type: public
+            html_url: https://github.com/packit/hello-world/pull/4166
+            id: 4367227567
+            issue_url: https://api.github.com/repos/packit/hello-world/issues/4166
+            labels: []
+            locked: false
+            maintainer_can_modify: true
+            merge_commit_sha: null
+            mergeable: null
+            mergeable_state: unknown
+            merged: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            node_id: PR_kwDOCwFO9M8AAAABBE6arw
+            number: 4166
+            patch_url: https://github.com/packit/hello-world/pull/4166.patch
+            rebaseable: null
+            requested_reviewers: []
+            requested_teams: []
+            review_comment_url: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+            review_comments: 0
+            review_comments_url: https://api.github.com/repos/packit/hello-world/pulls/4166/comments
+            state: open
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/7cf6d0cbeca285ecbeb19a0067cb243783b3c768
+            title: 'test: PR with maintainer edits enabled'
+            updated_at: '2026-08-26T12:56:02Z'
+            url: https://api.github.com/repos/packit/hello-world/pulls/4166
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/33840358?v=4
+              events_url: https://api.github.com/users/betulependule/events{/privacy}
+              followers_url: https://api.github.com/users/betulependule/followers
+              following_url: https://api.github.com/users/betulependule/following{/other_user}
+              gists_url: https://api.github.com/users/betulependule/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/betulependule
+              id: 33840358
+              login: betulependule
+              node_id: MDQ6VXNlcjMzODQwMzU4
+              organizations_url: https://api.github.com/users/betulependule/orgs
+              received_events_url: https://api.github.com/users/betulependule/received_events
+              repos_url: https://api.github.com/users/betulependule/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/betulependule/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/betulependule/subscriptions
+              type: User
+              url: https://api.github.com/users/betulependule
+              user_view_type: public
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset, Warning
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Length: '16052'
+            Content-Security-Policy: default-src 'self';script-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne'
+              https://apps.fedoraproject.org; style-src 'self' 'nonce-YqLDC0BS8d7iY8mKO7VtBbIne';
+              object-src 'none';base-uri 'self';img-src 'self' https:;
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Location: https://api.github.com/repos/packit/hello-world/pulls/4166
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: github.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP,Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: 18FB:AA1A:99616C4:B8092CB:5CC15425
+            X-OAuth-Scopes: repo, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4972'
+            X-RateLimit-Reset: '1572953901'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '1'
+            X-XSS-Protection: '0'
+            github-authentication-token-expiration: 2026-10-07 06:48:46 UTC
+            x-github-api-version-selected: '2022-11-28'
+            x-github-edge-region: fra
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: Created
+          status_code: 201

--- a/tests/integration/github/test_pull_requests.py
+++ b/tests/integration/github/test_pull_requests.py
@@ -195,6 +195,35 @@ class PullRequests(GithubTests):
         opened_pr.close()
         assert opened_pr.status == PRStatus.closed
 
+    def test_pr_create_upstream_fork_with_maintainer_edits(self):
+        """
+        Tests creating PR from fork to the upstream, by calling create_pr on fork.
+        Additionally, tests the process of setting allow_maintainer_edit on the PR
+        created by this test.
+
+        Requires  packit_service:test_source to be ahead of packit_service:test_target
+        at least by one commit.
+        """
+        gh_project = self.hello_world_project
+        pr_upstream_fork = gh_project.get_fork().create_pr(
+            title="test: PR with maintainer edits enabled",
+            body="pull request body",
+            target_branch="test_target",
+            source_branch="test_source",
+            allow_maintainer_edit=True,
+        )
+
+        assert pr_upstream_fork.title == "test: PR with maintainer edits enabled"
+        assert pr_upstream_fork.allow_maintainer_edit
+        assert pr_upstream_fork.status == PRStatus.open
+        assert not pr_upstream_fork.target_project.is_fork
+
+        pr_upstream_fork.update_info(allow_maintainer_edit=False)
+        assert not pr_upstream_fork.allow_maintainer_edit
+
+        pr_upstream_fork.close()
+        assert pr_upstream_fork.status == PRStatus.closed
+
     def test_pr_labels(self):
         """
         Remove the labels from this pr before regenerating the response files:

--- a/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_pr_maintainer_edits.yaml
+++ b/tests/integration/gitlab/test_data/test_pull_requests/PullRequests.test_pr_maintainer_edits.yaml
@@ -1,0 +1,1421 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://gitlab.com/api/v4/projects/14233409/merge_requests/92:
+      - metadata:
+          latency: 0.2979578971862793
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.utils
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              id: 40699970
+              locked: false
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              public_email: null
+              state: active
+              username: akucerov
+              web_url: https://gitlab.com/akucerov
+            blocking_discussions_resolved: true
+            changes_count: '1'
+            closed_at: null
+            closed_by: null
+            created_at: '2026-08-25T13:03:32.446Z'
+            description: Description
+            detailed_merge_status: preparing
+            diff_refs:
+              base_sha: 59b1a9bab5b5198c619270646410867788685c16
+              head_sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+              start_sha: dd9b6c54c0788301c86bdf058a8e91e3594a0a17
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            first_contribution: true
+            first_deployed_to_production_at: null
+            force_remove_source_branch: true
+            has_conflicts: false
+            head_pipeline: null
+            id: 523588543
+            iid: 92
+            imported: false
+            imported_from: none
+            labels: []
+            latest_build_finished_at: null
+            latest_build_started_at: null
+            merge_after: null
+            merge_commit_sha: null
+            merge_error: null
+            merge_status: checking
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            pipeline: null
+            prepared_at: null
+            project_id: 14233409
+            reference: '!92'
+            references:
+              full: packit-service/ogr-tests!92
+              relative: '!92'
+              short: '!92'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 85738133
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            subscribed: true
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: test mainainer edits setting
+            updated_at: '2026-08-25T13:03:32.446Z'
+            upvotes: 0
+            user:
+              can_merge: false
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/92
+            work_in_progress: false
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: BYPASS
+            CF-Ray: a30acc2a191fbc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-13-lb-gprd
+            gitlab-sv: api-gke-us-east1-b
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '6'
+            ratelimit-remaining: '1994'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc2a191fbc7b-PRG","version":"1"}'
+            x-request-id: a30acc2a191fbc7b-PRG
+            x-runtime: '0.125410'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/akucerov%2Fogr-tests:
+      - metadata:
+          latency: 0.33234572410583496
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.utils
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              cluster_agents: https://gitlab.com/api/v4/projects/85738133/cluster_agents
+              events: https://gitlab.com/api/v4/projects/85738133/events
+              issues: https://gitlab.com/api/v4/projects/85738133/issues
+              labels: https://gitlab.com/api/v4/projects/85738133/labels
+              members: https://gitlab.com/api/v4/projects/85738133/members
+              merge_requests: https://gitlab.com/api/v4/projects/85738133/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/85738133/repository/branches
+              self: https://gitlab.com/api/v4/projects/85738133
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            auto_cancel_pending_pipelines: enabled
+            auto_devops_deploy_strategy: continuous
+            auto_devops_enabled: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            build_git_strategy: fetch
+            build_timeout: 3600
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_allow_fork_pipelines_to_run_in_parent_project: true
+            ci_config_path: null
+            ci_default_git_depth: 50
+            ci_delete_pipelines_in_seconds: null
+            ci_display_pipeline_variables: false
+            ci_forward_deployment_enabled: true
+            ci_forward_deployment_rollback_allowed: true
+            ci_id_token_sub_claim_components:
+            - project_path
+            - ref_type
+            - ref
+            ci_job_token_scope_enabled: false
+            ci_pipeline_variables_minimum_override_role: no_one_allowed
+            ci_push_repository_for_job_token_allowed: false
+            ci_separated_caches: true
+            cicd_catalog_enabled: false
+            compliance_frameworks: []
+            container_expiration_policy:
+              cadence: 1d
+              enabled: false
+              keep_n: 10
+              name_regex: .*
+              name_regex_keep: null
+              next_run_at: '2026-08-26T12:31:15.663Z'
+              older_than: 90d
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/akucerov/ogr-tests
+            created_at: '2026-08-25T12:31:15.641Z'
+            creator_id: 40699970
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            description_html: <p data-sourcepos="1:1-1:84" dir="auto">Testing repository
+              for python-ogr package.  |  <a data-sourcepos="1:48-1:84" href="https://github.com/packit-service/ogr"
+              rel="nofollow noreferrer noopener" target="_blank">https://github.com/packit-service/ogr</a></p>
+            emails_disabled: false
+            emails_enabled: true
+            empty_repo: false
+            enforce_auth_checks_on_uploads: true
+            environments_access_level: enabled
+            external_authorization_classification_label: ''
+            feature_flags_access_level: enabled
+            forked_from_project:
+              avatar_url: null
+              created_at: '2019-09-10T10:28:09.946Z'
+              default_branch: master
+              description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+              forks_count: 6
+              http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+              id: 14233409
+              last_activity_at: '2026-08-25T12:51:03.047Z'
+              name: ogr-tests
+              name_with_namespace: Packit / ogr-tests
+              namespace:
+                avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+                full_path: packit-service
+                id: 6032704
+                kind: group
+                name: Packit
+                parent_id: null
+                path: packit-service
+                web_url: https://gitlab.com/groups/packit-service
+              path: ogr-tests
+              path_with_namespace: packit-service/ogr-tests
+              readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+              ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+              star_count: 0
+              tag_list: []
+              topics: []
+              visibility: public
+              web_url: https://gitlab.com/packit-service/ogr-tests
+            forking_access_level: enabled
+            forks_count: 0
+            group_runners_enabled: true
+            http_url_to_repo: https://gitlab.com/akucerov/ogr-tests.git
+            id: 85738133
+            import_error: null
+            import_status: finished
+            import_type: null
+            import_url: null
+            infrastructure_access_level: enabled
+            issue_branch_template: null
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            keep_latest_artifact: true
+            last_activity_at: '2026-08-25T12:31:15.333Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            max_artifacts_size: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            model_experiments_access_level: enabled
+            model_registry_access_level: enabled
+            monitor_access_level: enabled
+            mr_default_target_self: false
+            mr_default_title_template: null
+            name: ogr-tests
+            name_with_namespace: "Al\u017Eb\u011Bta Ku\u010Derov\xE1 / ogr-tests"
+            namespace:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              full_path: akucerov
+              id: 138405067
+              kind: user
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              parent_id: null
+              path: akucerov
+              web_url: https://gitlab.com/akucerov
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 0
+            owner:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              id: 40699970
+              locked: false
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              public_email: null
+              state: active
+              username: akucerov
+              web_url: https://gitlab.com/akucerov
+            package_registry_access_level: public
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: akucerov/ogr-tests
+            permissions:
+              group_access: null
+              project_access:
+                access_level: 50
+                notification_level: 3
+            printing_merge_request_link_enabled: true
+            protect_merge_request_pipelines: true
+            public_jobs: true
+            readme_url: https://gitlab.com/akucerov/ogr-tests/-/blob/master/README.md
+            releases_access_level: enabled
+            remove_source_branch_after_merge: true
+            repository_access_level: enabled
+            repository_object_format: sha1
+            request_access_enabled: true
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            resource_group_default_process_mode: unordered
+            restrict_user_defined_variables: true
+            runner_token_expiration_interval: null
+            runners_token: nooneknows
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: true
+            service_desk_address: contact-project+akucerov-ogr-tests-85738133-issue-@incoming.gitlab.com
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            show_diff_preview_in_email: true
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:akucerov/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            updated_at: '2026-08-25T12:31:17.607Z'
+            visibility: public
+            warn_about_potentially_unwanted_characters: true
+            web_based_commit_signing_enabled: false
+            web_url: https://gitlab.com/akucerov/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: BYPASS
+            CF-Ray: a30acc19dd2dbc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-04-lb-gprd
+            gitlab-sv: api-gke-us-east1-b
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '2'
+            ratelimit-remaining: '1998'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc19dd2dbc7b-PRG","version":"1"}'
+            x-request-id: a30acc19dd2dbc7b-PRG
+            x-runtime: '0.150162'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/projects/packit-service%2Fogr-tests:
+      - metadata:
+          latency: 0.9745008945465088
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.utils
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              cluster_agents: https://gitlab.com/api/v4/projects/14233409/cluster_agents
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            cicd_catalog_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            description_html: <p data-sourcepos="1:1-1:84" dir="auto">Testing repository
+              for python-ogr package.  |  <a data-sourcepos="1:48-1:84" href="https://github.com/packit-service/ogr"
+              rel="nofollow noreferrer noopener" target="_blank">https://github.com/packit-service/ogr</a></p>
+            emails_disabled: false
+            emails_enabled: true
+            empty_repo: false
+            enforce_auth_checks_on_uploads: true
+            environments_access_level: enabled
+            external_authorization_classification_label: ''
+            feature_flags_access_level: enabled
+            forking_access_level: enabled
+            forks_count: 6
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_status: none
+            infrastructure_access_level: enabled
+            issue_branch_template: null
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            last_activity_at: '2026-08-25T12:51:03.047Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            max_artifacts_size: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            model_experiments_access_level: enabled
+            model_registry_access_level: enabled
+            monitor_access_level: enabled
+            mr_default_title_template: null
+            name: ogr-tests
+            name_with_namespace: Packit / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: Packit
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 77
+            package_registry_access_level: public
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access: null
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            releases_access_level: enabled
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            repository_object_format: sha1
+            request_access_enabled: false
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            show_diff_preview_in_email: true
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            updated_at: '2026-08-25T12:51:03.047Z'
+            visibility: public
+            warn_about_potentially_unwanted_characters: true
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: BYPASS
+            CF-Ray: a30acc1bed15bc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-22-lb-gprd
+            gitlab-sv: api-gke-us-east1-b
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '3'
+            ratelimit-remaining: '1997'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc1bed15bc7b-PRG","version":"1"}'
+            x-request-id: a30acc1bed15bc7b-PRG
+            x-runtime: '0.791641'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.704564094543457
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.utils
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - ogr.services.gitlab.project
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              cluster_agents: https://gitlab.com/api/v4/projects/14233409/cluster_agents
+              events: https://gitlab.com/api/v4/projects/14233409/events
+              issues: https://gitlab.com/api/v4/projects/14233409/issues
+              labels: https://gitlab.com/api/v4/projects/14233409/labels
+              members: https://gitlab.com/api/v4/projects/14233409/members
+              merge_requests: https://gitlab.com/api/v4/projects/14233409/merge_requests
+              repo_branches: https://gitlab.com/api/v4/projects/14233409/repository/branches
+              self: https://gitlab.com/api/v4/projects/14233409
+            allow_merge_on_skipped_pipeline: null
+            analytics_access_level: enabled
+            archived: false
+            autoclose_referenced_issues: true
+            avatar_url: null
+            builds_access_level: enabled
+            can_create_merge_request_in: true
+            ci_config_path: null
+            cicd_catalog_enabled: false
+            compliance_frameworks: []
+            container_registry_access_level: enabled
+            container_registry_enabled: true
+            container_registry_image_prefix: registry.gitlab.com/packit-service/ogr-tests
+            created_at: '2019-09-10T10:28:09.946Z'
+            creator_id: 433670
+            default_branch: master
+            description: Testing repository for python-ogr package.  |  https://github.com/packit-service/ogr
+            description_html: <p data-sourcepos="1:1-1:84" dir="auto">Testing repository
+              for python-ogr package.  |  <a data-sourcepos="1:48-1:84" href="https://github.com/packit-service/ogr"
+              rel="nofollow noreferrer noopener" target="_blank">https://github.com/packit-service/ogr</a></p>
+            emails_disabled: false
+            emails_enabled: true
+            empty_repo: false
+            enforce_auth_checks_on_uploads: true
+            environments_access_level: enabled
+            external_authorization_classification_label: ''
+            feature_flags_access_level: enabled
+            forking_access_level: enabled
+            forks_count: 6
+            http_url_to_repo: https://gitlab.com/packit-service/ogr-tests.git
+            id: 14233409
+            import_status: none
+            infrastructure_access_level: enabled
+            issue_branch_template: null
+            issues_access_level: enabled
+            issues_enabled: true
+            jobs_enabled: true
+            last_activity_at: '2026-08-25T12:51:03.047Z'
+            lfs_enabled: true
+            marked_for_deletion_at: null
+            marked_for_deletion_on: null
+            max_artifacts_size: null
+            merge_commit_template: null
+            merge_method: merge
+            merge_requests_access_level: enabled
+            merge_requests_enabled: true
+            model_experiments_access_level: enabled
+            model_registry_access_level: enabled
+            monitor_access_level: enabled
+            mr_default_title_template: null
+            name: ogr-tests
+            name_with_namespace: Packit / ogr-tests
+            namespace:
+              avatar_url: /uploads/-/system/group/avatar/6032704/logo-square-small-borders.png
+              full_path: packit-service
+              id: 6032704
+              kind: group
+              name: Packit
+              parent_id: null
+              path: packit-service
+              web_url: https://gitlab.com/groups/packit-service
+            only_allow_merge_if_all_discussions_are_resolved: false
+            only_allow_merge_if_pipeline_succeeds: false
+            open_issues_count: 77
+            package_registry_access_level: public
+            packages_enabled: true
+            pages_access_level: enabled
+            path: ogr-tests
+            path_with_namespace: packit-service/ogr-tests
+            permissions:
+              group_access: null
+              project_access: null
+            printing_merge_request_link_enabled: true
+            public_jobs: true
+            readme_url: https://gitlab.com/packit-service/ogr-tests/-/blob/master/README.md
+            releases_access_level: enabled
+            remove_source_branch_after_merge: null
+            repository_access_level: enabled
+            repository_object_format: sha1
+            request_access_enabled: false
+            requirements_access_level: enabled
+            requirements_enabled: false
+            resolve_outdated_diff_discussions: false
+            security_and_compliance_access_level: private
+            security_and_compliance_enabled: false
+            service_desk_enabled: true
+            shared_runners_enabled: true
+            shared_with_groups: []
+            show_diff_preview_in_email: true
+            snippets_access_level: enabled
+            snippets_enabled: true
+            squash_commit_template: null
+            squash_option: default_off
+            ssh_url_to_repo: git@gitlab.com:packit-service/ogr-tests.git
+            star_count: 0
+            suggestion_commit_message: null
+            tag_list: []
+            topics: []
+            updated_at: '2026-08-25T12:51:03.047Z'
+            visibility: public
+            warn_about_potentially_unwanted_characters: true
+            web_url: https://gitlab.com/packit-service/ogr-tests
+            wiki_access_level: enabled
+            wiki_enabled: true
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: BYPASS
+            CF-Ray: a30acc25a89ebc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-25-lb-gprd
+            gitlab-sv: api-gke-us-east1-b
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '5'
+            ratelimit-remaining: '1995'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc25a89ebc7b-PRG","version":"1"}'
+            x-request-id: a30acc25a89ebc7b-PRG
+            x-runtime: '0.431368'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      https://gitlab.com/api/v4/user:
+      - metadata:
+          latency: 0.5324723720550537
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.gitlab.user
+          - ogr.services.gitlab.service
+          - gitlab.client
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+            bio: ''
+            bot: false
+            can_create_group: true
+            can_create_project: true
+            color_scheme_id: 1
+            commit_email: akucerov@redhat.com
+            confirmed_at: '2026-07-28T08:33:13.927Z'
+            created_at: '2026-07-28T08:30:49.069Z'
+            current_sign_in_at: '2026-08-25T12:28:29.115Z'
+            discord: ''
+            email: akucerov@redhat.com
+            external: false
+            extra_shared_runners_minutes_limit: null
+            github: ''
+            id: 40699970
+            identities:
+            - extern_uid: baf072e0-5609-11f0-b969-0a58ac147216
+              provider: group_saml
+              saml_provider_id: 1769
+            job_title: ''
+            last_activity_on: '2026-08-25'
+            last_sign_in_at: '2026-07-30T11:44:54.530Z'
+            linkedin: ''
+            local_time: null
+            location: ''
+            locked: false
+            name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+            organization: ''
+            preferred_language: en
+            private_profile: false
+            projects_limit: 100000
+            pronouns: null
+            public_email: null
+            scim_identities: []
+            shared_runners_minutes_limit: null
+            state: active
+            theme_id: 3
+            twitter: ''
+            two_factor_enabled: true
+            username: akucerov
+            web_url: https://gitlab.com/akucerov
+            website_url: ''
+            work_information: null
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: BYPASS
+            CF-Ray: a30acc17cda2bc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-44-lb-gprd
+            gitlab-sv: api-gke-us-east1-c
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '1'
+            ratelimit-remaining: '1999'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc17cda2bc7b-PRG","version":"1"}'
+            x-request-id: a30acc17cda2bc7b-PRG
+            x-runtime: '0.117526'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://gitlab.com/api/v4/projects/85738133/merge_requests:
+      - metadata:
+          latency: 0.5690553188323975
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.utils
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              id: 40699970
+              locked: false
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              public_email: null
+              state: active
+              username: akucerov
+              web_url: https://gitlab.com/akucerov
+            blocking_discussions_resolved: true
+            changes_count: null
+            closed_at: null
+            closed_by: null
+            created_at: '2026-08-25T13:03:32.446Z'
+            description: Description
+            detailed_merge_status: preparing
+            diff_refs: null
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            first_deployed_to_production_at: null
+            force_remove_source_branch: true
+            has_conflicts: false
+            head_pipeline: null
+            id: 523588543
+            iid: 92
+            imported: false
+            imported_from: none
+            labels: []
+            latest_build_finished_at: null
+            latest_build_started_at: null
+            merge_after: null
+            merge_commit_sha: null
+            merge_error: null
+            merge_status: checking
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            pipeline: null
+            prepared_at: null
+            project_id: 14233409
+            reference: packit-service/ogr-tests!92
+            references:
+              full: packit-service/ogr-tests!92
+              relative: packit-service/ogr-tests!92
+              short: '!92'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 85738133
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            subscribed: true
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: test mainainer edits setting
+            updated_at: '2026-08-25T13:03:32.446Z'
+            upvotes: 0
+            user:
+              can_merge: false
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/92
+            work_in_progress: false
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-Ray: a30acc221b76bc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Length: '2064'
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-29-lb-gprd
+            gitlab-sv: api-gke-us-east1-c
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '4'
+            ratelimit-remaining: '1996'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc221b76bc7b-PRG","version":"1"}'
+            x-gitlab-namespace: akucerov
+            x-gitlab-score-gitaly: '4'
+            x-request-id: a30acc221b76bc7b-PRG
+            x-runtime: '0.406038'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: Created
+          status_code: 201
+    PUT:
+      https://gitlab.com/api/v4/projects/14233409/merge_requests/92:
+      - metadata:
+          latency: 0.8193626403808594
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - gitlab.mixins
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_collaboration: true
+            allow_maintainer_to_push: true
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              id: 40699970
+              locked: false
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              public_email: null
+              state: active
+              username: akucerov
+              web_url: https://gitlab.com/akucerov
+            blocking_discussions_resolved: true
+            changes_count: '1'
+            closed_at: null
+            closed_by: null
+            created_at: '2026-08-25T13:03:32.446Z'
+            description: this update shouldn't disable maintainer edits
+            detailed_merge_status: checking
+            diff_refs:
+              base_sha: 59b1a9bab5b5198c619270646410867788685c16
+              head_sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+              start_sha: dd9b6c54c0788301c86bdf058a8e91e3594a0a17
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            first_deployed_to_production_at: null
+            force_remove_source_branch: true
+            has_conflicts: false
+            head_pipeline: null
+            id: 523588543
+            iid: 92
+            imported: false
+            imported_from: none
+            labels: []
+            latest_build_finished_at: null
+            latest_build_started_at: null
+            merge_after: null
+            merge_commit_sha: null
+            merge_error: null
+            merge_status: checking
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            pipeline: null
+            prepared_at: '2026-08-25T13:03:33.928Z'
+            project_id: 14233409
+            reference: '!92'
+            references:
+              full: packit-service/ogr-tests!92
+              relative: '!92'
+              short: '!92'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 85738133
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            subscribed: true
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: test mainainer edits setting
+            updated_at: '2026-08-25T13:03:34.285Z'
+            upvotes: 0
+            user:
+              can_merge: false
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/92
+            work_in_progress: false
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-Ray: a30acc2c1ff6bc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-15-lb-gprd
+            gitlab-sv: api-gke-us-east1-d
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '7'
+            ratelimit-remaining: '1993'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc2c1ff6bc7b-PRG","version":"1"}'
+            x-gitlab-namespace: packit-service
+            x-gitlab-score-gitaly: '2'
+            x-request-id: a30acc2c1ff6bc7b-PRG
+            x-runtime: '0.409924'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.7585508823394775
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - gitlab.mixins
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_collaboration: false
+            allow_maintainer_to_push: false
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              id: 40699970
+              locked: false
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              public_email: null
+              state: active
+              username: akucerov
+              web_url: https://gitlab.com/akucerov
+            blocking_discussions_resolved: true
+            changes_count: '1'
+            closed_at: null
+            closed_by: null
+            created_at: '2026-08-25T13:03:32.446Z'
+            description: this update shouldn't disable maintainer edits
+            detailed_merge_status: mergeable
+            diff_refs:
+              base_sha: 59b1a9bab5b5198c619270646410867788685c16
+              head_sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+              start_sha: dd9b6c54c0788301c86bdf058a8e91e3594a0a17
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            first_deployed_to_production_at: null
+            force_remove_source_branch: true
+            has_conflicts: false
+            head_pipeline: null
+            id: 523588543
+            iid: 92
+            imported: false
+            imported_from: none
+            labels: []
+            latest_build_finished_at: null
+            latest_build_started_at: null
+            merge_after: null
+            merge_commit_sha: null
+            merge_error: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            pipeline: null
+            prepared_at: '2026-08-25T13:03:33.928Z'
+            project_id: 14233409
+            reference: '!92'
+            references:
+              full: packit-service/ogr-tests!92
+              relative: '!92'
+              short: '!92'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 85738133
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: opened
+            subscribed: true
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: test mainainer edits setting
+            updated_at: '2026-08-25T13:03:34.951Z'
+            upvotes: 0
+            user:
+              can_merge: false
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/92
+            work_in_progress: false
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-Ray: a30acc313ab5bc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-23-lb-gprd
+            gitlab-sv: gke-cny-api
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '8'
+            ratelimit-remaining: '1992'
+            ratelimit-reset: '1787663040'
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc313ab5bc7b-PRG","version":"1"}'
+            x-gitlab-namespace: packit-service
+            x-gitlab-score-gitaly: '6'
+            x-request-id: a30acc313ab5bc7b-PRG
+            x-runtime: '0.567443'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.5422101020812988
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests.integration.gitlab.test_pull_requests
+          - ogr.abstract.exception
+          - ogr.services.gitlab.pull_request
+          - gitlab.mixins
+          - gitlab.exceptions
+          - gitlab.mixins
+          - gitlab.client
+          - gitlab._backends.requests_backend
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_collaboration: false
+            allow_maintainer_to_push: false
+            approvals_before_merge: null
+            assignee: null
+            assignees: []
+            author:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              id: 40699970
+              locked: false
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              public_email: null
+              state: active
+              username: akucerov
+              web_url: https://gitlab.com/akucerov
+            blocking_discussions_resolved: true
+            changes_count: '1'
+            closed_at: '2026-08-25T13:03:35.646Z'
+            closed_by:
+              avatar_url: https://secure.gravatar.com/avatar/8e9f7fa31246159d6479f97e8f3efabeb501c4eb99c14489d73b4f2fcdfc1f2a?s=80&d=identicon
+              id: 40699970
+              locked: false
+              name: "Al\u017Eb\u011Bta Ku\u010Derov\xE1"
+              public_email: null
+              state: active
+              username: akucerov
+              web_url: https://gitlab.com/akucerov
+            created_at: '2026-08-25T13:03:32.446Z'
+            description: this update shouldn't disable maintainer edits
+            detailed_merge_status: not_open
+            diff_refs:
+              base_sha: 59b1a9bab5b5198c619270646410867788685c16
+              head_sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+              start_sha: dd9b6c54c0788301c86bdf058a8e91e3594a0a17
+            discussion_locked: null
+            downvotes: 0
+            draft: false
+            first_deployed_to_production_at: null
+            force_remove_source_branch: true
+            has_conflicts: false
+            head_pipeline: null
+            id: 523588543
+            iid: 92
+            imported: false
+            imported_from: none
+            labels: []
+            latest_build_finished_at: null
+            latest_build_started_at: null
+            merge_after: null
+            merge_commit_sha: null
+            merge_error: null
+            merge_status: can_be_merged
+            merge_user: null
+            merge_when_pipeline_succeeds: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            pipeline: null
+            prepared_at: '2026-08-25T13:03:33.928Z'
+            project_id: 14233409
+            reference: '!92'
+            references:
+              full: packit-service/ogr-tests!92
+              relative: '!92'
+              short: '!92'
+            reviewers: []
+            sha: 6a9b824f6fa26eb6a3c0d8f164a5bbe95118d2c9
+            should_remove_source_branch: null
+            source_branch: pr-test1
+            source_project_id: 85738133
+            squash: false
+            squash_commit_sha: null
+            squash_on_merge: false
+            state: closed
+            subscribed: true
+            target_branch: master
+            target_project_id: 14233409
+            task_completion_status:
+              completed_count: 0
+              count: 0
+            time_stats:
+              human_time_estimate: null
+              human_total_time_spent: null
+              time_estimate: 0
+              total_time_spent: 0
+            title: test mainainer edits setting
+            updated_at: '2026-08-25T13:03:35.617Z'
+            upvotes: 0
+            user:
+              can_merge: false
+            user_notes_count: 0
+            web_url: https://gitlab.com/packit-service/ogr-tests/-/merge_requests/92
+            work_in_progress: false
+          _next: null
+          elapsed: 0.2
+          encoding: utf-8
+          headers:
+            CF-Cache-Status: DYNAMIC
+            CF-Ray: a30acc360c2cbc7b-PRG
+            Cache-Control: max-age=0, private, must-revalidate
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Type: application/json
+            Date: Fri, 01 Nov 2019 13-36-03 GMT
+            ETag: W/"1e51b8e1c48787a433405211e9e0fe61"
+            Server: cloudflare
+            Strict-Transport-Security: max-age=31536000
+            Transfer-Encoding: chunked
+            Vary: Origin
+            content-security-policy: default-src 'none'
+            gitlab-lb: haproxy-main-30-lb-gprd
+            gitlab-sv: api-gke-us-east1-d
+            nel: '{"max_age": 0}'
+            ratelimit-limit: '2000'
+            ratelimit-name: throttle_authenticated_api
+            ratelimit-observed: '9'
+            ratelimit-remaining: '1991'
+            ratelimit-reset: '1787663040'
+            referrer-policy: strict-origin-when-cross-origin
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-gitlab-meta: '{"correlation_id":"a30acc360c2cbc7b-PRG","version":"1"}'
+            x-request-id: a30acc360c2cbc7b-PRG
+            x-runtime: '0.384848'
+          raw: !!binary ""
+          raw_decoded: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests/integration/gitlab/test_pull_requests.py
+++ b/tests/integration/gitlab/test_pull_requests.py
@@ -97,6 +97,30 @@ class PullRequests(GitlabTests):
         closed_pr = pr_for_closing.close()
         assert closed_pr.status == PRStatus.closed
 
+    def test_pr_maintainer_edits(self):
+        project = self.service.get_project(
+            repo="ogr-tests",
+            namespace=self.service.user.get_username(),
+        )
+
+        pr = project.create_pr(
+            title="test mainainer edits setting",
+            body="Description",
+            target_branch="master",
+            source_branch="pr-test1",
+            allow_maintainer_edit=True,
+        )
+
+        pr = self.project.get_pr(pr.id)
+
+        pr.update_info(description="this update shouldn't disable maintainer edits")
+        assert pr.allow_maintainer_edit
+
+        pr.update_info(allow_maintainer_edit=False)
+        assert not pr.allow_maintainer_edit
+
+        pr.close()
+
     def test_pr_merge(self):
         """
         Create new PR and update pull request ID to this test before this test


### PR DESCRIPTION
### PR summary
This PR adds support for enabling edits from maintainers on PRs/MRs across all forges, which support this (GitHub, GitLab and Forgejo). The Forgejo API doesn't allow setting this directly when creating a PR, so in this case, it is only supported when editing the PR created. Pagure doesn't support this option.

This functionality is needed in preparation for the migration of dist-git to Forgejo, but it was implemented for the other forges as well for consistency's sake.

While working on this, I also improved the implementation of `PullRequest.update_info()` for GitHub, which seemed problematic as it could raise an error. The fix is related to this code and is small enough that I don't think it would deserve a separate PR, so I included it as a separate commit.

### Tests
Integration tests have been added for GitHub and GitLab. 

Our Forgejo testing repo is hosted on `v10.next.forgejo.org`, which is past its EOL, so I was not able to create an account there to be able to run and record an integration test for Forgejo. I would generally use our packit-validator account for creating tests, but for this particular test, I would need a different account in order to create a fork and a PR from it.

As for Pagure, the tests are hosted on `pagure.io`, which is currently read-only, so I was not able to run a test for it, either. Considering that Pagure doesn't support enabling edits from maintainers anyway, this isn't a big deal.

Related to: [#2748](https://github.com/packit/packit/issues/2748)

RELEASE NOTES BEGIN

In `ogr`, a potential bug has been fixed in the GitHub implementation of `PullRequest.update_info()`. Previously, `None` values could be passed to the underlying method called to edit a PR, which could result in an `AssertionError` being raised as this method doesn't support `None` values.

`ogr` now supports the `allow_maintainer_edit` option for PRs/MRs for GitHub, GitLab and Forgejo. As the Forgejo API doesn't allow to set this directly when creating a PR, `allow_maintainer_edit` can only be set when updating it.

RELEASE NOTES END
