### PR TITLE
bump fullsend to v0.40.0

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -42,7 +42,7 @@ jobs:
     if: >-
       github.event_name != 'issue_comment'
       || github.event.comment.user.type != 'Bot'
-    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@3cfa255ab4cc8190670585ea42da529119251632 # v0.32.0
+    uses: fullsend-ai/fullsend/.github/workflows/reusable-dispatch.yml@2a103497560b9bcca901372c70a6e073b1a73cde # v0.40.0
     with:
       event_action: ${{ github.event.action }}
       install_mode: per-repo


### PR DESCRIPTION
mainly to fix the openshell invocation error:

> Failure (creating sandbox: sandbox creation failed after 3 attempts:
> sandbox create failed: exit status 2 (output: error: unexpected argument
> '--detach' found tip: to pass '--detach' as a value, use '-- --deta…) ·
> Started 12:02 PM UTC · Completed 12:02 PM UTC

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>
Assisted-by: Codex

RELEASE NOTES BEGIN

Internal change

RELEASE NOTES END
